### PR TITLE
tasks: add increase_seq_len n300/t3000

### DIFF
--- a/tasks/increase_seq_len_n300.yaml
+++ b/tasks/increase_seq_len_n300.yaml
@@ -1,0 +1,52 @@
+prompt: |
+  Welcome to the ttnn_models project! Take your time to read the source code and understand it. This is based on tt-metal and ttnn. You can find the tt-metal source in /proj_sw/user_dev/moconnor/tt-metal/ if you need to look something up.
+
+  Our task today is to increase the max sequence length for an n300 model implementation while preserving correctness and paged attention + paged KV cache.
+
+  The issue title should point at a directory like: models/<org>/<MODEL>/n300/functional
+  The issue details are {{item}}.
+
+  Requirements:
+  - Keep paged attention + paged KV cache if the model already uses it; do not regress to a non-paged cache.
+  - If the model uses a fixed small KV cache cap (e.g. MAX_CACHE_SEQ_LEN), raise it and/or migrate to paged cache so we can run at higher max_seq_len.
+  - Choose a target max_seq_len:
+    - Prefer the HF config max position embeddings, OR match the n150 row's Seq len in MODELS.md.
+    - If that OOMs, reduce max_seq_len only as much as needed to make demo/eval succeed, and document the reason.
+  - Final validation must run with the chosen max_seq_len:
+    python eval.py <model.py> --model <hf-id> --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len <max_seq_len>
+  - Also run the demo and sanity-check the output is not clearly garbage/corrupted.
+  - Always produce demo.log and eval.log, even if the command fails (capture stdout/stderr, then continue).
+  - Update MODELS.md for this model/hardware/variant row with Top-1/Top-5/TTFT/t/s/u/Seq len.
+
+  Notes:
+  - If mesh device init fails, set `TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto`.
+  - If `TT_VISIBLE_DEVICES` is unset and you suspect the wrong chips are being used, run `tt-smi -ls` and set `TT_VISIBLE_DEVICES` to the two PCI indices that form the n300.
+  - If you see `cannot map elf file into memory: No space left on device`, rerun with `TT_METAL_CACHE=/tmp/tt-metal-cache` and `TT_METAL_RUNTIME_ROOT=/proj_sw/user_dev/moconnor/tt-runtime-root`.
+
+  Deliverables:
+  - Updated <dir>/model.py (+ any helper files you touched).
+  - Updated MODELS.md.
+  - <dir>/demo.log and <dir>/eval.log (command line + output).
+  - Updated/created <dir>/MODEL_BRINGUP.md describing the chosen max_seq_len and any memory/caching changes.
+
+set_up: |
+  Make sure you are in /localdev/moconnor/ttnn_models
+  If there are any unsaved changes, stash them and be sure to mention it in your output.
+  Create and switch to a new branch named seq_<sanitized_title>, where <sanitized_title> is the issue title with the leading 'models/' stripped and slashes replaced by dashes: {{item}}
+  Run 'tt-smi -r' to reset the device.
+  Run 'tt-smi -ls' and set TT_VISIBLE_DEVICES based on the PCI Dev IDs shown before running demo/eval:
+  - If the host exposes 2 single-chip boards for n300, use both IDs (example: export TT_VISIBLE_DEVICES=4,5).
+  - If the host exposes a single 2-chip n300 board, use that one ID (example: export TT_VISIBLE_DEVICES=0).
+
+on_success: |
+  Add, commit and push MODELS.md, MODEL_BRINGUP.md, model.py and the demo/eval log files, remove anything in generated/.
+  If a PR already exists for this branch, update it (push new commits). Otherwise open a PR and link it back to the issue {{item}}.
+  Include `Fixes #<issue-number>` on its own line in the PR body, and use `gh pr create --body-file ...` (not `--body` with `\n` escapes) so GitHub recognizes the closing keyword.
+
+on_failure: |
+  Add, commit and push MODELS.md, MODEL_BRINGUP.md, model.py and the demo/eval log files, remove anything in generated/.
+  If you made meaningful progress, open a PR for review, but do NOT include a closing keyword (use `Refs #<issue-number>` instead).
+
+tear_down: |
+  Switch back to the main branch and leave the repo is in a clean state, e.g. no temporary files etc.
+

--- a/tasks/increase_seq_len_t3000.yaml
+++ b/tasks/increase_seq_len_t3000.yaml
@@ -1,0 +1,53 @@
+prompt: |
+  Welcome to the ttnn_models project! Take your time to read the source code and understand it. This is based on tt-metal and ttnn. You can find the tt-metal source in /proj_sw/user_dev/moconnor/tt-metal/ if you need to look something up.
+
+  Our task today is to increase the max sequence length for a t3000 model implementation while preserving correctness and paged attention + paged KV cache.
+
+  The issue title should point at a directory like: models/<org>/<MODEL>/t3000/functional
+  The issue details are {{item}}.
+
+  Requirements:
+  - Keep paged attention + paged KV cache if the model already uses it; do not regress to a non-paged cache.
+  - If the model uses a fixed small KV cache cap (e.g. MAX_CACHE_SEQ_LEN), raise it and/or migrate to paged cache so we can run at higher max_seq_len.
+  - Choose a target max_seq_len:
+    - Prefer the HF config max position embeddings, OR match the n150 row's Seq len in MODELS.md.
+    - If that OOMs, reduce max_seq_len only as much as needed to make demo/eval succeed, and document the reason.
+  - Final validation must run with the chosen max_seq_len:
+    python eval.py <model.py> --model <hf-id> --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len <max_seq_len>
+  - Also run the demo and sanity-check the output is not clearly garbage/corrupted.
+  - Always produce demo.log and eval.log, even if the command fails (capture stdout/stderr, then continue).
+  - Update MODELS.md for this model/hardware/variant row with Top-1/Top-5/TTFT/t/s/u/Seq len.
+
+  Notes:
+  - If mesh device init fails, set `TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto`.
+  - If `TT_VISIBLE_DEVICES` is unset, set it from `tt-smi -ls`. On Loudbox t3k hosts this is often the 4 PCI Dev IDs for the n300 boards (example: `0,1,2,3`); do not assume `0-7`.
+  - If you see `cannot map elf file into memory: No space left on device`, rerun with `TT_METAL_CACHE=/tmp/tt-metal-cache` and `TT_METAL_RUNTIME_ROOT=/proj_sw/user_dev/moconnor/tt-runtime-root`.
+  - If you see TT JIT compile errors in `llk_*` headers (e.g. `_llk_unpack_untilize_init_` arg mismatch), run:
+    `cd /proj_sw/user_dev/moconnor/tt-metal && git submodule update --init --recursive`
+    and then rerun demo/eval.
+
+  Deliverables:
+  - Updated <dir>/model.py (+ any helper files you touched).
+  - Updated MODELS.md.
+  - <dir>/demo.log and <dir>/eval.log (command line + output).
+  - Updated/created <dir>/MODEL_BRINGUP.md describing the chosen max_seq_len and any memory/caching changes.
+
+set_up: |
+  Make sure you are in /localdev/moconnor/ttnn_models
+  If there are any unsaved changes, stash them and be sure to mention it in your output.
+  Create and switch to a new branch named seq_<sanitized_title>, where <sanitized_title> is the issue title with the leading 'models/' stripped and slashes replaced by dashes: {{item}}
+  Run 'tt-smi -r' to reset the device.
+  Run 'tt-smi -ls' and set TT_VISIBLE_DEVICES to the PCI Dev IDs listed before running demo/eval (example: export TT_VISIBLE_DEVICES=0,1,2,3).
+
+on_success: |
+  Add, commit and push MODELS.md, MODEL_BRINGUP.md, model.py and the demo/eval log files, remove anything in generated/.
+  If a PR already exists for this branch, update it (push new commits). Otherwise open a PR and link it back to the issue {{item}}.
+  Include `Fixes #<issue-number>` on its own line in the PR body, and use `gh pr create --body-file ...` (not `--body` with `\n` escapes) so GitHub recognizes the closing keyword.
+
+on_failure: |
+  Add, commit and push MODELS.md, MODEL_BRINGUP.md, model.py and the demo/eval log files, remove anything in generated/.
+  If you made meaningful progress, open a PR for review, but do NOT include a closing keyword (use `Refs #<issue-number>` instead).
+
+tear_down: |
+  Switch back to the main branch and leave the repo is in a clean state, e.g. no temporary files etc.
+


### PR DESCRIPTION
Add task templates for increasing max_seq_len (paged KV cache capacity) on n300 and t3000.
