### PR TITLE
models/microsoft/Phi-3-mini-128k-instruct/n150/functional

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -30,7 +30,7 @@ Note: Keep the table columns padded with spaces and right-justify numeric cells 
 | google/gemma-3-4b-it                |   n150   | functional |   92% |  100% |   98ms |  13.9 |   40960 |
 | google/gemma-3-4b-it                |   n300   | functional |   bad |   bad |  360ms |   4.6 |     256 |
 | google/gemma-3-4b-it                |  t3000   | functional |   bad |   bad |   bad |   bad |     256 |
-| microsoft/Phi-3-mini-128k-instruct  |   n150   | functional |   84% |   98% |   82ms |  13.6 |   12288 |
+| microsoft/Phi-3-mini-128k-instruct  |   n150   | functional |   92% |   99% |   80ms |  13.7 |   12288 |
 | microsoft/Phi-3-mini-128k-instruct  |   n300   | functional |   90% |  100% |  168ms |   7.6 |     256 |
 | microsoft/Phi-3-mini-128k-instruct  |  t3000   | functional |   bad |   bad |   bad |   bad |     256 |
 | tiiuae/Falcon3-7B-Instruct          |   n150   | functional |   97% |  100% |  144ms |  13.4 |   32768 |

--- a/models/microsoft/Phi-3-mini-128k-instruct/n150/functional/MODEL_BRINGUP.md
+++ b/models/microsoft/Phi-3-mini-128k-instruct/n150/functional/MODEL_BRINGUP.md
@@ -30,8 +30,12 @@ Phi-3 uses LongRoPE (`rope_scaling.type = longrope`). This bringup:
   `original_max_position_embeddings` (4096).
 - Pads the RoPE dimension to a multiple of 64 for TT rotary (then slices back).
 
-If you need a prompt that crosses 4096 after prefill, rerun with a `max_seq_len`
-large enough for that prompt so the long factors are used consistently.
+This bringup precomputes **both** short and long RoPE caches and selects between
+them per call:
+- Prefill uses the long cache only when `seq_len > original_max_position_embeddings`.
+- Decode switches to the long cache when `start_pos >= original_max_position_embeddings`.
+This matches HF’s dynamic LongRoPE behavior so sequences that cross 4096 during
+decode use the correct frequency factors.
 
 ## KV cache and tiling constraints
 - Cache tensors are paged: `[max_num_blocks, n_kv_heads, block_size, head_dim]` with `block_size=64`.
@@ -57,3 +61,10 @@ Automation wrapper (emits YT_METRICS JSON):
 ```
 python scripts/run_eval.py --mode tt --hf-model microsoft/Phi-3-mini-128k-instruct --system n150 --max-seq-len 12288
 ```
+
+## Latest results (2026-02-09)
+- Long eval (`prompts/bringup_eval_long.txt`, `--max_new_tokens 100`, `--max_seq_len 12288`): Top-1 92%, Top-5 99%.
+- Demo: TTFT 80 ms, decode 13.7 t/s/u.
+- Fix: compute both short/long RoPE caches and switch based on `seq_len` (prefill) or
+  `start_pos` (decode) to align with HF LongRoPE dynamic selection.
+- Note: `eval.py` enforces `--max_seq_len >= 2048`.

--- a/models/microsoft/Phi-3-mini-128k-instruct/n150/functional/demo.log
+++ b/models/microsoft/Phi-3-mini-128k-instruct/n150/functional/demo.log
@@ -1,52 +1,52 @@
 python demo.py models/microsoft/Phi-3-mini-128k-instruct/n150/functional/model.py
 /proj_sw/user_dev/moconnor/tt-metal/python_env/lib/python3.10/site-packages/transformers/utils/hub.py:111: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
   warnings.warn(
-2026-02-09 11:47:15.052 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+2026-02-09 12:51:06.455 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
-2026-02-09 11:47:15.450 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 11:47:15.451 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-02-09 11:47:15.455 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 11:47:15.475 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 11:47:15.476 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x80 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 11:47:15.566 | info     |             UMD | Opening local chip ids/PCIe ids: {0}/[4] and remote chip ids {} (cluster.cpp:186)
-2026-02-09 11:47:15.566 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-02-09 11:47:15.566 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
-2026-02-09 11:47:15.568 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-02-09 11:47:15.570 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 11:47:15.656 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.WORKER
-2026-02-09 11:47:15.657 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-02-09 11:47:15.657 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:863)
-2026-02-09 11:47:15.657 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:840)
-2026-02-09 11:47:15.657 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
-2026-02-09 11:47:15.657 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
-2026-02-09 11:47:15.675 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 12:51:06.915 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 12:51:06.915 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-09 12:51:06.920 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 12:51:06.939 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 12:51:06.940 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x80 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 12:51:07.030 | info     |             UMD | Opening local chip ids/PCIe ids: {0}/[4] and remote chip ids {} (cluster.cpp:186)
+2026-02-09 12:51:07.030 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-09 12:51:07.030 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-09 12:51:07.032 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-09 12:51:07.033 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 12:51:07.122 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.WORKER
+2026-02-09 12:51:07.122 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-09 12:51:07.122 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:863)
+2026-02-09 12:51:07.122 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:840)
+2026-02-09 12:51:07.122 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
+2026-02-09 12:51:07.122 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
+2026-02-09 12:51:07.142 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
 Loading tokenizer: microsoft/Phi-3-mini-128k-instruct
 Opening TT device...
 Loading HuggingFace reference model on CPU: microsoft/Phi-3-mini-128k-instruct
-Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:01<00:01,  1.10s/it]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.28it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.20it/s]
-2026-02-09 11:47:50.098 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/7944994127753528348/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:47:55.654 | warning  |    BuildKernels | Compute kernel 'tilize/17731151790256603023/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:48:00.778 | warning  |    BuildKernels | Compute kernel 'layernorm/4884704230036260402/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:48:05.919 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/6459158174352101094/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:48:06.149 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/10380771056115669711/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:48:16.636 | warning  |    BuildKernels | Compute kernel 'tilize/11337404802072393109/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:48:21.756 | warning  |    BuildKernels | Compute kernel 'pack_untilize/15529522441930124248/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:48:26.895 | warning  |    BuildKernels | Compute kernel 'pack_untilize/5445543247183471221/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:48:27.149 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/15977828201954068243/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:48:32.580 | warning  |    BuildKernels | Compute kernel 'tilize/5674158030118682369/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:48:32.750 | warning  |    BuildKernels | Compute kernel 'sdpa/18318591445458372772/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:48:32.966 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4931792159892224567/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:48:38.667 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/13862988462773022913/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:48:54.531 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4716092588016794557/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:48:54.715 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/12743793310271913512/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:48:54.883 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/771060300310080457/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:48:55.124 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/18025573480810144695/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:48:55.309 | warning  |    BuildKernels | Compute kernel 'update_cache/1108314601679714129/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:48:55.423 | warning  |    BuildKernels | Compute kernel 'sdpa_flash_decode/10579690541320338821/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:48:55.706 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/9455956975227903173/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:48:55.821 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/17107799782473473287/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:49:01.238 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/9946959827408487608/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:49:01.426 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/10208751014080416571/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:01<00:01,  1.04s/it]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.38it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.30it/s]
+2026-02-09 12:51:41.930 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/7944994127753528348/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:51:47.448 | warning  |    BuildKernels | Compute kernel 'tilize/17731151790256603023/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:51:52.580 | warning  |    BuildKernels | Compute kernel 'layernorm/4884704230036260402/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:51:57.720 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/6459158174352101094/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:52:08.434 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/10380771056115669711/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:52:08.586 | warning  |    BuildKernels | Compute kernel 'tilize/11337404802072393109/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:52:08.689 | warning  |    BuildKernels | Compute kernel 'pack_untilize/15529522441930124248/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:52:14.090 | warning  |    BuildKernels | Compute kernel 'pack_untilize/5445543247183471221/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:52:19.353 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/15977828201954068243/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:52:19.512 | warning  |    BuildKernels | Compute kernel 'tilize/5674158030118682369/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:52:19.663 | warning  |    BuildKernels | Compute kernel 'sdpa/18318591445458372772/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:52:19.870 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4931792159892224567/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:52:30.487 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/13862988462773022913/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:52:36.236 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4716092588016794557/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:52:41.782 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/12743793310271913512/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:52:47.420 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/771060300310080457/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:52:47.654 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/18025573480810144695/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:52:53.062 | warning  |    BuildKernels | Compute kernel 'update_cache/1108314601679714129/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:52:53.172 | warning  |    BuildKernels | Compute kernel 'sdpa_flash_decode/10579690541320338821/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:52:58.815 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/9455956975227903173/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:52:58.924 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/17107799782473473287/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:53:09.423 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/9946959827408487608/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:53:15.078 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/10208751014080416571/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
 Building TT model...
   Loading embeddings...
   Computing RoPE cache...
@@ -55,7 +55,7 @@ TT demo (n150)
 Model: microsoft/Phi-3-mini-128k-instruct
 Mesh shape: 1x1
 Prompt tokens: 60 | Generated tokens: 128
-TTFT: 82 ms | Decode: 13.6 t/s/u (127 tokens)
+TTFT: 80 ms | Decode: 13.7 t/s/u (127 tokens)
 
 Prompt:
 Journal entry, 1957: Tonight a tiny sphere called Sputnik 1 crossed the sky, beeping like a metronome for a new era. The neighbors gathered on the roof, listening and arguing about what comes next. I wrote in my notebook that
@@ -66,5 +66,5 @@ Output:
 2. Title: "The Dice of Destiny: A Teenager’s Tale of Cold War Risk"
    - Narrative Logic: Following the narrative of a high-stakes game of chance, the story can be used to parallel the unpredictable developments during the Cold War. The protagonist's character growth is tied to their understanding of the larger world.
    - Short Story: "In 1англ., 1986—My family's old dice set sat in the
-2026-02-09 11:49:13.617 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-02-09 11:49:13.617 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
+2026-02-09 12:53:27.204 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-09 12:53:27.204 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/microsoft/Phi-3-mini-128k-instruct/n150/functional/eval.log
+++ b/models/microsoft/Phi-3-mini-128k-instruct/n150/functional/eval.log
@@ -1,58 +1,57 @@
-python eval.py models/microsoft/Phi-3-mini-128k-instruct/n150/functional/model.py --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 12288
-2026-02-09 11:49:34.255 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+python eval.py models/microsoft/Phi-3-mini-128k-instruct/n150/functional/model.py --model microsoft/Phi-3-mini-128k-instruct --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 12288
+2026-02-09 12:46:40.476 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
 /proj_sw/user_dev/moconnor/tt-metal/python_env/lib/python3.10/site-packages/transformers/utils/hub.py:111: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
   warnings.warn(
 Loading model module: /localdev/moconnor/ttnn_models/models/microsoft/Phi-3-mini-128k-instruct/n150/functional/model.py
-Using HuggingFace model inferred from path: microsoft/Phi-3-mini-128k-instruct
 Loading HuggingFace tokenizer...
 Loading HuggingFace reference model on CPU...
-Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:01<00:01,  1.02s/it]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.39it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.31it/s]
-2026-02-09 11:51:04.839 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 11:51:04.841 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-02-09 11:51:04.845 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 11:51:04.866 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 11:51:04.866 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x80 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 11:51:04.960 | info     |             UMD | Opening local chip ids/PCIe ids: {0}/[4] and remote chip ids {} (cluster.cpp:186)
-2026-02-09 11:51:04.960 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-02-09 11:51:04.960 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
-2026-02-09 11:51:04.962 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-02-09 11:51:04.963 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 11:51:05.059 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.WORKER
-2026-02-09 11:51:05.060 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-02-09 11:51:05.060 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:863)
-2026-02-09 11:51:05.060 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:840)
-2026-02-09 11:51:05.060 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
-2026-02-09 11:51:05.060 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
-2026-02-09 11:51:05.079 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 11:51:40.077 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/7944994127753528348/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:51:45.538 | warning  |    BuildKernels | Compute kernel 'tilize/17731151790256603023/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:51:50.687 | warning  |    BuildKernels | Compute kernel 'layernorm/4884704230036260402/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:51:55.795 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/12265219684519922531/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:52:01.396 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/10380771056115669711/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:52:01.554 | warning  |    BuildKernels | Compute kernel 'tilize/1982224783747614441/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:52:01.556 | warning  |    BuildKernels | Compute kernel 'tilize/11337404802072393109/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:52:07.077 | warning  |    BuildKernels | Compute kernel 'pack_untilize/1369520511343747262/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:52:07.077 | warning  |    BuildKernels | Compute kernel 'pack_untilize/15529522441930124248/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:52:17.275 | warning  |    BuildKernels | Compute kernel 'pack_untilize/5445543247183471221/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:52:17.275 | warning  |    BuildKernels | Compute kernel 'pack_untilize/808529285405081447/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:52:22.575 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/7317598834983320959/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:52:22.581 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/3500961269753639563/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:52:28.114 | warning  |    BuildKernels | Compute kernel 'tilize/5674158030118682369/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:52:28.114 | warning  |    BuildKernels | Compute kernel 'tilize/3616169035476323512/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:52:33.756 | warning  |    BuildKernels | Compute kernel 'sdpa/16476601990160721599/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:52:39.391 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4487912705438789235/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:52:45.085 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/343545304713059735/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:52:55.827 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/11708689732707033683/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:53:01.400 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/12915024539697323054/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:53:07.021 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/771060300310080457/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:53:12.715 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/18025573480810144695/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:53:18.281 | warning  |    BuildKernels | Compute kernel 'update_cache/1108314601679714129/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:53:23.856 | warning  |    BuildKernels | Compute kernel 'sdpa_flash_decode/7191414720724713666/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:53:29.088 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/9455956975227903173/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:53:34.636 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/17107799782473473287/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:53:40.291 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/9946959827408487608/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:53:40.467 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/10208751014080416571/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:01<00:01,  1.04s/it]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.34it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.27it/s]
+2026-02-09 12:48:10.135 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 12:48:10.136 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-09 12:48:10.141 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 12:48:10.161 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 12:48:10.162 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x80 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 12:48:10.257 | info     |             UMD | Opening local chip ids/PCIe ids: {0}/[4] and remote chip ids {} (cluster.cpp:186)
+2026-02-09 12:48:10.258 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-09 12:48:10.258 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-09 12:48:10.259 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-09 12:48:10.261 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 12:48:10.348 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.WORKER
+2026-02-09 12:48:10.349 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-09 12:48:10.349 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:863)
+2026-02-09 12:48:10.349 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:840)
+2026-02-09 12:48:10.349 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
+2026-02-09 12:48:10.349 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
+2026-02-09 12:48:10.365 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 12:48:46.374 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/7944994127753528348/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:48:51.850 | warning  |    BuildKernels | Compute kernel 'tilize/17731151790256603023/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:48:51.958 | warning  |    BuildKernels | Compute kernel 'layernorm/4884704230036260402/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:48:57.543 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/12265219684519922531/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:49:03.205 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/10380771056115669711/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:49:03.358 | warning  |    BuildKernels | Compute kernel 'tilize/1982224783747614441/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:49:03.358 | warning  |    BuildKernels | Compute kernel 'tilize/11337404802072393109/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:49:08.756 | warning  |    BuildKernels | Compute kernel 'pack_untilize/1369520511343747262/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:49:08.757 | warning  |    BuildKernels | Compute kernel 'pack_untilize/15529522441930124248/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:49:13.875 | warning  |    BuildKernels | Compute kernel 'pack_untilize/5445543247183471221/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:49:13.875 | warning  |    BuildKernels | Compute kernel 'pack_untilize/808529285405081447/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:49:19.163 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/3500961269753639563/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:49:19.164 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/7317598834983320959/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:49:34.806 | warning  |    BuildKernels | Compute kernel 'tilize/5674158030118682369/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:49:34.807 | warning  |    BuildKernels | Compute kernel 'tilize/3616169035476323512/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:49:40.003 | warning  |    BuildKernels | Compute kernel 'sdpa/16476601990160721599/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:49:45.174 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4487912705438789235/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:49:50.850 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/343545304713059735/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:49:51.230 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/11708689732707033683/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:49:56.469 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/12915024539697323054/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:49:56.657 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/771060300310080457/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:02.144 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/18025573480810144695/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:07.730 | warning  |    BuildKernels | Compute kernel 'update_cache/1108314601679714129/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:13.248 | warning  |    BuildKernels | Compute kernel 'sdpa_flash_decode/7191414720724713666/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:18.507 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/9455956975227903173/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:24.007 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/17107799782473473287/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:34.283 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/9946959827408487608/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:34.463 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/10208751014080416571/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
 Generating reference tokens...
 Opening device (1x1)...
 Loading ttnn model...
@@ -60,7 +59,7 @@ Loading ttnn model...
   Computing RoPE cache...
   Loading 32 layers...
 Running teacher-forcing eval (100 tokens)...
-Top-1 accuracy: 84.00% (0.8400)
-Top-5 accuracy: 98.00% (0.9800)
-2026-02-09 11:53:50.578 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-02-09 11:53:50.578 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
+Top-1 accuracy: 92.00% (0.9200)
+Top-5 accuracy: 99.00% (0.9900)
+2026-02-09 12:50:44.597 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-09 12:50:44.597 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/microsoft/Phi-3-mini-128k-instruct/n150/functional/model.py
+++ b/models/microsoft/Phi-3-mini-128k-instruct/n150/functional/model.py
@@ -98,7 +98,11 @@ def compute_attention_scaling(config: ModelConfig) -> float:
     return math.sqrt(1 + math.log(factor) / math.log(config.original_max_position_embeddings))
 
 
-def compute_rope_cache(config: ModelConfig, max_seq_len: int) -> tuple:
+def compute_rope_cache(
+    config: ModelConfig,
+    max_seq_len: int,
+    use_long: Optional[bool] = None,
+) -> tuple:
     """
     Precompute RoPE cos/sin cache in HuggingFace format.
     Returns cos, sin tensors of shape [1, 1, max_seq_len, head_dim].
@@ -117,10 +121,9 @@ def compute_rope_cache(config: ModelConfig, max_seq_len: int) -> tuple:
 
         long_factor = config.rope_scaling["long_factor"]
         short_factor = config.rope_scaling["short_factor"]
-        if max_seq_len > config.original_max_position_embeddings:
-            ext_factors = torch.tensor(long_factor, dtype=torch.float32)
-        else:
-            ext_factors = torch.tensor(short_factor, dtype=torch.float32)
+        if use_long is None:
+            use_long = max_seq_len > config.original_max_position_embeddings
+        ext_factors = torch.tensor(long_factor if use_long else short_factor, dtype=torch.float32)
 
         inv_freq = 1.0 / (
             ext_factors * (config.rope_theta ** (torch.arange(0, head_dim, 2).float() / head_dim))
@@ -193,8 +196,10 @@ class Attention:
         config: ModelConfig,
         layer_idx: int,
         state_dict: dict,
-        cos_cache: ttnn.Tensor,
-        sin_cache: ttnn.Tensor,
+        cos_cache_short: ttnn.Tensor,
+        sin_cache_short: ttnn.Tensor,
+        cos_cache_long: ttnn.Tensor,
+        sin_cache_long: ttnn.Tensor,
         tt_device,
         paged_attention_config: PagedAttentionConfig,
         page_table: ttnn.Tensor,
@@ -202,6 +207,7 @@ class Attention:
         self.tt_device = tt_device
         self.n_heads = config.num_attention_heads
         self.n_kv_heads = config.num_key_value_heads
+        self.original_max_position_embeddings = config.original_max_position_embeddings
         self.head_dim = config.head_dim
         self.head_dim_padded = pad_head_dim(self.head_dim)
         self.head_dim_half = self.head_dim // 2
@@ -210,8 +216,10 @@ class Attention:
         self.paged_attention_config = paged_attention_config
         self.page_table = page_table
 
-        self.cos_cache = cos_cache
-        self.sin_cache = sin_cache
+        self.cos_cache_short = cos_cache_short
+        self.sin_cache_short = sin_cache_short
+        self.cos_cache_long = cos_cache_long
+        self.sin_cache_long = sin_cache_long
 
         p = f"model.layers.{layer_idx}.self_attn."
         self.qkv_proj = self._load_weight(state_dict[f"{p}qkv_proj.weight"])
@@ -312,6 +320,13 @@ class Attention:
     ) -> ttnn.Tensor:
         is_prefill = seq_len > 1
         padded_seq = pad_to_tile(seq_len)
+        use_long = (
+            seq_len > self.original_max_position_embeddings
+            if is_prefill
+            else start_pos >= self.original_max_position_embeddings
+        )
+        cos_cache = self.cos_cache_long if use_long else self.cos_cache_short
+        sin_cache = self.sin_cache_long if use_long else self.sin_cache_short
 
         qkv = ttnn.linear(x, self.qkv_proj)
 
@@ -330,8 +345,8 @@ class Attention:
             q = ttnn.to_memory_config(q, ttnn.DRAM_MEMORY_CONFIG)
             k = ttnn.to_memory_config(k, ttnn.DRAM_MEMORY_CONFIG)
 
-            cos = self.cos_cache[:, :, :padded_seq, :]
-            sin = self.sin_cache[:, :, :padded_seq, :]
+            cos = cos_cache[:, :, :padded_seq, :]
+            sin = sin_cache[:, :, :padded_seq, :]
             q = self._slice_head_dim(ttnn.experimental.rotary_embedding(self._pad_head_dim(q), cos, sin))
             k = self._slice_head_dim(ttnn.experimental.rotary_embedding(self._pad_head_dim(k), cos, sin))
 
@@ -366,7 +381,7 @@ class Attention:
             q = ttnn.to_memory_config(q, ttnn.DRAM_MEMORY_CONFIG)
             q = self._slice_head_dim(
                 ttnn.experimental.rotary_embedding(
-                    self._pad_head_dim(q), self.cos_cache, self.sin_cache, start_pos
+                    self._pad_head_dim(q), cos_cache, sin_cache, start_pos
                 )
             )
             q = ttnn.reshape(q, (1, q.shape[2] // self.n_heads, self.n_heads, self.head_dim))
@@ -375,7 +390,7 @@ class Attention:
             k = ttnn.to_memory_config(k, ttnn.DRAM_MEMORY_CONFIG)
             k = self._slice_head_dim(
                 ttnn.experimental.rotary_embedding(
-                    self._pad_head_dim(k), self.cos_cache, self.sin_cache, start_pos
+                    self._pad_head_dim(k), cos_cache, sin_cache, start_pos
                 )
             )
             k = ttnn.reshape(k, (1, k.shape[2] // self.n_kv_heads, self.n_kv_heads, self.head_dim))
@@ -460,8 +475,10 @@ class DecoderLayer:
         config: ModelConfig,
         layer_idx: int,
         state_dict: dict,
-        cos_cache: ttnn.Tensor,
-        sin_cache: ttnn.Tensor,
+        cos_cache_short: ttnn.Tensor,
+        sin_cache_short: ttnn.Tensor,
+        cos_cache_long: ttnn.Tensor,
+        sin_cache_long: ttnn.Tensor,
         tt_device,
         paged_attention_config: PagedAttentionConfig,
         page_table: ttnn.Tensor,
@@ -473,8 +490,10 @@ class DecoderLayer:
             config,
             layer_idx,
             state_dict,
-            cos_cache,
-            sin_cache,
+            cos_cache_short,
+            sin_cache_short,
+            cos_cache_long,
+            sin_cache_long,
             tt_device,
             paged_attention_config,
             page_table,
@@ -535,16 +554,31 @@ class TtnnPhi3ForCausalLM(torch.nn.Module, GenerationMixin):
         )
 
         print("  Computing RoPE cache...")
-        cos, sin = compute_rope_cache(self.tt_config, self.max_seq_len)
-        self.cos_cache = ttnn.as_tensor(
-            cos,
+        cos_short, sin_short = compute_rope_cache(self.tt_config, self.max_seq_len, use_long=False)
+        cos_long, sin_long = compute_rope_cache(self.tt_config, self.max_seq_len, use_long=True)
+        self.cos_cache_short = ttnn.as_tensor(
+            cos_short,
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
             device=tt_device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
-        self.sin_cache = ttnn.as_tensor(
-            sin,
+        self.sin_cache_short = ttnn.as_tensor(
+            sin_short,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        self.cos_cache_long = ttnn.as_tensor(
+            cos_long,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        self.sin_cache_long = ttnn.as_tensor(
+            sin_long,
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
             device=tt_device,
@@ -567,8 +601,10 @@ class TtnnPhi3ForCausalLM(torch.nn.Module, GenerationMixin):
                 self.tt_config,
                 i,
                 state_dict,
-                self.cos_cache,
-                self.sin_cache,
+                self.cos_cache_short,
+                self.sin_cache_short,
+                self.cos_cache_long,
+                self.sin_cache_long,
                 tt_device,
                 self.paged_attention_config,
                 self.page_table,


### PR DESCRIPTION
Phi-3 mini n150: fix RoPE cache selection for long context.

- Long eval now passes (Top-1 92%, Top-5 99%).
- Updates model.py, MODELS.md, and demo/eval logs.

Fixes #86
