### PR TITLE
Arcee-Spark n300: refresh demo/eval metrics

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -9,7 +9,7 @@ Note: Keep the table columns padded with spaces and right-justify numeric cells 
 | Model                               | Hardware |  Variant   | Top-1 | Top-5 |   TTFT | t/s/u | Seq len |
 | ----------------------------------- | :------: | :--------: | ----: | ----: | -----: | ----: | ------: |
 | arcee-ai/Arcee-Spark                |   n150   | functional |   86% |  100% |   94ms |  12.3 |   29952 |
-| arcee-ai/Arcee-Spark                |   n300   | functional |   88% |  100% |  328ms |   5.0 |   32768 |
+| arcee-ai/Arcee-Spark                |   n300   | functional |   88% |  100% |  329ms |   4.9 |   32768 |
 | arcee-ai/Arcee-Spark                |  t3000   | functional |   90% |  100% |  343ms |   4.9 |   32768 |
 | arcee-ai/AFM-4.5B                   |  t3000   | functional |   98% |  100% |  181ms |   7.1 |   65536 |
 | arcee-ai/AFM-4.5B                   |   n150   | functional |   98% |  100% |   72ms |  17.2 |   65536 |

--- a/models/arcee-ai/Arcee-Spark/n300/functional/demo.log
+++ b/models/arcee-ai/Arcee-Spark/n300/functional/demo.log
@@ -1,62 +1,62 @@
 python demo.py models/arcee-ai/Arcee-Spark/n300/functional/model.py
 /proj_sw/user_dev/moconnor/tt-metal/python_env/lib/python3.10/site-packages/transformers/utils/hub.py:111: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
   warnings.warn(
-2026-02-09 03:51:04.906 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+2026-02-09 12:44:17.083 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
-2026-02-09 03:51:05.611 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 03:51:05.619 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-02-09 03:51:05.622 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 03:51:05.650 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 03:51:05.671 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 03:51:05.767 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 03:51:05.786 | info     |             UMD | Opening local chip ids/PCIe ids: {0}/[0] and remote chip ids {1} (cluster.cpp:186)
-2026-02-09 03:51:05.786 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-02-09 03:51:05.786 | info     |             UMD | KMD version: 2.4.0 (cluster.cpp:164)
-2026-02-09 03:51:05.790 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-02-09 03:51:05.793 | info     |             UMD | Mapped hugepage 0x340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 03:51:05.797 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 03:51:05.854 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:863)
-2026-02-09 03:51:05.855 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:840)
-2026-02-09 03:51:05.855 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=2, n_phys=2, log_deg_hist={1:2}, phys_deg_hist={1:2} (topology_mapper_utils.cpp:171)
-2026-02-09 03:51:05.855 | info     |          Fabric | Fast-path path-graph mapping succeeded for mesh 0 (topology_mapper_utils.cpp:401)
-2026-02-09 03:51:05.855 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=2, n_phys=2, log_deg_hist={1:2}, phys_deg_hist={1:2} (topology_mapper_utils.cpp:171)
-2026-02-09 03:51:05.855 | info     |          Fabric | Fast-path path-graph mapping succeeded for mesh 0 (topology_mapper_utils.cpp:401)
-2026-02-09 03:51:05.860 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
-2026-02-09 03:51:05.861 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-02-09 03:51:05.867 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 03:51:05.870 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 03:51:06.023 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:748)
-2026-02-09 03:51:06.023 | info     |           Metal | Dispatch on FabricConfig::FABRIC_1D with 1 Command Queues
+2026-02-09 12:44:18.087 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 12:44:18.096 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-09 12:44:18.099 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 12:44:18.127 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 12:44:18.149 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 12:44:18.244 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 12:44:18.263 | info     |             UMD | Opening local chip ids/PCIe ids: {0}/[0] and remote chip ids {1} (cluster.cpp:186)
+2026-02-09 12:44:18.263 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-09 12:44:18.263 | info     |             UMD | KMD version: 2.4.0 (cluster.cpp:164)
+2026-02-09 12:44:18.266 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-09 12:44:18.270 | info     |             UMD | Mapped hugepage 0x340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 12:44:18.274 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 12:44:18.331 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:863)
+2026-02-09 12:44:18.331 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:840)
+2026-02-09 12:44:18.331 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=2, n_phys=2, log_deg_hist={1:2}, phys_deg_hist={1:2} (topology_mapper_utils.cpp:171)
+2026-02-09 12:44:18.331 | info     |          Fabric | Fast-path path-graph mapping succeeded for mesh 0 (topology_mapper_utils.cpp:401)
+2026-02-09 12:44:18.331 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=2, n_phys=2, log_deg_hist={1:2}, phys_deg_hist={1:2} (topology_mapper_utils.cpp:171)
+2026-02-09 12:44:18.331 | info     |          Fabric | Fast-path path-graph mapping succeeded for mesh 0 (topology_mapper_utils.cpp:401)
+2026-02-09 12:44:18.377 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-09 12:44:18.378 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-09 12:44:18.402 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 12:44:18.427 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 12:44:18.591 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:748)
+2026-02-09 12:44:18.591 | info     |           Metal | Dispatch on FabricConfig::FABRIC_1D with 1 Command Queues
  (device_manager.cpp:331)
-2026-02-09 03:51:06.028 | info     |           Metal | Initializing Fabric (device_manager.cpp:409)
-2026-02-09 03:51:06.170 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:392)
-2026-02-09 03:51:06.175 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:392)
-2026-02-09 03:51:06.175 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_1D (device_manager.cpp:414)
-2026-02-09 03:51:06.449 | info     |           Metal | Command Queue initialized on Device 1 (device_manager.cpp:510)
+2026-02-09 12:44:18.594 | info     |           Metal | Initializing Fabric (device_manager.cpp:409)
+2026-02-09 12:44:18.781 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:392)
+2026-02-09 12:44:18.785 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:392)
+2026-02-09 12:44:18.785 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_1D (device_manager.cpp:414)
+2026-02-09 12:44:19.077 | info     |           Metal | Command Queue initialized on Device 1 (device_manager.cpp:510)
 Loading tokenizer: arcee-ai/Arcee-Spark
 Opening TT device...
 Loading HuggingFace reference model on CPU: arcee-ai/Arcee-Spark
-Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]Loading checkpoint shards:  25%|██▌       | 1/4 [00:41<02:04, 41.40s/it]Loading checkpoint shards:  50%|█████     | 2/4 [01:23<01:23, 41.77s/it]Loading checkpoint shards:  75%|███████▌  | 3/4 [01:44<00:32, 32.40s/it]Loading checkpoint shards: 100%|██████████| 4/4 [01:51<00:00, 22.41s/it]Loading checkpoint shards: 100%|██████████| 4/4 [01:51<00:00, 27.95s/it]
-2026-02-09 03:55:51.531 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/1946668303481953098/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 03:55:51.704 | warning  |    BuildKernels | Compute kernel 'tilize/16710459033883627519/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 03:55:51.834 | warning  |    BuildKernels | Compute kernel 'layernorm/10542101839200362021/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 03:55:52.022 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/16965186647696393185/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 03:55:52.173 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4253338908046788346/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 03:55:52.520 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/9827946993736593312/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 03:55:58.057 | warning  |    BuildKernels | Compute kernel 'sdpa/1735706825316263621/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 03:56:06.949 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/8472509241545217589/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 03:56:11.530 | warning  |    BuildKernels | Compute kernel 'line_reduction/17263434165235172306/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 03:56:23.649 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/13473633558675166352/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 03:56:32.546 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/7219748586200322087/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 03:56:37.162 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/3013695628060452422/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 03:56:45.934 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/15786952279964970039/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 03:57:10.637 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/3491980988751689818/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 03:57:30.456 | warning  |    BuildKernels | Compute kernel 'update_cache/2003637544384205828/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 03:57:34.756 | warning  |    BuildKernels | Compute kernel 'sdpa_flash_decode/12012443040452206598/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 03:57:47.732 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/9837562700720210015/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 03:58:04.054 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/11667390843077337182/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 03:58:12.843 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/3711497408002898896/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 03:58:17.475 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/12852667090996147398/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]Loading checkpoint shards:  25%|██▌       | 1/4 [00:42<02:08, 42.77s/it]Loading checkpoint shards:  50%|█████     | 2/4 [01:25<01:25, 42.82s/it]Loading checkpoint shards:  75%|███████▌  | 3/4 [02:03<00:40, 40.43s/it]Loading checkpoint shards: 100%|██████████| 4/4 [02:12<00:00, 28.23s/it]Loading checkpoint shards: 100%|██████████| 4/4 [02:12<00:00, 33.19s/it]
+2026-02-09 12:50:18.157 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/1946668303481953098/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:18.307 | warning  |    BuildKernels | Compute kernel 'tilize/16710459033883627519/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:18.422 | warning  |    BuildKernels | Compute kernel 'layernorm/10542101839200362021/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:18.589 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/16965186647696393185/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:18.741 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4253338908046788346/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:19.042 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/9827946993736593312/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:19.271 | warning  |    BuildKernels | Compute kernel 'sdpa/1735706825316263621/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:19.540 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/8472509241545217589/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:19.689 | warning  |    BuildKernels | Compute kernel 'line_reduction/17263434165235172306/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:20.088 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/13473633558675166352/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:20.579 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/7219748586200322087/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:20.781 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/3013695628060452422/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:21.265 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/15786952279964970039/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:21.687 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/3491980988751689818/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:22.045 | warning  |    BuildKernels | Compute kernel 'update_cache/2003637544384205828/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:22.168 | warning  |    BuildKernels | Compute kernel 'sdpa_flash_decode/12012443040452206598/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:22.548 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/9837562700720210015/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:22.866 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/11667390843077337182/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:23.163 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/3711497408002898896/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:50:23.336 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/12852667090996147398/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
 Building TT model...
   Loading embeddings...
   Computing RoPE cache...
@@ -65,7 +65,7 @@ TT demo (n300)
 Model: arcee-ai/Arcee-Spark
 Mesh shape: 2x1
 Prompt tokens: 56 | Generated tokens: 128
-TTFT: 328 ms | Decode: 5.0 t/s/u (127 tokens)
+TTFT: 329 ms | Decode: 4.9 t/s/u (127 tokens)
 
 Prompt:
 Journal entry, 1957: Tonight a tiny sphere called Sputnik 1 crossed the sky, beeping like a metronome for a new era. The neighbors gathered on the roof, listening and arguing about what comes next. I wrote in my notebook that
@@ -73,5 +73,5 @@ Journal entry, 1957: Tonight a tiny sphere called Sputnik 1 crossed the sky, bee
 Output:
  this might be the first time that a machine and man were in orbit together. (This might be a lie, as we’re mostly just in orbit around it.) I didn’t know this then, of course.
 Now, I can watch Earth and stars with the push of a button and know, if I want, that I’m just one person orbiting the sun in a spaceship that was once a toy. My phone sits on my desk and watches me all day. It keeps time and tells me what I should be doing, and it knows exactly how many pixels it will have to show me at the end of the year. It
-2026-02-09 03:58:51.519 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-02-09 03:58:51.519 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
+2026-02-09 12:50:52.578 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-09 12:50:52.578 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/arcee-ai/Arcee-Spark/n300/functional/eval.log
+++ b/models/arcee-ai/Arcee-Spark/n300/functional/eval.log
@@ -1,72 +1,72 @@
 python eval.py models/arcee-ai/Arcee-Spark/n300/functional/model.py --model arcee-ai/Arcee-Spark --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 32768
-2026-02-09 03:59:42.008 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+2026-02-09 12:51:46.577 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
 /proj_sw/user_dev/moconnor/tt-metal/python_env/lib/python3.10/site-packages/transformers/utils/hub.py:111: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
   warnings.warn(
 Loading model module: /localdev/moconnor/ttnn_models/models/arcee-ai/Arcee-Spark/n300/functional/model.py
 Loading HuggingFace tokenizer...
 Loading HuggingFace reference model on CPU...
-Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]Loading checkpoint shards:  25%|██▌       | 1/4 [00:28<01:25, 28.43s/it]Loading checkpoint shards:  50%|█████     | 2/4 [00:32<00:27, 13.91s/it]Loading checkpoint shards:  75%|███████▌  | 3/4 [00:39<00:10, 10.88s/it]Loading checkpoint shards: 100%|██████████| 4/4 [00:40<00:00,  6.91s/it]Loading checkpoint shards: 100%|██████████| 4/4 [00:40<00:00, 10.07s/it]
-Generating reference tokens...
+Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]Loading checkpoint shards:  25%|██▌       | 1/4 [00:00<00:02,  1.06it/s]Loading checkpoint shards:  50%|█████     | 2/4 [00:01<00:01,  1.08it/s]Loading checkpoint shards:  75%|███████▌  | 3/4 [00:02<00:00,  1.16it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:02<00:00,  1.66it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:02<00:00,  1.41it/s]
 The following generation flags are not valid and may be ignored: ['temperature', 'top_p', 'top_k']. Set `TRANSFORMERS_VERBOSITY=info` for more details.
-Opening device (2x1)...
-2026-02-09 04:03:58.434 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 04:03:58.443 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-02-09 04:03:58.446 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 04:03:58.476 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 04:03:58.499 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 04:03:58.596 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 04:03:58.615 | info     |             UMD | Opening local chip ids/PCIe ids: {0}/[0] and remote chip ids {1} (cluster.cpp:186)
-2026-02-09 04:03:58.615 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-02-09 04:03:58.615 | info     |             UMD | KMD version: 2.4.0 (cluster.cpp:164)
-2026-02-09 04:03:58.618 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-02-09 04:03:58.622 | info     |             UMD | Mapped hugepage 0x340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 04:03:58.626 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 04:03:58.685 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:863)
-2026-02-09 04:03:58.685 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:840)
-2026-02-09 04:03:58.685 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=2, n_phys=2, log_deg_hist={1:2}, phys_deg_hist={1:2} (topology_mapper_utils.cpp:171)
-2026-02-09 04:03:58.685 | info     |          Fabric | Fast-path path-graph mapping succeeded for mesh 0 (topology_mapper_utils.cpp:401)
-2026-02-09 04:03:58.685 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=2, n_phys=2, log_deg_hist={1:2}, phys_deg_hist={1:2} (topology_mapper_utils.cpp:171)
-2026-02-09 04:03:58.685 | info     |          Fabric | Fast-path path-graph mapping succeeded for mesh 0 (topology_mapper_utils.cpp:401)
-2026-02-09 04:03:58.691 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
-2026-02-09 04:03:58.691 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-02-09 04:03:58.701 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 04:03:58.704 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 04:03:58.865 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:748)
-2026-02-09 04:03:58.865 | info     |           Metal | Dispatch on FabricConfig::FABRIC_1D with 1 Command Queues
+2026-02-09 12:55:23.720 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 12:55:23.730 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-09 12:55:23.735 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 12:55:23.775 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 12:55:23.804 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 12:55:23.933 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 12:55:23.958 | info     |             UMD | Opening local chip ids/PCIe ids: {0}/[0] and remote chip ids {1} (cluster.cpp:186)
+2026-02-09 12:55:23.958 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-09 12:55:23.958 | info     |             UMD | KMD version: 2.4.0 (cluster.cpp:164)
+2026-02-09 12:55:23.964 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-09 12:55:23.969 | info     |             UMD | Mapped hugepage 0x340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 12:55:23.974 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 12:55:24.252 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:863)
+2026-02-09 12:55:24.252 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:840)
+2026-02-09 12:55:24.252 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=2, n_phys=2, log_deg_hist={1:2}, phys_deg_hist={1:2} (topology_mapper_utils.cpp:171)
+2026-02-09 12:55:24.252 | info     |          Fabric | Fast-path path-graph mapping succeeded for mesh 0 (topology_mapper_utils.cpp:401)
+2026-02-09 12:55:24.252 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=2, n_phys=2, log_deg_hist={1:2}, phys_deg_hist={1:2} (topology_mapper_utils.cpp:171)
+2026-02-09 12:55:24.252 | info     |          Fabric | Fast-path path-graph mapping succeeded for mesh 0 (topology_mapper_utils.cpp:401)
+2026-02-09 12:55:24.263 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-09 12:55:24.263 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-09 12:55:24.278 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 12:55:24.285 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 12:55:24.533 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:748)
+2026-02-09 12:55:24.533 | info     |           Metal | Dispatch on FabricConfig::FABRIC_1D with 1 Command Queues
  (device_manager.cpp:331)
-2026-02-09 04:03:58.871 | info     |           Metal | Initializing Fabric (device_manager.cpp:409)
-2026-02-09 04:03:59.028 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:392)
-2026-02-09 04:03:59.032 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:392)
-2026-02-09 04:03:59.032 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_1D (device_manager.cpp:414)
-2026-02-09 04:03:59.315 | info     |           Metal | Command Queue initialized on Device 1 (device_manager.cpp:510)
+2026-02-09 12:55:24.547 | info     |           Metal | Initializing Fabric (device_manager.cpp:409)
+2026-02-09 12:55:24.779 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:392)
+2026-02-09 12:55:24.806 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:392)
+2026-02-09 12:55:24.806 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_1D (device_manager.cpp:414)
+2026-02-09 12:55:25.328 | info     |           Metal | Command Queue initialized on Device 1 (device_manager.cpp:510)
+2026-02-09 12:58:26.087 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/1946668303481953098/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:58:26.237 | warning  |    BuildKernels | Compute kernel 'tilize/16710459033883627519/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:58:26.349 | warning  |    BuildKernels | Compute kernel 'layernorm/10542101839200362021/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:58:26.516 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/14216073807973207408/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:58:26.642 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4253338908046788346/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:58:26.932 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/4953326823212577371/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:58:26.932 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/9827946993736593312/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:58:27.139 | warning  |    BuildKernels | Compute kernel 'sdpa/8694780724438041477/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:58:27.379 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/12598109284296644813/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:58:27.505 | warning  |    BuildKernels | Compute kernel 'line_reduction/17263434165235172306/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:58:27.850 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/15409489668736129835/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:58:28.305 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/16719760577929023786/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:58:28.473 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/5892571261870727225/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:58:29.388 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/15786952279964970039/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:58:29.823 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/3491980988751689818/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:58:30.162 | warning  |    BuildKernels | Compute kernel 'update_cache/2003637544384205828/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:58:30.282 | warning  |    BuildKernels | Compute kernel 'sdpa_flash_decode/3542743382050355035/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:58:30.599 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/9837562700720210015/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:58:30.944 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/11667390843077337182/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:58:31.225 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/3711497408002898896/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 12:58:31.397 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/12852667090996147398/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+Generating reference tokens...
+Opening device (2x1)...
 Loading ttnn model...
   Loading embeddings...
   Computing RoPE cache...
   Loading 28 layers...
 Running teacher-forcing eval (100 tokens)...
-2026-02-09 04:06:46.888 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/1946668303481953098/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 04:06:47.064 | warning  |    BuildKernels | Compute kernel 'tilize/16710459033883627519/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 04:06:52.512 | warning  |    BuildKernels | Compute kernel 'layernorm/10542101839200362021/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 04:06:52.755 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/14216073807973207408/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 04:06:57.760 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4253338908046788346/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 04:07:07.347 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/4953326823212577371/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 04:07:07.347 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/9827946993736593312/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 04:07:12.008 | warning  |    BuildKernels | Compute kernel 'sdpa/8694780724438041477/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 04:07:21.175 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/12598109284296644813/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 04:07:26.105 | warning  |    BuildKernels | Compute kernel 'line_reduction/17263434165235172306/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 04:07:38.925 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/15409489668736129835/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 04:07:48.637 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/16719760577929023786/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 04:07:53.541 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/5892571261870727225/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 04:07:59.333 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/15786952279964970039/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 04:07:59.857 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/3491980988751689818/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 04:08:00.285 | warning  |    BuildKernels | Compute kernel 'update_cache/2003637544384205828/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 04:08:04.736 | warning  |    BuildKernels | Compute kernel 'sdpa_flash_decode/3542743382050355035/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 04:08:10.305 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/9837562700720210015/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 04:08:10.747 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/11667390843077337182/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 04:08:11.117 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/3711497408002898896/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 04:08:11.334 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/12852667090996147398/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
 Top-1 accuracy: 88.00% (0.8800)
 Top-5 accuracy: 100.00% (1.0000)
-2026-02-09 04:08:34.368 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-02-09 04:08:34.368 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
+2026-02-09 12:58:54.232 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-09 12:58:54.232 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)


### PR DESCRIPTION
Update Arcee-Spark n300 demo/eval artifacts and MODELS metrics from the latest run.

Fixes #72
