### PR TITLE
models/microsoft/Phi-3-mini-128k-instruct/n150/functional

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -30,7 +30,7 @@ Note: Keep the table columns padded with spaces and right-justify numeric cells 
 | google/gemma-3-4b-it                |   n150   | functional |   92% |  100% |   98ms |  13.9 |   40960 |
 | google/gemma-3-4b-it                |   n300   | functional |   bad |   bad |  360ms |   4.6 |     256 |
 | google/gemma-3-4b-it                |  t3000   | functional |   bad |   bad |   bad |   bad |     256 |
-| microsoft/Phi-3-mini-128k-instruct  |   n150   | functional |   84% |   98% |   80ms |  13.7 |   12288 |
+| microsoft/Phi-3-mini-128k-instruct  |   n150   | functional |   84% |   98% |   82ms |  13.6 |   12288 |
 | microsoft/Phi-3-mini-128k-instruct  |   n300   | functional |   90% |  100% |  168ms |   7.6 |     256 |
 | microsoft/Phi-3-mini-128k-instruct  |  t3000   | functional |   bad |   bad |   bad |   bad |     256 |
 | tiiuae/Falcon3-7B-Instruct          |   n150   | functional |   97% |  100% |  144ms |  13.4 |   32768 |

--- a/models/microsoft/Phi-3-mini-128k-instruct/n150/functional/demo.log
+++ b/models/microsoft/Phi-3-mini-128k-instruct/n150/functional/demo.log
@@ -1,51 +1,52 @@
 python demo.py models/microsoft/Phi-3-mini-128k-instruct/n150/functional/model.py
 /proj_sw/user_dev/moconnor/tt-metal/python_env/lib/python3.10/site-packages/transformers/utils/hub.py:111: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
   warnings.warn(
-2026-01-26 21:36:44.642 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+2026-02-09 11:47:15.052 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
-2026-01-26 21:36:45.344 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-01-26 21:36:45.344 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-01-26 21:36:45.347 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-01-26 21:36:45.366 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-01-26 21:36:45.366 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x10 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-01-26 21:36:45.454 | info     |             UMD | Opening local chip ids/PCIe ids: {0}/[7] and remote chip ids {} (cluster.cpp:186)
-2026-01-26 21:36:45.454 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-01-26 21:36:45.454 | info     |             UMD | KMD version: 2.4.0 (cluster.cpp:164)
-2026-01-26 21:36:45.456 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-01-26 21:36:45.459 | info     |             UMD | Mapped hugepage 0x4280000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-01-26 21:36:45.515 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.WORKER
-2026-01-26 21:36:45.515 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-01-26 21:36:45.515 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:863)
-2026-01-26 21:36:45.515 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:840)
-2026-01-26 21:36:45.515 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
-2026-01-26 21:36:45.515 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
+2026-02-09 11:47:15.450 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 11:47:15.451 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-09 11:47:15.455 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 11:47:15.475 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 11:47:15.476 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x80 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 11:47:15.566 | info     |             UMD | Opening local chip ids/PCIe ids: {0}/[4] and remote chip ids {} (cluster.cpp:186)
+2026-02-09 11:47:15.566 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-09 11:47:15.566 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-09 11:47:15.568 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-09 11:47:15.570 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 11:47:15.656 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.WORKER
+2026-02-09 11:47:15.657 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-09 11:47:15.657 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:863)
+2026-02-09 11:47:15.657 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:840)
+2026-02-09 11:47:15.657 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
+2026-02-09 11:47:15.657 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
+2026-02-09 11:47:15.675 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
 Loading tokenizer: microsoft/Phi-3-mini-128k-instruct
 Opening TT device...
 Loading HuggingFace reference model on CPU: microsoft/Phi-3-mini-128k-instruct
-Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:47<00:47, 47.06s/it]Loading checkpoint shards: 100%|██████████| 2/2 [01:12<00:00, 34.55s/it]Loading checkpoint shards: 100%|██████████| 2/2 [01:12<00:00, 36.43s/it]
-2026-01-26 21:38:29.443 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/7944994127753528348/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:38:34.832 | warning  |    BuildKernels | Compute kernel 'tilize/17731151790256603023/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:38:40.285 | warning  |    BuildKernels | Compute kernel 'layernorm/4884704230036260402/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:38:45.570 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/6459158174352101094/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:38:56.051 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/10380771056115669711/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:39:05.735 | warning  |    BuildKernels | Compute kernel 'tilize/11337404802072393109/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:39:10.573 | warning  |    BuildKernels | Compute kernel 'pack_untilize/15529522441930124248/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:39:15.565 | warning  |    BuildKernels | Compute kernel 'pack_untilize/5445543247183471221/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:39:34.436 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/15977828201954068243/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:39:39.352 | warning  |    BuildKernels | Compute kernel 'tilize/5674158030118682369/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:39:48.793 | warning  |    BuildKernels | Compute kernel 'sdpa/18318591445458372772/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:39:58.373 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4931792159892224567/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:40:03.378 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/13862988462773022913/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:40:08.488 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4716092588016794557/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:40:13.360 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/12743793310271913512/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:40:22.646 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/771060300310080457/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:40:31.900 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/18025573480810144695/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:40:36.288 | warning  |    BuildKernels | Compute kernel 'update_cache/1108314601679714129/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:40:41.766 | warning  |    BuildKernels | Compute kernel 'sdpa_flash_decode/10579690541320338821/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:40:56.785 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/9455956975227903173/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:41:01.576 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/17107799782473473287/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:41:07.154 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/9946959827408487608/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:41:12.098 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/10208751014080416571/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:01<00:01,  1.10s/it]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.28it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.20it/s]
+2026-02-09 11:47:50.098 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/7944994127753528348/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:47:55.654 | warning  |    BuildKernels | Compute kernel 'tilize/17731151790256603023/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:48:00.778 | warning  |    BuildKernels | Compute kernel 'layernorm/4884704230036260402/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:48:05.919 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/6459158174352101094/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:48:06.149 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/10380771056115669711/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:48:16.636 | warning  |    BuildKernels | Compute kernel 'tilize/11337404802072393109/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:48:21.756 | warning  |    BuildKernels | Compute kernel 'pack_untilize/15529522441930124248/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:48:26.895 | warning  |    BuildKernels | Compute kernel 'pack_untilize/5445543247183471221/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:48:27.149 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/15977828201954068243/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:48:32.580 | warning  |    BuildKernels | Compute kernel 'tilize/5674158030118682369/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:48:32.750 | warning  |    BuildKernels | Compute kernel 'sdpa/18318591445458372772/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:48:32.966 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4931792159892224567/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:48:38.667 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/13862988462773022913/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:48:54.531 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4716092588016794557/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:48:54.715 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/12743793310271913512/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:48:54.883 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/771060300310080457/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:48:55.124 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/18025573480810144695/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:48:55.309 | warning  |    BuildKernels | Compute kernel 'update_cache/1108314601679714129/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:48:55.423 | warning  |    BuildKernels | Compute kernel 'sdpa_flash_decode/10579690541320338821/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:48:55.706 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/9455956975227903173/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:48:55.821 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/17107799782473473287/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:49:01.238 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/9946959827408487608/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:49:01.426 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/10208751014080416571/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
 Building TT model...
   Loading embeddings...
   Computing RoPE cache...
@@ -54,7 +55,7 @@ TT demo (n150)
 Model: microsoft/Phi-3-mini-128k-instruct
 Mesh shape: 1x1
 Prompt tokens: 60 | Generated tokens: 128
-TTFT: 80 ms | Decode: 13.7 t/s/u (127 tokens)
+TTFT: 82 ms | Decode: 13.6 t/s/u (127 tokens)
 
 Prompt:
 Journal entry, 1957: Tonight a tiny sphere called Sputnik 1 crossed the sky, beeping like a metronome for a new era. The neighbors gathered on the roof, listening and arguing about what comes next. I wrote in my notebook that
@@ -65,5 +66,5 @@ Output:
 2. Title: "The Dice of Destiny: A Teenager’s Tale of Cold War Risk"
    - Narrative Logic: Following the narrative of a high-stakes game of chance, the story can be used to parallel the unpredictable developments during the Cold War. The protagonist's character growth is tied to their understanding of the larger world.
    - Short Story: "In 1англ., 1986—My family's old dice set sat in the
-2026-01-26 21:41:28.655 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-01-26 21:41:28.656 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
+2026-02-09 11:49:13.617 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-09 11:49:13.617 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/microsoft/Phi-3-mini-128k-instruct/n150/functional/eval.log
+++ b/models/microsoft/Phi-3-mini-128k-instruct/n150/functional/eval.log
@@ -1,58 +1,60 @@
-python eval.py models/microsoft/Phi-3-mini-128k-instruct/n150/functional/model.py --model microsoft/Phi-3-mini-128k-instruct --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 12288
-2026-01-26 21:42:29.829 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+python eval.py models/microsoft/Phi-3-mini-128k-instruct/n150/functional/model.py --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 12288
+2026-02-09 11:49:34.255 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
 /proj_sw/user_dev/moconnor/tt-metal/python_env/lib/python3.10/site-packages/transformers/utils/hub.py:111: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
   warnings.warn(
 Loading model module: /localdev/moconnor/ttnn_models/models/microsoft/Phi-3-mini-128k-instruct/n150/functional/model.py
+Using HuggingFace model inferred from path: microsoft/Phi-3-mini-128k-instruct
 Loading HuggingFace tokenizer...
 Loading HuggingFace reference model on CPU...
-Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:00<00:00,  1.32it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.80it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.71it/s]
-2026-01-26 21:44:55.080 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-01-26 21:44:55.081 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-01-26 21:44:55.083 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-01-26 21:44:55.103 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-01-26 21:44:55.104 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x10 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-01-26 21:44:55.187 | info     |             UMD | Opening local chip ids/PCIe ids: {0}/[7] and remote chip ids {} (cluster.cpp:186)
-2026-01-26 21:44:55.187 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-01-26 21:44:55.187 | info     |             UMD | KMD version: 2.4.0 (cluster.cpp:164)
-2026-01-26 21:44:55.189 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-01-26 21:44:55.192 | info     |             UMD | Mapped hugepage 0x4280000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-01-26 21:44:55.244 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.WORKER
-2026-01-26 21:44:55.244 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-01-26 21:44:55.244 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:863)
-2026-01-26 21:44:55.244 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:840)
-2026-01-26 21:44:55.245 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
-2026-01-26 21:44:55.245 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
-2026-01-26 21:45:17.026 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/7944994127753528348/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:45:17.174 | warning  |    BuildKernels | Compute kernel 'tilize/17731151790256603023/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:45:21.059 | warning  |    BuildKernels | Compute kernel 'layernorm/4884704230036260402/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:45:21.249 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/12265219684519922531/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:45:30.110 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/10380771056115669711/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:45:30.299 | warning  |    BuildKernels | Compute kernel 'tilize/11337404802072393109/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:45:30.304 | warning  |    BuildKernels | Compute kernel 'tilize/1982224783747614441/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:45:33.700 | warning  |    BuildKernels | Compute kernel 'pack_untilize/15529522441930124248/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:45:33.704 | warning  |    BuildKernels | Compute kernel 'pack_untilize/1369520511343747262/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:45:38.517 | warning  |    BuildKernels | Compute kernel 'pack_untilize/5445543247183471221/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:45:38.522 | warning  |    BuildKernels | Compute kernel 'pack_untilize/808529285405081447/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:45:43.490 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/3500961269753639563/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:45:43.490 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/7317598834983320959/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:45:43.702 | warning  |    BuildKernels | Compute kernel 'tilize/5674158030118682369/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:45:43.707 | warning  |    BuildKernels | Compute kernel 'tilize/3616169035476323512/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:45:53.236 | warning  |    BuildKernels | Compute kernel 'sdpa/16476601990160721599/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:46:02.163 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4487912705438789235/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:46:06.872 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/343545304713059735/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:46:13.238 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/11708689732707033683/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:46:19.123 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/12915024539697323054/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:46:24.829 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/771060300310080457/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:46:25.281 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/18025573480810144695/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:46:25.599 | warning  |    BuildKernels | Compute kernel 'update_cache/1108314601679714129/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:46:30.532 | warning  |    BuildKernels | Compute kernel 'sdpa_flash_decode/7191414720724713666/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:46:35.701 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/9455956975227903173/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:46:35.835 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/17107799782473473287/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:46:36.116 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/9946959827408487608/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:46:36.292 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/10208751014080416571/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:01<00:01,  1.02s/it]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.39it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.31it/s]
+2026-02-09 11:51:04.839 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 11:51:04.841 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-09 11:51:04.845 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 11:51:04.866 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 11:51:04.866 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x80 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 11:51:04.960 | info     |             UMD | Opening local chip ids/PCIe ids: {0}/[4] and remote chip ids {} (cluster.cpp:186)
+2026-02-09 11:51:04.960 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-09 11:51:04.960 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-09 11:51:04.962 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-09 11:51:04.963 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 11:51:05.059 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.WORKER
+2026-02-09 11:51:05.060 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-09 11:51:05.060 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:863)
+2026-02-09 11:51:05.060 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:840)
+2026-02-09 11:51:05.060 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
+2026-02-09 11:51:05.060 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
+2026-02-09 11:51:05.079 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 11:51:40.077 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/7944994127753528348/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:51:45.538 | warning  |    BuildKernels | Compute kernel 'tilize/17731151790256603023/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:51:50.687 | warning  |    BuildKernels | Compute kernel 'layernorm/4884704230036260402/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:51:55.795 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/12265219684519922531/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:52:01.396 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/10380771056115669711/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:52:01.554 | warning  |    BuildKernels | Compute kernel 'tilize/1982224783747614441/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:52:01.556 | warning  |    BuildKernels | Compute kernel 'tilize/11337404802072393109/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:52:07.077 | warning  |    BuildKernels | Compute kernel 'pack_untilize/1369520511343747262/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:52:07.077 | warning  |    BuildKernels | Compute kernel 'pack_untilize/15529522441930124248/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:52:17.275 | warning  |    BuildKernels | Compute kernel 'pack_untilize/5445543247183471221/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:52:17.275 | warning  |    BuildKernels | Compute kernel 'pack_untilize/808529285405081447/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:52:22.575 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/7317598834983320959/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:52:22.581 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/3500961269753639563/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:52:28.114 | warning  |    BuildKernels | Compute kernel 'tilize/5674158030118682369/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:52:28.114 | warning  |    BuildKernels | Compute kernel 'tilize/3616169035476323512/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:52:33.756 | warning  |    BuildKernels | Compute kernel 'sdpa/16476601990160721599/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:52:39.391 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4487912705438789235/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:52:45.085 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/343545304713059735/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:52:55.827 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/11708689732707033683/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:53:01.400 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/12915024539697323054/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:53:07.021 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/771060300310080457/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:53:12.715 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/18025573480810144695/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:53:18.281 | warning  |    BuildKernels | Compute kernel 'update_cache/1108314601679714129/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:53:23.856 | warning  |    BuildKernels | Compute kernel 'sdpa_flash_decode/7191414720724713666/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:53:29.088 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/9455956975227903173/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:53:34.636 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/17107799782473473287/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:53:40.291 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/9946959827408487608/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 11:53:40.467 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/10208751014080416571/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
 Generating reference tokens...
-Opening device...
+Opening device (1x1)...
 Loading ttnn model...
   Loading embeddings...
   Computing RoPE cache...
@@ -60,5 +62,5 @@ Loading ttnn model...
 Running teacher-forcing eval (100 tokens)...
 Top-1 accuracy: 84.00% (0.8400)
 Top-5 accuracy: 98.00% (0.9800)
-2026-01-26 21:46:45.565 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-01-26 21:46:45.565 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
+2026-02-09 11:53:50.578 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-09 11:53:50.578 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)


### PR DESCRIPTION
Rerun demo/eval on n150 and update MODELS.md + logs.

Results:
- Top-1 84%, Top-5 98% (still below target)
- TTFT 82 ms, Decode 13.6 t/s/u
- No obvious correctness issues in logs; only kernel deprecation warnings

Refs #67