### PR TITLE
models/Qwen/Qwen3-0.6B/t3000/functional

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -23,7 +23,7 @@ Note: Keep the table columns padded with spaces and right-justify numeric cells 
 | mistralai/Mistral-7B-Instruct-v0.3  |  t3000   | functional |   97% |  100% |        |       |    1024 |
 | Qwen/Qwen3-0.6B                     |   n150   | functional |   99% |  100% |   52ms |  28.0 |   40960 |
 | Qwen/Qwen3-0.6B                     |   n300   | functional |   99% |  100% |        |       |         |
-| Qwen/Qwen3-0.6B                     |  t3000   | functional |   bad |   bad |   bad |   bad |         |
+| Qwen/Qwen3-0.6B                     |  t3000   | functional |   98% |  100% |  229ms |   6.2 |   40960 |
 | google/gemma-3-4b-it                |   n150   | functional |   92% |  100% |   98ms |  13.9 |   40960 |
 | google/gemma-3-4b-it                |   n300   | functional |   bad |   bad |  360ms |   4.6 |     256 |
 | google/gemma-3-4b-it                |  t3000   | functional |   91% |  100% |        |       |     256 |

--- a/models/Qwen/Qwen3-0.6B/t3000/functional/demo.log
+++ b/models/Qwen/Qwen3-0.6B/t3000/functional/demo.log
@@ -1,143 +1,59 @@
 TT_VISIBLE_DEVICES=0,1,2,3 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto python demo.py models/Qwen/Qwen3-0.6B/t3000/functional/model.py
-2026-02-09 02:31:18.310 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+2026-02-09 06:29:58.811 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
-2026-02-09 02:31:19.129 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 02:31:19.161 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-02-09 02:31:19.170 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 02:31:19.242 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 02:31:19.305 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x202 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 02:31:19.361 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 02:31:19.372 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 02:31:19.382 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 02:31:19.392 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 02:31:19.405 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 02:31:19.419 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 02:31:19.432 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x5 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 02:31:19.445 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 3, 1, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
-2026-02-09 02:31:19.445 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-02-09 02:31:19.445 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
-2026-02-09 02:31:19.454 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-02-09 02:31:19.454 | info     |             UMD | Mapped hugepage 0x240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 02:31:19.455 | info     |             UMD | Mapped hugepage 0x200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 02:31:19.456 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 02:31:19.457 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 02:31:19.458 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 02:31:19.458 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 02:31:19.459 | info     |             UMD | Mapped hugepage 0x42c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 02:31:19.460 | info     |             UMD | Mapped hugepage 0x4280000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 02:31:19.518 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto (metal_context.cpp:822)
-2026-02-09 02:31:19.519 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
-2026-02-09 02:31:19.523 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
-2026-02-09 02:31:19.524 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-02-09 02:31:19.528 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 02:31:19.531 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 02:31:19.531 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 02:31:19.532 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 02:31:19.532 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 02:31:19.533 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 02:31:19.534 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 02:31:19.535 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 02:31:19.871 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
-2026-02-09 02:31:19.871 | info     |           Metal | Dispatch on FabricConfig::FABRIC_2D with 1 Command Queues
+2026-02-09 06:29:59.552 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 06:29:59.584 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-09 06:29:59.594 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 06:29:59.669 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 06:29:59.733 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x202 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 06:29:59.787 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 06:29:59.797 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 06:29:59.807 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 06:29:59.817 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 06:29:59.831 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 06:29:59.845 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 06:29:59.858 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x5 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 06:29:59.872 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 3, 1, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
+2026-02-09 06:29:59.872 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-09 06:29:59.872 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-09 06:29:59.882 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-09 06:29:59.883 | info     |             UMD | Mapped hugepage 0x240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 06:29:59.884 | info     |             UMD | Mapped hugepage 0x200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 06:29:59.885 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 06:29:59.885 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 06:29:59.886 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 06:29:59.887 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 06:29:59.888 | info     |             UMD | Mapped hugepage 0x42c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 06:29:59.889 | info     |             UMD | Mapped hugepage 0x4280000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 06:29:59.943 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto (metal_context.cpp:822)
+2026-02-09 06:29:59.944 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-09 06:29:59.949 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-09 06:29:59.949 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-09 06:29:59.956 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 06:29:59.959 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 06:29:59.960 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 06:29:59.960 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 06:29:59.961 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 06:29:59.962 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 06:29:59.962 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 06:29:59.963 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 06:30:00.311 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
+2026-02-09 06:30:00.311 | info     |           Metal | Dispatch on FabricConfig::FABRIC_2D with 1 Command Queues
  (device_manager.cpp:328)
-2026-02-09 02:31:19.887 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
-2026-02-09 02:31:20.063 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
-2026-02-09 02:31:20.064 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
-2026-02-09 02:31:20.109 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
-2026-02-09 02:31:20.110 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
-2026-02-09 02:31:20.113 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
-2026-02-09 02:31:20.119 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
-2026-02-09 02:31:20.122 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
-2026-02-09 02:31:20.128 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
-2026-02-09 02:31:20.128 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_2D (device_manager.cpp:409)
-2026-02-09 02:31:20.234 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
-2026-02-09 02:31:20.234 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
-2026-02-09 02:31:20.238 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
-2026-02-09 02:31:20.238 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
-2026-02-09 02:32:02.573 | error    |    BuildKernels | trisc2 compile failure -- cmd: cd /proj_sw/user_dev/moconnor/tt-metal-cache/tt-metal-cache07a0186786/1122223303392688457/kernels/tilize/8963115395528636651/trisc2/ && /proj_sw/user_dev/moconnor/tt-metal/runtime/sfpi/compiler/bin/riscv-tt-elf-g++ -O3 -std=c++17 -flto=auto -ffast-math -fno-exceptions -g -MMD -fno-use-cxa-atexit -Wall -Werror -Wno-unknown-pragmas -Wno-deprecated-declarations -Wno-error=multistatement-macros -Wno-error=parentheses -Wno-error=unused-but-set-variable -Wno-unused-variable -Wno-unused-function -mcpu=tt-wh-tensix -I. -I.. -I/proj_sw/user_dev/moconnor/tt-metal/ -I/proj_sw/user_dev/moconnor/tt-metal/ttnn -I/proj_sw/user_dev/moconnor/tt-metal/ttnn/cpp -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/include -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/inc -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hostdevcommon/api -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/inc/debug -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/api/ -I/proj_sw/user_dev/moconnor/tt-metal/runtime/sfpi/include -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/common -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/inc/internal/tt-1xx -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/inc/internal/tt-1xx/wormhole -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/inc/internal/tt-1xx/wormhole/wormhole_b0_defines -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/common/inc -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/firmware/src/tt-1xx -c -o trisck.o /proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/firmware/src/tt-1xx/trisck.cc -DIS_NOT_POW2_NUM_DRAM_BANKS=1 -DLOG_BASE_2_OF_NUM_L1_BANKS=6 -DNUM_DRAM_BANKS=12 -DNUM_L1_BANKS=64 -DPCIE_NOC_X=0 -DPCIE_NOC_Y=3 -DTENSIX_FIRMWARE -DLOCAL_MEM_EN=0 -DROUTING_FW_ENABLED -DPROCESSOR_INDEX=4 -DUCK_CHLKC_PACK -DNAMESPACE=chlkc_pack -DCOMPILE_FOR_TRISC=2 -DARCH_WORMHOLE -DDISPATCH_MESSAGE_ADDR=4290052232 -DKERNEL_BUILD -DKERNEL_COMPILE_TIME_ARGS=0,2,1,32,1  (build.cpp:51)
-2026-02-09 02:32:02.577 | critical |          Always | TT_THROW: trisc2 build failed. Log: In file included from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/include/compute_kernel_api/common_globals.h:24,
-                 from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/include/compute_kernel_api/common.h:7,
-                 from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/include/compute_kernel_api/tilize.h:7,
-                 from /proj_sw/user_dev/moconnor/tt-metal/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize.cpp:7,
-                 from ../chlkc_pack.cpp:3,
-                 from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/common/chlkc_list.h:29,
-                 from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/firmware/src/tt-1xx/trisck.cc:13:
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h: In function 'void llk_pack_fast_tilize_hw_configure(const llk_pack_params_t*)':
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h:292:5: error: '_llk_pack_fast_tilize_hw_configure_' was not declared in this scope; did you mean 'llk_pack_fast_tilize_hw_configure'? [-Wtemplate-body]
-  292 |     _llk_pack_fast_tilize_hw_configure_<is_fp32_dest_acc_en>(pack_src_format[output_id], pack_dst_format[output_id]);
-      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      |     llk_pack_fast_tilize_hw_configure
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h: In instantiation of 'void llk_pack_init(uint32_t) [with bool untilize = false; bool zero_output = false; bool tilize = false; uint32_t = long unsigned int]':
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/include/compute_kernel_api/compute_kernel_hw_startup.h:46:5:   required from here
-   46 |     PACK((llk_pack_init<false /*untilize*/, false /*zero_output*/, false /*tilize*/>(ocb)));
-      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h:124:43: error: no matching function for call to '_llk_pack_init_<false, false>(const unsigned char&, const unsigned char&, const uint32_t&, const uint32_t&, const bool&, const bool&, bool)'
-  124 |     _llk_pack_init_<untilize, zero_output>(
-      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
-  125 |         pack_dst_format[output_id], pack_src_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile, true);
-      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h:124:43: note: there are 2 candidates
-In file included from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h:18:
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h:142:13: note: candidate 1: 'template<bool untilize, bool zero_output> void _llk_pack_init_(uint32_t, uint32_t, uint32_t, bool, bool)'
-  142 | inline void _llk_pack_init_(
-      |             ^~~~~~~~~~~~~~~
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h:142:13: note: candidate expects 5 arguments, 7 provided
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h:161:13: note: candidate 2: 'template<bool untilize, bool zero_output> void _llk_pack_init_(uint32_t, uint32_t, uint32_t, uint32_t, bool, bool)'
-  161 | inline void _llk_pack_init_(
-      |             ^~~~~~~~~~~~~~~
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h:161:13: note: candidate expects 6 arguments, 7 provided
- (assert.hpp:104)
-2026-02-09 02:32:03.055 | critical |          Always | TT_THROW: Failed to generate binaries for tilize TT_THROW @ /proj_sw/user_dev/moconnor/tt-metal/tt_metal/jit_build/build.cpp:55: tt::exception
-info:
-trisc2 build failed. Log: In file included from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/include/compute_kernel_api/common_globals.h:24,
-                 from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/include/compute_kernel_api/common.h:7,
-                 from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/include/compute_kernel_api/tilize.h:7,
-                 from /proj_sw/user_dev/moconnor/tt-metal/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize.cpp:7,
-                 from ../chlkc_pack.cpp:3,
-                 from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/common/chlkc_list.h:29,
-                 from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/firmware/src/tt-1xx/trisck.cc:13:
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h: In function 'void llk_pack_fast_tilize_hw_configure(const llk_pack_params_t*)':
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h:292:5: error: '_llk_pack_fast_tilize_hw_configure_' was not declared in this scope; did you mean 'llk_pack_fast_tilize_hw_configure'? [-Wtemplate-body]
-  292 |     _llk_pack_fast_tilize_hw_configure_<is_fp32_dest_acc_en>(pack_src_format[output_id], pack_dst_format[output_id]);
-      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      |     llk_pack_fast_tilize_hw_configure
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h: In instantiation of 'void llk_pack_init(uint32_t) [with bool untilize = false; bool zero_output = false; bool tilize = false; uint32_t = long unsigned int]':
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/include/compute_kernel_api/compute_kernel_hw_startup.h:46:5:   required from here
-   46 |     PACK((llk_pack_init<false /*untilize*/, false /*zero_output*/, false /*tilize*/>(ocb)));
-      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h:124:43: error: no matching function for call to '_llk_pack_init_<false, false>(const unsigned char&, const unsigned char&, const uint32_t&, const uint32_t&, const bool&, const bool&, bool)'
-  124 |     _llk_pack_init_<untilize, zero_output>(
-      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
-  125 |         pack_dst_format[output_id], pack_src_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile, true);
-      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h:124:43: note: there are 2 candidates
-In file included from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h:18:
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h:142:13: note: candidate 1: 'template<bool untilize, bool zero_output> void _llk_pack_init_(uint32_t, uint32_t, uint32_t, bool, bool)'
-  142 | inline void _llk_pack_init_(
-      |             ^~~~~~~~~~~~~~~
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h:142:13: note: candidate expects 5 arguments, 7 provided
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h:161:13: note: candidate 2: 'template<bool untilize, bool zero_output> void _llk_pack_init_(uint32_t, uint32_t, uint32_t, uint32_t, bool, bool)'
-  161 | inline void _llk_pack_init_(
-      |             ^~~~~~~~~~~~~~~
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h:161:13: note: candidate expects 6 arguments, 7 provided
-
-backtrace:
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/_ttnncpp.so(+0x2f89b08) [0x7fa00c196b08]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x75e1dc) [0x7fa008cdd1dc]
- --- tt::tt_metal::JitBuildState::compile_one(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, tt::tt_metal::JitBuildSettings const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x770d08) [0x7fa008cefd08]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x770c82) [0x7fa008cefc82]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x51060f) [0x7fa008a8f60f]
- --- /lib/x86_64-linux-gnu/libc.so.6(+0x99ee8) [0x7fa0dc53dee8]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x710759) [0x7fa008c8f759]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x770a8e) [0x7fa008cefa8e]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x7142b5) [0x7fa008c932b5]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x712eed) [0x7fa008c91eed]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x712338) [0x7fa008c91338]
- --- /lib/x86_64-linux-gnu/libstdc++.so.6(+0xdc253) [0x7fa0c6bc5253]
- --- /lib/x86_64-linux-gnu/libc.so.6(+0x94ac3) [0x7fa0dc538ac3]
- --- /lib/x86_64-linux-gnu/libc.so.6(+0x1268d0) [0x7fa0dc5ca8d0]
- (assert.hpp:104)
+2026-02-09 06:30:00.329 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
+2026-02-09 06:30:00.672 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
+2026-02-09 06:30:00.673 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
+2026-02-09 06:30:00.674 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
+2026-02-09 06:30:00.674 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
+2026-02-09 06:30:00.677 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
+2026-02-09 06:30:00.684 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
+2026-02-09 06:30:00.687 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
+2026-02-09 06:30:00.693 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
+2026-02-09 06:30:00.693 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_2D (device_manager.cpp:409)
+2026-02-09 06:30:00.834 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
+2026-02-09 06:30:00.835 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
+2026-02-09 06:30:00.836 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
+2026-02-09 06:30:00.836 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
 Loading tokenizer: Qwen/Qwen3-0.6B
 Opening TT device...
 Loading HuggingFace reference model on CPU: Qwen/Qwen3-0.6B
@@ -145,91 +61,16 @@ Building TT model...
   Loading embeddings...
   Computing RoPE cache...
   Loading 28 layers...
-Traceback (most recent call last):
-  File "/localdev/moconnor/ttnn_models/demo.py", line 374, in <module>
-    main()
-  File "/localdev/moconnor/ttnn_models/demo.py", line 353, in main
-    run_tt_demo(
-  File "/localdev/moconnor/ttnn_models/demo.py", line 302, in run_tt_demo
-    warmup_model(tt_model, input_ids, True, tt_device)
-  File "/localdev/moconnor/ttnn_models/demo.py", line 58, in warmup_model
-    outputs = model(input_ids, use_cache=True)
-  File "/proj_sw/user_dev/moconnor/tt-metal/python_env/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
-    return self._call_impl(*args, **kwargs)
-  File "/proj_sw/user_dev/moconnor/tt-metal/python_env/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
-    return forward_call(*args, **kwargs)
-  File "/localdev/moconnor/ttnn_models/models/Qwen/Qwen3-0.6B/t3000/functional/model.py", line 582, in forward
-    h = ttnn.embedding(tokens, self.embed, layout=ttnn.TILE_LAYOUT)
-  File "/proj_sw/user_dev/moconnor/tt-metal/ttnn/ttnn/decorators.py", line 447, in __call__
-    result = self.function(*function_args, **function_kwargs)
-RuntimeError: TT_THROW @ /proj_sw/user_dev/moconnor/tt-metal/tt_metal/impl/program/program.cpp:160: tt::exception
-info:
-Failed to generate binaries for tilize TT_THROW @ /proj_sw/user_dev/moconnor/tt-metal/tt_metal/jit_build/build.cpp:55: tt::exception
-info:
-trisc2 build failed. Log: In file included from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/include/compute_kernel_api/common_globals.h:24,
-                 from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/include/compute_kernel_api/common.h:7,
-                 from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/include/compute_kernel_api/tilize.h:7,
-                 from /proj_sw/user_dev/moconnor/tt-metal/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize.cpp:7,
-                 from ../chlkc_pack.cpp:3,
-                 from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/common/chlkc_list.h:29,
-                 from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/firmware/src/tt-1xx/trisck.cc:13:
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h: In function 'void llk_pack_fast_tilize_hw_configure(const llk_pack_params_t*)':
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h:292:5: error: '_llk_pack_fast_tilize_hw_configure_' was not declared in this scope; did you mean 'llk_pack_fast_tilize_hw_configure'? [-Wtemplate-body]
-  292 |     _llk_pack_fast_tilize_hw_configure_<is_fp32_dest_acc_en>(pack_src_format[output_id], pack_dst_format[output_id]);
-      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      |     llk_pack_fast_tilize_hw_configure
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h: In instantiation of 'void llk_pack_init(uint32_t) [with bool untilize = false; bool zero_output = false; bool tilize = false; uint32_t = long unsigned int]':
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/include/compute_kernel_api/compute_kernel_hw_startup.h:46:5:   required from here
-   46 |     PACK((llk_pack_init<false /*untilize*/, false /*zero_output*/, false /*tilize*/>(ocb)));
-      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h:124:43: error: no matching function for call to '_llk_pack_init_<false, false>(const unsigned char&, const unsigned char&, const uint32_t&, const uint32_t&, const bool&, const bool&, bool)'
-  124 |     _llk_pack_init_<untilize, zero_output>(
-      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
-  125 |         pack_dst_format[output_id], pack_src_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile, true);
-      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h:124:43: note: there are 2 candidates
-In file included from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h:18:
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h:142:13: note: candidate 1: 'template<bool untilize, bool zero_output> void _llk_pack_init_(uint32_t, uint32_t, uint32_t, bool, bool)'
-  142 | inline void _llk_pack_init_(
-      |             ^~~~~~~~~~~~~~~
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h:142:13: note: candidate expects 5 arguments, 7 provided
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h:161:13: note: candidate 2: 'template<bool untilize, bool zero_output> void _llk_pack_init_(uint32_t, uint32_t, uint32_t, uint32_t, bool, bool)'
-  161 | inline void _llk_pack_init_(
-      |             ^~~~~~~~~~~~~~~
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h:161:13: note: candidate expects 6 arguments, 7 provided
+TT demo (t3000)
+Model: Qwen/Qwen3-0.6B
+Mesh shape: 2x4
+Prompt tokens: 56 | Generated tokens: 128
+TTFT: 229 ms | Decode: 6.2 t/s/u (127 tokens)
 
-backtrace:
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/_ttnncpp.so(+0x2f89b08) [0x7fa00c196b08]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x75e1dc) [0x7fa008cdd1dc]
- --- tt::tt_metal::JitBuildState::compile_one(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, tt::tt_metal::JitBuildSettings const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x770d08) [0x7fa008cefd08]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x770c82) [0x7fa008cefc82]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x51060f) [0x7fa008a8f60f]
- --- /lib/x86_64-linux-gnu/libc.so.6(+0x99ee8) [0x7fa0dc53dee8]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x710759) [0x7fa008c8f759]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x770a8e) [0x7fa008cefa8e]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x7142b5) [0x7fa008c932b5]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x712eed) [0x7fa008c91eed]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x712338) [0x7fa008c91338]
- --- /lib/x86_64-linux-gnu/libstdc++.so.6(+0xdc253) [0x7fa0c6bc5253]
- --- /lib/x86_64-linux-gnu/libc.so.6(+0x94ac3) [0x7fa0dc538ac3]
- --- /lib/x86_64-linux-gnu/libc.so.6(+0x1268d0) [0x7fa0dc5ca8d0]
+Prompt:
+Journal entry, 1957: Tonight a tiny sphere called Sputnik 1 crossed the sky, beeping like a metronome for a new era. The neighbors gathered on the roof, listening and arguing about what comes next. I wrote in my notebook that
 
-backtrace:
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x621308) [0x7fa008ba0308]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x5e2f32) [0x7fa008b61f32]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x770d08) [0x7fa008cefd08]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x770c82) [0x7fa008cefc82]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x51060f) [0x7fa008a8f60f]
- --- /lib/x86_64-linux-gnu/libc.so.6(+0x99ee8) [0x7fa0dc53dee8]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x710759) [0x7fa008c8f759]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x770a8e) [0x7fa008cefa8e]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x7142b5) [0x7fa008c932b5]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x712eed) [0x7fa008c91eed]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x712338) [0x7fa008c91338]
- --- /lib/x86_64-linux-gnu/libstdc++.so.6(+0xdc253) [0x7fa0c6bc5253]
- --- /lib/x86_64-linux-gnu/libc.so.6(+0x94ac3) [0x7fa0dc538ac3]
- --- /lib/x86_64-linux-gnu/libc.so.6(+0x1268d0) [0x7fa0dc5ca8d0]
-
-2026-02-09 02:32:05.063 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-02-09 02:32:05.063 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
+Output:
+ I saw the first satellite, which was very small. It was not a small satellite for Earth, but for the new era of an unknown future. A few days later, it was already visible as the first satellite of the USSR, the 'Star 619' 6. And that, in the first month of the Soviet Union's establishment, was the first satellite launched by a country. I remember all the memories of the children in the city, who were frightened by the idea of a future without a home. The first satellite was also for the child who could have had a home. So I wrote, "The first
+2026-02-09 06:31:10.905 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-09 06:31:10.905 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/Qwen/Qwen3-0.6B/t3000/functional/eval.log
+++ b/models/Qwen/Qwen3-0.6B/t3000/functional/eval.log
@@ -1,144 +1,60 @@
-TT_VISIBLE_DEVICES=0,1,2,3 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto python eval.py models/Qwen/Qwen3-0.6B/t3000/functional/model.py --model Qwen/Qwen3-0.6B --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100
-2026-02-09 02:32:27.787 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+TT_VISIBLE_DEVICES=0,1,2,3 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto python eval.py models/Qwen/Qwen3-0.6B/t3000/functional/model.py --model Qwen/Qwen3-0.6B --max_new_tokens 100 --prompt_file prompts/bringup_eval_long.txt
+2026-02-09 06:31:26.795 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
 The following generation flags are not valid and may be ignored: ['temperature', 'top_p', 'top_k']. Set `TRANSFORMERS_VERBOSITY=info` for more details.
-2026-02-09 02:32:57.172 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 02:32:57.202 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-02-09 02:32:57.211 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 02:32:57.284 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 02:32:57.347 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x202 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 02:32:57.406 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 02:32:57.416 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 02:32:57.427 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 02:32:57.437 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 02:32:57.450 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 02:32:57.463 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 02:32:57.477 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x5 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 02:32:57.490 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 3, 1, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
-2026-02-09 02:32:57.490 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-02-09 02:32:57.490 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
-2026-02-09 02:32:57.498 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-02-09 02:32:57.499 | info     |             UMD | Mapped hugepage 0x240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 02:32:57.500 | info     |             UMD | Mapped hugepage 0x200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 02:32:57.501 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 02:32:57.501 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 02:32:57.502 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 02:32:57.503 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 02:32:57.504 | info     |             UMD | Mapped hugepage 0x42c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 02:32:57.505 | info     |             UMD | Mapped hugepage 0x4280000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 02:32:57.562 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto (metal_context.cpp:822)
-2026-02-09 02:32:57.563 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
-2026-02-09 02:32:57.567 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
-2026-02-09 02:32:57.568 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-02-09 02:32:57.573 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 02:32:57.576 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 02:32:57.577 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 02:32:57.577 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 02:32:57.578 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 02:32:57.579 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 02:32:57.580 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 02:32:57.580 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 02:32:57.917 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
-2026-02-09 02:32:57.917 | info     |           Metal | Dispatch on FabricConfig::FABRIC_2D with 1 Command Queues
+2026-02-09 06:31:57.944 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 06:31:57.975 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-09 06:31:57.985 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 06:31:58.059 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 06:31:58.123 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x202 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 06:31:58.179 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 06:31:58.189 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 06:31:58.199 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 06:31:58.209 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 06:31:58.223 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 06:31:58.236 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 06:31:58.250 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x5 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 06:31:58.264 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 3, 1, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
+2026-02-09 06:31:58.264 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-09 06:31:58.264 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-09 06:31:58.272 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-09 06:31:58.273 | info     |             UMD | Mapped hugepage 0x240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 06:31:58.274 | info     |             UMD | Mapped hugepage 0x200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 06:31:58.275 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 06:31:58.275 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 06:31:58.276 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 06:31:58.277 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 06:31:58.278 | info     |             UMD | Mapped hugepage 0x42c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 06:31:58.279 | info     |             UMD | Mapped hugepage 0x4280000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 06:31:58.331 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto (metal_context.cpp:822)
+2026-02-09 06:31:58.332 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-09 06:31:58.337 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-09 06:31:58.337 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-09 06:31:58.346 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 06:31:58.349 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 06:31:58.349 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 06:31:58.350 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 06:31:58.350 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 06:31:58.351 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 06:31:58.351 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 06:31:58.352 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 06:31:58.691 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
+2026-02-09 06:31:58.691 | info     |           Metal | Dispatch on FabricConfig::FABRIC_2D with 1 Command Queues
  (device_manager.cpp:328)
-2026-02-09 02:32:57.941 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
-2026-02-09 02:32:58.185 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
-2026-02-09 02:32:58.186 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
-2026-02-09 02:32:58.187 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
-2026-02-09 02:32:58.187 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
-2026-02-09 02:32:58.190 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
-2026-02-09 02:32:58.197 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
-2026-02-09 02:32:58.200 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
-2026-02-09 02:32:58.206 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
-2026-02-09 02:32:58.206 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_2D (device_manager.cpp:409)
-2026-02-09 02:32:58.315 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
-2026-02-09 02:32:58.315 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
-2026-02-09 02:32:58.316 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
-2026-02-09 02:32:58.317 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
-2026-02-09 02:33:27.232 | error    |    BuildKernels | trisc2 compile failure -- cmd: cd /proj_sw/user_dev/moconnor/tt-metal-cache/tt-metal-cache07a0186786/1122223303392688457/kernels/tilize/8963115395528636651/trisc2/ && /proj_sw/user_dev/moconnor/tt-metal/runtime/sfpi/compiler/bin/riscv-tt-elf-g++ -O3 -std=c++17 -flto=auto -ffast-math -fno-exceptions -g -MMD -fno-use-cxa-atexit -Wall -Werror -Wno-unknown-pragmas -Wno-deprecated-declarations -Wno-error=multistatement-macros -Wno-error=parentheses -Wno-error=unused-but-set-variable -Wno-unused-variable -Wno-unused-function -mcpu=tt-wh-tensix -I. -I.. -I/proj_sw/user_dev/moconnor/tt-metal/ -I/proj_sw/user_dev/moconnor/tt-metal/ttnn -I/proj_sw/user_dev/moconnor/tt-metal/ttnn/cpp -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/include -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/inc -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hostdevcommon/api -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/inc/debug -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/api/ -I/proj_sw/user_dev/moconnor/tt-metal/runtime/sfpi/include -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/common -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/inc/internal/tt-1xx -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/inc/internal/tt-1xx/wormhole -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/inc/internal/tt-1xx/wormhole/wormhole_b0_defines -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/common/inc -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu -I/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/firmware/src/tt-1xx -c -o trisck.o /proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/firmware/src/tt-1xx/trisck.cc -DIS_NOT_POW2_NUM_DRAM_BANKS=1 -DLOG_BASE_2_OF_NUM_L1_BANKS=6 -DNUM_DRAM_BANKS=12 -DNUM_L1_BANKS=64 -DPCIE_NOC_X=0 -DPCIE_NOC_Y=3 -DTENSIX_FIRMWARE -DLOCAL_MEM_EN=0 -DROUTING_FW_ENABLED -DPROCESSOR_INDEX=4 -DUCK_CHLKC_PACK -DNAMESPACE=chlkc_pack -DCOMPILE_FOR_TRISC=2 -DARCH_WORMHOLE -DDISPATCH_MESSAGE_ADDR=4290052232 -DKERNEL_BUILD -DKERNEL_COMPILE_TIME_ARGS=0,2,1,32,1  (build.cpp:51)
-2026-02-09 02:33:27.236 | critical |          Always | TT_THROW: trisc2 build failed. Log: In file included from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/include/compute_kernel_api/common_globals.h:24,
-                 from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/include/compute_kernel_api/common.h:7,
-                 from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/include/compute_kernel_api/tilize.h:7,
-                 from /proj_sw/user_dev/moconnor/tt-metal/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize.cpp:7,
-                 from ../chlkc_pack.cpp:3,
-                 from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/common/chlkc_list.h:29,
-                 from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/firmware/src/tt-1xx/trisck.cc:13:
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h: In function 'void llk_pack_fast_tilize_hw_configure(const llk_pack_params_t*)':
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h:292:5: error: '_llk_pack_fast_tilize_hw_configure_' was not declared in this scope; did you mean 'llk_pack_fast_tilize_hw_configure'? [-Wtemplate-body]
-  292 |     _llk_pack_fast_tilize_hw_configure_<is_fp32_dest_acc_en>(pack_src_format[output_id], pack_dst_format[output_id]);
-      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      |     llk_pack_fast_tilize_hw_configure
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h: In instantiation of 'void llk_pack_init(uint32_t) [with bool untilize = false; bool zero_output = false; bool tilize = false; uint32_t = long unsigned int]':
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/include/compute_kernel_api/compute_kernel_hw_startup.h:46:5:   required from here
-   46 |     PACK((llk_pack_init<false /*untilize*/, false /*zero_output*/, false /*tilize*/>(ocb)));
-      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h:124:43: error: no matching function for call to '_llk_pack_init_<false, false>(const unsigned char&, const unsigned char&, const uint32_t&, const uint32_t&, const bool&, const bool&, bool)'
-  124 |     _llk_pack_init_<untilize, zero_output>(
-      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
-  125 |         pack_dst_format[output_id], pack_src_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile, true);
-      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h:124:43: note: there are 2 candidates
-In file included from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h:18:
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h:142:13: note: candidate 1: 'template<bool untilize, bool zero_output> void _llk_pack_init_(uint32_t, uint32_t, uint32_t, bool, bool)'
-  142 | inline void _llk_pack_init_(
-      |             ^~~~~~~~~~~~~~~
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h:142:13: note: candidate expects 5 arguments, 7 provided
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h:161:13: note: candidate 2: 'template<bool untilize, bool zero_output> void _llk_pack_init_(uint32_t, uint32_t, uint32_t, uint32_t, bool, bool)'
-  161 | inline void _llk_pack_init_(
-      |             ^~~~~~~~~~~~~~~
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h:161:13: note: candidate expects 6 arguments, 7 provided
- (assert.hpp:104)
-2026-02-09 02:33:27.239 | critical |          Always | TT_THROW: Failed to generate binaries for tilize TT_THROW @ /proj_sw/user_dev/moconnor/tt-metal/tt_metal/jit_build/build.cpp:55: tt::exception
-info:
-trisc2 build failed. Log: In file included from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/include/compute_kernel_api/common_globals.h:24,
-                 from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/include/compute_kernel_api/common.h:7,
-                 from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/include/compute_kernel_api/tilize.h:7,
-                 from /proj_sw/user_dev/moconnor/tt-metal/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize.cpp:7,
-                 from ../chlkc_pack.cpp:3,
-                 from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/common/chlkc_list.h:29,
-                 from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/firmware/src/tt-1xx/trisck.cc:13:
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h: In function 'void llk_pack_fast_tilize_hw_configure(const llk_pack_params_t*)':
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h:292:5: error: '_llk_pack_fast_tilize_hw_configure_' was not declared in this scope; did you mean 'llk_pack_fast_tilize_hw_configure'? [-Wtemplate-body]
-  292 |     _llk_pack_fast_tilize_hw_configure_<is_fp32_dest_acc_en>(pack_src_format[output_id], pack_dst_format[output_id]);
-      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      |     llk_pack_fast_tilize_hw_configure
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h: In instantiation of 'void llk_pack_init(uint32_t) [with bool untilize = false; bool zero_output = false; bool tilize = false; uint32_t = long unsigned int]':
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/include/compute_kernel_api/compute_kernel_hw_startup.h:46:5:   required from here
-   46 |     PACK((llk_pack_init<false /*untilize*/, false /*zero_output*/, false /*tilize*/>(ocb)));
-      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h:124:43: error: no matching function for call to '_llk_pack_init_<false, false>(const unsigned char&, const unsigned char&, const uint32_t&, const uint32_t&, const bool&, const bool&, bool)'
-  124 |     _llk_pack_init_<untilize, zero_output>(
-      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
-  125 |         pack_dst_format[output_id], pack_src_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile, true);
-      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h:124:43: note: there are 2 candidates
-In file included from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h:18:
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h:142:13: note: candidate 1: 'template<bool untilize, bool zero_output> void _llk_pack_init_(uint32_t, uint32_t, uint32_t, bool, bool)'
-  142 | inline void _llk_pack_init_(
-      |             ^~~~~~~~~~~~~~~
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h:142:13: note: candidate expects 5 arguments, 7 provided
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h:161:13: note: candidate 2: 'template<bool untilize, bool zero_output> void _llk_pack_init_(uint32_t, uint32_t, uint32_t, uint32_t, bool, bool)'
-  161 | inline void _llk_pack_init_(
-      |             ^~~~~~~~~~~~~~~
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h:161:13: note: candidate expects 6 arguments, 7 provided
-
-backtrace:
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/_ttnncpp.so(+0x2f89b08) [0x7feac8647b08]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x75e1dc) [0x7feac518e1dc]
- --- tt::tt_metal::JitBuildState::compile_one(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, tt::tt_metal::JitBuildSettings const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x770d08) [0x7feac51a0d08]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x770c82) [0x7feac51a0c82]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x51060f) [0x7feac4f4060f]
- --- /lib/x86_64-linux-gnu/libc.so.6(+0x99ee8) [0x7feb32348ee8]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x710759) [0x7feac5140759]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x770a8e) [0x7feac51a0a8e]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x7142b5) [0x7feac51442b5]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x712eed) [0x7feac5142eed]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x712338) [0x7feac5142338]
- --- /lib/x86_64-linux-gnu/libstdc++.so.6(+0xdc253) [0x7feb1c9c5253]
- --- /lib/x86_64-linux-gnu/libc.so.6(+0x94ac3) [0x7feb32343ac3]
- --- /lib/x86_64-linux-gnu/libc.so.6(+0x1268d0) [0x7feb323d58d0]
- (assert.hpp:104)
+2026-02-09 06:31:58.715 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
+2026-02-09 06:31:58.958 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
+2026-02-09 06:31:58.959 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
+2026-02-09 06:31:58.959 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
+2026-02-09 06:31:58.960 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
+2026-02-09 06:31:58.963 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
+2026-02-09 06:31:58.969 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
+2026-02-09 06:31:58.973 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
+2026-02-09 06:31:58.979 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
+2026-02-09 06:31:58.979 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_2D (device_manager.cpp:409)
+2026-02-09 06:31:59.086 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
+2026-02-09 06:31:59.086 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
+2026-02-09 06:31:59.088 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
+2026-02-09 06:31:59.091 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
 Loading model module: /localdev/moconnor/ttnn_models/models/Qwen/Qwen3-0.6B/t3000/functional/model.py
 Loading HuggingFace tokenizer...
 Loading HuggingFace reference model on CPU...
@@ -149,89 +65,7 @@ Loading ttnn model...
   Computing RoPE cache...
   Loading 28 layers...
 Running teacher-forcing eval (100 tokens)...
-Traceback (most recent call last):
-  File "/localdev/moconnor/ttnn_models/eval.py", line 192, in <module>
-    main()
-  File "/localdev/moconnor/ttnn_models/eval.py", line 171, in main
-    top1, top5, total = evaluate(
-  File "/localdev/moconnor/ttnn_models/eval.py", line 45, in evaluate
-    outputs = tt_model(prompt_ids, past_key_values=past, use_cache=True)
-  File "/proj_sw/user_dev/moconnor/tt-metal/python_env/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
-    return self._call_impl(*args, **kwargs)
-  File "/proj_sw/user_dev/moconnor/tt-metal/python_env/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
-    return forward_call(*args, **kwargs)
-  File "/localdev/moconnor/ttnn_models/models/Qwen/Qwen3-0.6B/t3000/functional/model.py", line 582, in forward
-    h = ttnn.embedding(tokens, self.embed, layout=ttnn.TILE_LAYOUT)
-  File "/proj_sw/user_dev/moconnor/tt-metal/ttnn/ttnn/decorators.py", line 447, in __call__
-    result = self.function(*function_args, **function_kwargs)
-RuntimeError: TT_THROW @ /proj_sw/user_dev/moconnor/tt-metal/tt_metal/impl/program/program.cpp:160: tt::exception
-info:
-Failed to generate binaries for tilize TT_THROW @ /proj_sw/user_dev/moconnor/tt-metal/tt_metal/jit_build/build.cpp:55: tt::exception
-info:
-trisc2 build failed. Log: In file included from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/include/compute_kernel_api/common_globals.h:24,
-                 from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/include/compute_kernel_api/common.h:7,
-                 from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/include/compute_kernel_api/tilize.h:7,
-                 from /proj_sw/user_dev/moconnor/tt-metal/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize.cpp:7,
-                 from ../chlkc_pack.cpp:3,
-                 from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/common/chlkc_list.h:29,
-                 from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/firmware/src/tt-1xx/trisck.cc:13:
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h: In function 'void llk_pack_fast_tilize_hw_configure(const llk_pack_params_t*)':
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h:292:5: error: '_llk_pack_fast_tilize_hw_configure_' was not declared in this scope; did you mean 'llk_pack_fast_tilize_hw_configure'? [-Wtemplate-body]
-  292 |     _llk_pack_fast_tilize_hw_configure_<is_fp32_dest_acc_en>(pack_src_format[output_id], pack_dst_format[output_id]);
-      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      |     llk_pack_fast_tilize_hw_configure
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h: In instantiation of 'void llk_pack_init(uint32_t) [with bool untilize = false; bool zero_output = false; bool tilize = false; uint32_t = long unsigned int]':
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/include/compute_kernel_api/compute_kernel_hw_startup.h:46:5:   required from here
-   46 |     PACK((llk_pack_init<false /*untilize*/, false /*zero_output*/, false /*tilize*/>(ocb)));
-      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h:124:43: error: no matching function for call to '_llk_pack_init_<false, false>(const unsigned char&, const unsigned char&, const uint32_t&, const uint32_t&, const bool&, const bool&, bool)'
-  124 |     _llk_pack_init_<untilize, zero_output>(
-      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
-  125 |         pack_dst_format[output_id], pack_src_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile, true);
-      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h:124:43: note: there are 2 candidates
-In file included from /proj_sw/user_dev/moconnor/tt-metal/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h:18:
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h:142:13: note: candidate 1: 'template<bool untilize, bool zero_output> void _llk_pack_init_(uint32_t, uint32_t, uint32_t, bool, bool)'
-  142 | inline void _llk_pack_init_(
-      |             ^~~~~~~~~~~~~~~
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h:142:13: note: candidate expects 5 arguments, 7 provided
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h:161:13: note: candidate 2: 'template<bool untilize, bool zero_output> void _llk_pack_init_(uint32_t, uint32_t, uint32_t, uint32_t, bool, bool)'
-  161 | inline void _llk_pack_init_(
-      |             ^~~~~~~~~~~~~~~
-/proj_sw/user_dev/moconnor/tt-metal/tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h:161:13: note: candidate expects 6 arguments, 7 provided
-
-backtrace:
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/_ttnncpp.so(+0x2f89b08) [0x7feac8647b08]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x75e1dc) [0x7feac518e1dc]
- --- tt::tt_metal::JitBuildState::compile_one(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, tt::tt_metal::JitBuildSettings const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x770d08) [0x7feac51a0d08]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x770c82) [0x7feac51a0c82]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x51060f) [0x7feac4f4060f]
- --- /lib/x86_64-linux-gnu/libc.so.6(+0x99ee8) [0x7feb32348ee8]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x710759) [0x7feac5140759]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x770a8e) [0x7feac51a0a8e]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x7142b5) [0x7feac51442b5]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x712eed) [0x7feac5142eed]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x712338) [0x7feac5142338]
- --- /lib/x86_64-linux-gnu/libstdc++.so.6(+0xdc253) [0x7feb1c9c5253]
- --- /lib/x86_64-linux-gnu/libc.so.6(+0x94ac3) [0x7feb32343ac3]
- --- /lib/x86_64-linux-gnu/libc.so.6(+0x1268d0) [0x7feb323d58d0]
-
-backtrace:
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x621308) [0x7feac5051308]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x5e2f32) [0x7feac5012f32]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x770d08) [0x7feac51a0d08]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x770c82) [0x7feac51a0c82]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x51060f) [0x7feac4f4060f]
- --- /lib/x86_64-linux-gnu/libc.so.6(+0x99ee8) [0x7feb32348ee8]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x710759) [0x7feac5140759]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x770a8e) [0x7feac51a0a8e]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x7142b5) [0x7feac51442b5]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x712eed) [0x7feac5142eed]
- --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x712338) [0x7feac5142338]
- --- /lib/x86_64-linux-gnu/libstdc++.so.6(+0xdc253) [0x7feb1c9c5253]
- --- /lib/x86_64-linux-gnu/libc.so.6(+0x94ac3) [0x7feb32343ac3]
- --- /lib/x86_64-linux-gnu/libc.so.6(+0x1268d0) [0x7feb323d58d0]
-
-2026-02-09 02:33:28.899 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-02-09 02:33:28.899 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
+Top-1 accuracy: 98.00% (0.9800)
+Top-5 accuracy: 100.00% (1.0000)
+2026-02-09 06:32:48.287 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-09 06:32:48.287 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)


### PR DESCRIPTION
Rerun demo/eval on t3000 now that the t3k host tt-metal submodules are synced; update MODELS.md + demo.log + eval.log.

If TT JIT llk_* arg mismatch appears, run: cd /proj_sw/user_dev/moconnor/tt-metal && git submodule update --init --recursive.

Closes #56.