### PR TITLE
Worker: unbuffer codexapi output

### DIFF
--- a/scripts/worker.sh
+++ b/scripts/worker.sh
@@ -89,6 +89,7 @@ while true; do
         sleep 60
         continue
     fi
-    codexapi task -p https://github.com/users/yieldthought/projects/6 -n "$agent_name" "${task_files[@]}"
+    # Ensure codexapi output is flushed promptly to nohup logs.
+    PYTHONUNBUFFERED=1 codexapi task -p https://github.com/users/yieldthought/projects/6 -n "$agent_name" "${task_files[@]}"
     sleep 60
 done


### PR DESCRIPTION
Set PYTHONUNBUFFERED=1 for codexapi so /tmp/agent*.log updates promptly.