### PR TITLE
models/google/gemma-3-4b-it/t3000/functional

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -29,7 +29,7 @@ Note: Keep the table columns padded with spaces and right-justify numeric cells 
 | Qwen/Qwen3-0.6B                     |  t3000   | functional |   98% |  100% |  229ms |   6.2 |   40960 |
 | google/gemma-3-4b-it                |   n150   | functional |   92% |  100% |   98ms |  13.9 |   40960 |
 | google/gemma-3-4b-it                |   n300   | functional |   94% |  100% |  523ms |   3.3 |     256 |
-| google/gemma-3-4b-it                |  t3000   | functional |   92% |  100% |  322ms |   4.8 |     256 |
+| google/gemma-3-4b-it                |  t3000   | functional |   92% |  100% |  330ms |   4.7 |   40960 |
 | microsoft/Phi-3-mini-128k-instruct  |   n150   | functional |   92% |   99% |   80ms |  13.7 |   12288 |
 | microsoft/Phi-3-mini-128k-instruct  |   n300   | functional |   90% |  100% |  168ms |   7.6 |     256 |
 | microsoft/Phi-3-mini-128k-instruct  |  t3000   | functional |   90% |  100% |  145ms |   7.3 |     256 |

--- a/models/google/gemma-3-4b-it/t3000/functional/MODEL_BRINGUP.md
+++ b/models/google/gemma-3-4b-it/t3000/functional/MODEL_BRINGUP.md
@@ -34,8 +34,9 @@ It is designed to be easy to read and to serve as a template for future bringups
 - `ttnn.rms_norm` for RMSNorm and Q/K head norm
 - `ttnn.experimental.rotary_embedding` for HuggingFace-format RoPE
 - `ttnn.experimental.nlp_create_qkv_heads[_decode]` and `ttnn.experimental.nlp_concat_heads`
-- `ttnn.transformer.scaled_dot_product_attention[_decode]`
-- `ttnn.fill_cache` (prefill) and `ttnn.experimental.paged_update_cache` (decode)
+- `ttnn.transformer.scaled_dot_product_attention` (prefill) and
+  `ttnn.transformer.paged_scaled_dot_product_attention_decode` (decode)
+- `ttnn.experimental.paged_fill_cache` (prefill) and `ttnn.experimental.paged_update_cache` (decode)
 
 ## Gemma3 specifics
 - Q/K RMSNorm uses `(1 + weight)` (Gemma3RMSNorm).
@@ -53,8 +54,9 @@ Decode path detail:
   RoPE, then reshape back to `[1, B, heads, head_dim]`.
 
 ## KV cache and tiling constraints
-- Cache tensors are `[32, n_kv_heads, max_seq_len, head_dim]`.
-- `MAX_CACHE_SEQ_LEN` is set to 256 to cap memory usage; increase if needed.
+- Paged cache tensors are `[max_num_blocks, n_kv_heads, PAGED_BLOCK_SIZE, head_dim]`.
+- `max_num_blocks = ceil(max_seq_len / PAGED_BLOCK_SIZE)` with `PAGED_BLOCK_SIZE = 64`.
+- This bringup runs with `max_seq_len = 40960` (matches the n150 row).
 
 ## Precision
 - Weights use `ttnn.bfloat8_b`.
@@ -68,7 +70,8 @@ Decode trims padded head width after concatenating heads.
 Teacher-forcing accuracy is computed against the HF reference model.
 
 ```
-python eval.py models/google/gemma-3-4b-it/t3000/functional/model.py --model google/gemma-3-4b-it
+python eval.py models/google/gemma-3-4b-it/t3000/functional/model.py --model google/gemma-3-4b-it \
+  --max_new_tokens 100 --max_seq_len 40960
 ```
 
 On this T3000 host, set the mesh graph descriptor and use all 8 devices:
@@ -76,7 +79,8 @@ On this T3000 host, set the mesh graph descriptor and use all 8 devices:
 ```
 TT_MESH_GRAPH_DESC_PATH=/home/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto \
 TT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
-python eval.py models/google/gemma-3-4b-it/t3000/functional/model.py --model google/gemma-3-4b-it
+python eval.py models/google/gemma-3-4b-it/t3000/functional/model.py --model google/gemma-3-4b-it \
+  --max_new_tokens 100 --max_seq_len 40960
 ```
 
 If `/home` is full, redirect runtime artifacts to a writable location. On this host,
@@ -88,7 +92,8 @@ TT_MESH_GRAPH_DESC_PATH=/home/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descr
 TT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
 TT_METAL_CACHE=/tmp/tt-metal-cache TT_METAL_RUNTIME_ROOT=/proj_sw/user_dev/moconnor/tt-runtime-root \
 TT_METAL_INSPECTOR_LOG_PATH=/tmp/tt-metal-inspector TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT=0 \
-python eval.py models/google/gemma-3-4b-it/t3000/functional/model.py --model google/gemma-3-4b-it
+python eval.py models/google/gemma-3-4b-it/t3000/functional/model.py --model google/gemma-3-4b-it \
+  --max_new_tokens 100 --max_seq_len 40960
 ```
 
 Automation wrapper (emits YT_METRICS JSON):
@@ -107,11 +112,12 @@ python scripts/run_eval.py --mode tt --hf-model google/gemma-3-4b-it
 ## Changes (2026-02-09)
 - Handle `sliding_window_pattern` when configs omit `layer_types` and supply a per-layer list,
   preventing a `TypeError` during layer setup.
+- Switched to paged KV cache + paged attention decode and increased `max_seq_len` to 40960.
 - Re-ran demo and long teacher-forcing eval for the release thresholds.
 
 ### Latest results (t3000 functional)
 - Top-1: 92%
 - Top-5: 100%
-- TTFT: 322 ms
-- Decode: 4.8 t/s/u
-- Seq len: 256 (MAX_CACHE_SEQ_LEN)
+- TTFT: 330 ms
+- Decode: 4.7 t/s/u
+- Seq len: 40960

--- a/models/google/gemma-3-4b-it/t3000/functional/demo.log
+++ b/models/google/gemma-3-4b-it/t3000/functional/demo.log
@@ -1,105 +1,63 @@
-CMD: HF_HOME=/proj_sw/user_dev/moconnor/hf-cache TT_VISIBLE_DEVICES=0,1,2,3 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto TT_METAL_CACHE=/tmp/tt-metal-cache TT_METAL_INSPECTOR_LOG_PATH=/tmp/tt-metal-inspector TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT=0 python demo.py models/google/gemma-3-4b-it/t3000/functional/model.py
-2026-02-09 13:40:08.736 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+CMD: env HF_HOME=/proj_sw/user_dev/moconnor/hf-cache TT_VISIBLE_DEVICES=0,1,2,3 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto TT_METAL_CACHE=/tmp/tt-metal-cache TT_METAL_INSPECTOR_LOG_PATH=/tmp/tt-metal-inspector TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT=0 python demo.py models/google/gemma-3-4b-it/t3000/functional/model.py --max_seq_len 40960
+2026-02-09 17:36:13.316 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
-2026-02-09 13:40:10.311 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 13:40:10.471 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-02-09 13:40:10.481 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 13:40:10.685 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 13:40:10.877 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x202 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 13:40:10.930 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 13:40:10.940 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 13:40:10.952 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 13:40:10.962 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 13:40:26.257 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 13:40:41.768 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 13:40:57.930 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x5 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 13:41:14.238 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 3, 1, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
-2026-02-09 13:41:14.238 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-02-09 13:41:14.238 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
-2026-02-09 13:41:14.250 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-02-09 13:41:14.251 | info     |             UMD | Mapped hugepage 0x240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 13:41:14.252 | info     |             UMD | Mapped hugepage 0x200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 13:41:14.253 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 13:41:14.254 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 13:41:14.255 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 13:41:14.255 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 13:41:14.256 | info     |             UMD | Mapped hugepage 0x42c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 13:41:14.257 | info     |             UMD | Mapped hugepage 0x4280000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 13:41:23.629 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto (metal_context.cpp:822)
-2026-02-09 13:41:23.630 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
-2026-02-09 13:41:23.636 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
-2026-02-09 13:41:23.637 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-02-09 13:41:23.642 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 13:41:23.645 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 13:41:23.645 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 13:41:23.645 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 13:41:24.198 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 13:41:24.641 | warning  |             UMD | Waiting for lock 'ARC_MSG' which is currently held by thread TID: 133106, PID: 132603 (robust_mutex.cpp:406)
-2026-02-09 13:41:24.641 | warning  |             UMD | Waiting for lock 'ARC_MSG' which is currently held by thread TID: 133106, PID: 132603 (robust_mutex.cpp:406)
-2026-02-09 13:41:24.724 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 13:41:25.590 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 13:41:26.356 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 13:42:19.732 | info     |           Metal | While initializing device 0, active ethernet dispatch core (x=21,y=17) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:19.732 | info     |           Metal | While initializing device 0, active ethernet dispatch core (x=22,y=17) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:19.732 | info     |           Metal | While initializing device 0, active ethernet dispatch core (x=18,y=17) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:19.732 | info     |           Metal | While initializing device 0, active ethernet dispatch core (x=25,y=17) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:19.732 | info     |           Metal | While initializing device 0, active ethernet dispatch core (x=21,y=16) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:19.732 | info     |           Metal | While initializing device 0, active ethernet dispatch core (x=22,y=16) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:19.735 | info     |           Metal | While initializing device 1, active ethernet dispatch core (x=21,y=17) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:19.735 | info     |           Metal | While initializing device 1, active ethernet dispatch core (x=22,y=17) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:19.735 | info     |           Metal | While initializing device 1, active ethernet dispatch core (x=18,y=17) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:19.736 | info     |           Metal | While initializing device 1, active ethernet dispatch core (x=25,y=17) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:19.736 | info     |           Metal | While initializing device 1, active ethernet dispatch core (x=21,y=16) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:19.736 | info     |           Metal | While initializing device 1, active ethernet dispatch core (x=22,y=16) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:19.738 | info     |           Metal | While initializing device 2, active ethernet dispatch core (x=21,y=17) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:19.738 | info     |           Metal | While initializing device 2, active ethernet dispatch core (x=18,y=17) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:19.738 | info     |           Metal | While initializing device 2, active ethernet dispatch core (x=25,y=17) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:19.738 | info     |           Metal | While initializing device 2, active ethernet dispatch core (x=22,y=17) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:19.738 | info     |           Metal | While initializing device 2, active ethernet dispatch core (x=18,y=16) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:19.738 | info     |           Metal | While initializing device 2, active ethernet dispatch core (x=25,y=16) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:19.741 | info     |           Metal | While initializing device 3, active ethernet dispatch core (x=21,y=17) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:19.741 | info     |           Metal | While initializing device 3, active ethernet dispatch core (x=18,y=17) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:19.741 | info     |           Metal | While initializing device 3, active ethernet dispatch core (x=25,y=17) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:19.741 | info     |           Metal | While initializing device 3, active ethernet dispatch core (x=22,y=17) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:19.741 | info     |           Metal | While initializing device 3, active ethernet dispatch core (x=18,y=16) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:19.741 | info     |           Metal | While initializing device 3, active ethernet dispatch core (x=25,y=16) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:19.744 | info     |           Metal | While initializing device 4, active ethernet dispatch core (x=21,y=16) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:19.947 | info     |           Metal | While initializing device 4, active ethernet dispatch core (x=22,y=16) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:20.187 | info     |           Metal | While initializing device 4, active ethernet dispatch core (x=18,y=16) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:20.307 | info     |           Metal | While initializing device 4, active ethernet dispatch core (x=25,y=16) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:20.410 | info     |           Metal | While initializing device 5, active ethernet dispatch core (x=21,y=16) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:20.663 | info     |           Metal | While initializing device 5, active ethernet dispatch core (x=22,y=16) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:20.915 | info     |           Metal | While initializing device 5, active ethernet dispatch core (x=18,y=16) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:21.041 | info     |           Metal | While initializing device 5, active ethernet dispatch core (x=25,y=16) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:21.099 | info     |           Metal | While initializing device 6, active ethernet dispatch core (x=21,y=16) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:21.099 | info     |           Metal | While initializing device 6, active ethernet dispatch core (x=22,y=16) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:21.100 | info     |           Metal | While initializing device 6, active ethernet dispatch core (x=18,y=16) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:21.100 | info     |           Metal | While initializing device 6, active ethernet dispatch core (x=25,y=16) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:21.216 | info     |           Metal | While initializing device 7, active ethernet dispatch core (x=21,y=16) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:21.402 | info     |           Metal | While initializing device 7, active ethernet dispatch core (x=22,y=16) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:21.403 | info     |           Metal | While initializing device 7, active ethernet dispatch core (x=18,y=16) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:21.403 | info     |           Metal | While initializing device 7, active ethernet dispatch core (x=25,y=16) detected as still running, issuing exit signal. (metal_context.cpp:866)
-2026-02-09 13:42:21.461 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
-2026-02-09 13:42:21.461 | info     |           Metal | Dispatch on FabricConfig::FABRIC_2D with 1 Command Queues
+2026-02-09 17:36:14.875 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 17:36:14.908 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-09 17:36:14.918 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 17:36:14.990 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 17:36:15.053 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x202 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 17:36:15.111 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 17:36:15.121 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 17:36:15.132 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 17:36:15.142 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 17:36:15.155 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 17:36:15.169 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 17:36:15.182 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x5 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 17:36:15.195 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 3, 1, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
+2026-02-09 17:36:15.195 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-09 17:36:15.195 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-09 17:36:15.205 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-09 17:36:15.206 | info     |             UMD | Mapped hugepage 0x240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 17:36:15.206 | info     |             UMD | Mapped hugepage 0x200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 17:36:15.207 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 17:36:15.208 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 17:36:15.209 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 17:36:15.210 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 17:36:15.211 | info     |             UMD | Mapped hugepage 0x42c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 17:36:15.211 | info     |             UMD | Mapped hugepage 0x4280000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 17:36:15.262 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto (metal_context.cpp:822)
+2026-02-09 17:36:15.263 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-09 17:36:15.268 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-09 17:36:15.268 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-09 17:36:15.272 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 17:36:15.275 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 17:36:15.275 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 17:36:15.276 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 17:36:15.276 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 17:36:15.277 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 17:36:15.277 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 17:36:15.277 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 17:36:15.593 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
+2026-02-09 17:36:15.593 | info     |           Metal | Dispatch on FabricConfig::FABRIC_2D with 1 Command Queues
  (device_manager.cpp:328)
-2026-02-09 13:42:21.476 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
-2026-02-09 13:42:21.638 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
-2026-02-09 13:42:21.639 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
-2026-02-09 13:42:21.675 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
-2026-02-09 13:42:21.676 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
-2026-02-09 13:42:21.679 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
-2026-02-09 13:42:21.685 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
-2026-02-09 13:42:21.688 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
-2026-02-09 13:42:21.695 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
-2026-02-09 13:42:21.695 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_2D (device_manager.cpp:409)
-2026-02-09 13:42:21.783 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
-2026-02-09 13:42:21.784 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
-2026-02-09 13:42:21.785 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
-2026-02-09 13:42:21.785 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
+2026-02-09 17:36:15.608 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
+2026-02-09 17:36:15.780 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
+2026-02-09 17:36:15.780 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
+2026-02-09 17:36:15.814 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
+2026-02-09 17:36:15.814 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
+2026-02-09 17:36:15.818 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
+2026-02-09 17:36:15.823 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
+2026-02-09 17:36:15.826 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
+2026-02-09 17:36:15.833 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
+2026-02-09 17:36:15.833 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_2D (device_manager.cpp:409)
+2026-02-09 17:36:15.954 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
+2026-02-09 17:36:15.956 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
+2026-02-09 17:36:15.956 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
+2026-02-09 17:36:15.956 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
 Loading tokenizer: google/gemma-3-4b-it
 Opening TT device...
 Loading HuggingFace reference model on CPU: google/gemma-3-4b-it
-Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:00<00:00,  1.23it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.53it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.47it/s]
+Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:05<00:05,  5.64s/it]Loading checkpoint shards: 100%|██████████| 2/2 [00:09<00:00,  4.73s/it]Loading checkpoint shards: 100%|██████████| 2/2 [00:09<00:00,  4.87s/it]
 Building TT model...
   Loading embeddings...
   Computing RoPE cache...
@@ -108,7 +66,7 @@ TT demo (t3000)
 Model: google/gemma-3-4b-it
 Mesh shape: 2x4
 Prompt tokens: 54 | Generated tokens: 128
-TTFT: 322 ms | Decode: 4.8 t/s/u (127 tokens)
+TTFT: 330 ms | Decode: 4.7 t/s/u (127 tokens)
 
 Prompt:
 Journal entry, 1957: Tonight a tiny sphere called Sputnik 1 crossed the sky, beeping like a metronome for a new era. The neighbors gathered on the roof, listening and arguing about what comes next. I wrote in my notebook that
@@ -121,5 +79,5 @@ Output:
 I've been thinking about that night ever since. Fifty years. Fifty years since a tiny, simple sphere whispered into the void, announcing the dawn of the Space Age. It feels like a lifetime, and yet, it's just a blink.
 
 The world has changed… profoundly. We’ve walked on the moon, sent probes to Mars, unravelled the secrets of the atom. We’ve talked to each other across the globe in an instant, built cities that scrape the sky,
-2026-02-09 13:46:07.890 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-02-09 13:46:07.890 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
+2026-02-09 17:39:31.727 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-09 17:39:31.727 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/google/gemma-3-4b-it/t3000/functional/eval.log
+++ b/models/google/gemma-3-4b-it/t3000/functional/eval.log
@@ -1,64 +1,64 @@
-CMD: HF_HOME=/proj_sw/user_dev/moconnor/hf-cache TT_VISIBLE_DEVICES=0,1,2,3 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto TT_METAL_CACHE=/tmp/tt-metal-cache TT_METAL_INSPECTOR_LOG_PATH=/tmp/tt-metal-inspector TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT=0 python eval.py models/google/gemma-3-4b-it/t3000/functional/model.py --model google/gemma-3-4b-it --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 2048
-2026-02-09 13:48:38.555 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+CMD: env HF_HOME=/proj_sw/user_dev/moconnor/hf-cache TT_VISIBLE_DEVICES=0,1,2,3 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto TT_METAL_CACHE=/tmp/tt-metal-cache TT_METAL_INSPECTOR_LOG_PATH=/tmp/tt-metal-inspector TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT=0 python eval.py models/google/gemma-3-4b-it/t3000/functional/model.py --model google/gemma-3-4b-it --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 40960
+2026-02-09 17:40:27.325 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
 Loading model module: /localdev/moconnor/ttnn_models/models/google/gemma-3-4b-it/t3000/functional/model.py
 Loading HuggingFace tokenizer...
 Loading HuggingFace reference model on CPU...
-Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:00<00:00,  1.25it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.52it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.48it/s]
+Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:00<00:00,  1.07it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.33it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.29it/s]
 The following generation flags are not valid and may be ignored: ['top_p', 'top_k']. Set `TRANSFORMERS_VERBOSITY=info` for more details.
-2026-02-09 13:49:35.374 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 13:49:35.404 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-02-09 13:49:35.413 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 13:49:35.493 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 13:49:35.558 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x202 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 13:49:35.614 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 13:49:35.625 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 13:49:35.635 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 13:49:35.645 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 13:49:35.659 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 13:49:35.672 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 13:49:35.685 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x5 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 13:49:35.699 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 3, 1, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
-2026-02-09 13:49:35.699 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-02-09 13:49:35.699 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
-2026-02-09 13:49:35.708 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-02-09 13:49:35.709 | info     |             UMD | Mapped hugepage 0x240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 13:49:35.709 | info     |             UMD | Mapped hugepage 0x200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 13:49:35.710 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 13:49:35.711 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 13:49:35.712 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 13:49:35.713 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 13:49:35.713 | info     |             UMD | Mapped hugepage 0x42c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 13:49:35.714 | info     |             UMD | Mapped hugepage 0x4280000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 13:49:35.766 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto (metal_context.cpp:822)
-2026-02-09 13:49:35.767 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
-2026-02-09 13:49:35.773 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
-2026-02-09 13:49:35.773 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-02-09 13:49:35.782 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 13:49:35.786 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 13:49:35.786 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 13:49:35.786 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 13:49:35.787 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 13:49:35.787 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 13:49:35.787 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 13:49:35.787 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 13:49:36.107 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
-2026-02-09 13:49:36.107 | info     |           Metal | Dispatch on FabricConfig::FABRIC_2D with 1 Command Queues
+2026-02-09 17:41:24.274 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 17:41:24.305 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-09 17:41:24.314 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 17:41:24.390 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 17:41:24.451 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x202 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 17:41:24.510 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 17:41:24.520 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 17:41:24.530 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 17:41:24.541 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 17:41:24.554 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 17:41:24.567 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 17:41:24.581 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x5 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 17:41:24.594 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 3, 1, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
+2026-02-09 17:41:24.594 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-09 17:41:24.594 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-09 17:41:24.603 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-09 17:41:24.604 | info     |             UMD | Mapped hugepage 0x240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 17:41:24.605 | info     |             UMD | Mapped hugepage 0x200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 17:41:24.606 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 17:41:24.606 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 17:41:24.607 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 17:41:24.608 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 17:41:24.609 | info     |             UMD | Mapped hugepage 0x42c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 17:41:24.610 | info     |             UMD | Mapped hugepage 0x4280000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 17:41:24.662 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto (metal_context.cpp:822)
+2026-02-09 17:41:24.663 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-09 17:41:24.668 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-09 17:41:24.668 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-09 17:41:24.676 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 17:41:24.680 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 17:41:24.680 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 17:41:24.680 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 17:41:24.680 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 17:41:24.681 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 17:41:24.681 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 17:41:24.681 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 17:41:25.003 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
+2026-02-09 17:41:25.003 | info     |           Metal | Dispatch on FabricConfig::FABRIC_2D with 1 Command Queues
  (device_manager.cpp:328)
-2026-02-09 13:49:36.123 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
-2026-02-09 13:49:36.344 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
-2026-02-09 13:49:36.344 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
-2026-02-09 13:49:36.345 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
-2026-02-09 13:49:36.346 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
-2026-02-09 13:49:36.349 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
-2026-02-09 13:49:36.355 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
-2026-02-09 13:49:36.358 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
-2026-02-09 13:49:36.365 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
-2026-02-09 13:49:36.365 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_2D (device_manager.cpp:409)
-2026-02-09 13:49:36.456 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
-2026-02-09 13:49:36.456 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
-2026-02-09 13:49:36.460 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
-2026-02-09 13:49:36.460 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
+2026-02-09 17:41:25.019 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
+2026-02-09 17:41:25.166 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
+2026-02-09 17:41:25.167 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
+2026-02-09 17:41:25.201 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
+2026-02-09 17:41:25.201 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
+2026-02-09 17:41:25.204 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
+2026-02-09 17:41:25.210 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
+2026-02-09 17:41:25.214 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
+2026-02-09 17:41:25.220 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
+2026-02-09 17:41:25.220 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_2D (device_manager.cpp:409)
+2026-02-09 17:41:25.315 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
+2026-02-09 17:41:25.316 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
+2026-02-09 17:41:25.318 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
+2026-02-09 17:41:25.318 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
 Generating reference tokens...
 Opening device (2x4)...
 Loading ttnn model...
@@ -68,5 +68,5 @@ Loading ttnn model...
 Running teacher-forcing eval (100 tokens)...
 Top-1 accuracy: 92.00% (0.9200)
 Top-5 accuracy: 100.00% (1.0000)
-2026-02-09 13:51:39.842 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-02-09 13:51:39.843 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
+2026-02-09 17:43:58.438 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-09 17:43:58.438 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/google/gemma-3-4b-it/t3000/functional/model.py
+++ b/models/google/gemma-3-4b-it/t3000/functional/model.py
@@ -19,7 +19,7 @@ from transformers.modeling_outputs import CausalLMOutputWithPast
 TILE_SIZE = 32
 WEIGHT_DTYPE = ttnn.bfloat8_b
 WEIGHT_LAYOUT = ttnn.TILE_LAYOUT
-MAX_CACHE_SEQ_LEN = 256
+PAGED_BLOCK_SIZE = 64
 MESH_SHAPE = (2, 4)
 MESH_TOPOLOGY = ttnn.Topology.Linear
 MESH_NUM_LINKS = 1
@@ -113,6 +113,14 @@ class ParallelConfig:
     vocab_composer: object
 
 
+@dataclass
+class PagedAttentionConfig:
+    """Paged KV cache configuration."""
+
+    block_size: int
+    max_num_blocks: int
+
+
 def validate_parallel_config(config: ModelConfig, num_devices: int) -> None:
     if num_devices != 8:
         raise ValueError("T3000 model expects an 8-device mesh")
@@ -166,6 +174,19 @@ def compute_rope_cache(
     cos = emb.cos().unsqueeze(0).unsqueeze(0).to(torch.bfloat16)
     sin = emb.sin().unsqueeze(0).unsqueeze(0).to(torch.bfloat16)
     return cos, sin
+
+
+def resolve_max_seq_len(hf_config, max_seq_len: Optional[int]) -> int:
+    """Resolve max sequence length from HF config when not provided."""
+    text_config = getattr(hf_config, "text_config", hf_config)
+    config_max = getattr(text_config, "max_position_embeddings", None)
+    if max_seq_len is None:
+        if config_max is None:
+            raise ValueError("max_seq_len is required when config has no max_position_embeddings")
+        return config_max
+    if config_max is not None and max_seq_len > config_max:
+        raise ValueError(f"max_seq_len {max_seq_len} exceeds config max {config_max}")
+    return max_seq_len
 
 
 class RMSNorm:
@@ -227,7 +248,8 @@ class Attention:
         cos_cache_local: ttnn.Tensor,
         sin_cache_local: ttnn.Tensor,
         parallel: ParallelConfig,
-        max_seq_len: int,
+        paged_attention_config: PagedAttentionConfig,
+        page_table: ttnn.Tensor,
     ):
         self.parallel = parallel
         self.n_heads = config.num_attention_heads
@@ -243,6 +265,8 @@ class Attention:
         self.n_local_kv_heads = self.n_kv_heads // parallel.num_devices
         self.head_dim = config.head_dim
         self.scale = 1.0 / math.sqrt(config.query_pre_attn_scalar)
+        self.paged_attention_config = paged_attention_config
+        self.page_table = page_table
         if config.layer_types is not None:
             self.is_sliding = config.layer_types[layer_idx] == "sliding_attention"
         else:
@@ -270,7 +294,12 @@ class Attention:
         self.q_norm = RMSNorm(state_dict[f"{p}q_norm.weight"], config.rms_norm_eps, parallel)
         self.k_norm = RMSNorm(state_dict[f"{p}k_norm.weight"], config.rms_norm_eps, parallel)
 
-        cache_shape = (TILE_SIZE, self.n_kv_heads, max_seq_len, self.head_dim)
+        cache_shape = (
+            self.paged_attention_config.max_num_blocks,
+            self.n_kv_heads,
+            self.paged_attention_config.block_size,
+            self.head_dim,
+        )
         self.k_cache = ttnn.as_tensor(
             torch.zeros(cache_shape, dtype=torch.bfloat16),
             dtype=ttnn.bfloat16,
@@ -348,8 +377,8 @@ class Attention:
             q = ttnn.experimental.rotary_embedding(q, cos, sin)
             k = ttnn.experimental.rotary_embedding(k, cos, sin)
 
-            ttnn.fill_cache(self.k_cache, k, batch_idx=0)
-            ttnn.fill_cache(self.v_cache, v, batch_idx=0)
+            ttnn.experimental.paged_fill_cache(self.k_cache, k, self.page_table, batch_idx=0)
+            ttnn.experimental.paged_fill_cache(self.v_cache, v, self.page_table, batch_idx=0)
 
             attn_out = ttnn.transformer.scaled_dot_product_attention(
                 q, k, v, is_causal=True, scale=self.scale
@@ -393,11 +422,20 @@ class Attention:
             q = ttnn.to_memory_config(q, q_mem)
             k = ttnn.to_memory_config(k, k_mem)
 
-            ttnn.experimental.paged_update_cache(self.k_cache, k, update_idxs_tensor=cur_pos_tensor)
-            ttnn.experimental.paged_update_cache(self.v_cache, v, update_idxs_tensor=cur_pos_tensor)
+            ttnn.experimental.paged_update_cache(
+                self.k_cache, k, update_idxs_tensor=cur_pos_tensor, page_table=self.page_table
+            )
+            ttnn.experimental.paged_update_cache(
+                self.v_cache, v, update_idxs_tensor=cur_pos_tensor, page_table=self.page_table
+            )
 
-            attn_out = ttnn.transformer.scaled_dot_product_attention_decode(
-                q, self.k_cache, self.v_cache, cur_pos_tensor=cur_pos_tensor, scale=self.scale
+            attn_out = ttnn.transformer.paged_scaled_dot_product_attention_decode(
+                q,
+                self.k_cache,
+                self.v_cache,
+                page_table_tensor=self.page_table,
+                cur_pos_tensor=cur_pos_tensor,
+                scale=self.scale,
             )
             attn_out = ttnn.transpose(attn_out, 1, 2)
             attn_out = ttnn.experimental.nlp_concat_heads(attn_out, memory_config=ttnn.DRAM_MEMORY_CONFIG)
@@ -427,7 +465,8 @@ class DecoderLayer:
         cos_cache_local: ttnn.Tensor,
         sin_cache_local: ttnn.Tensor,
         parallel: ParallelConfig,
-        max_seq_len: int,
+        paged_attention_config: PagedAttentionConfig,
+        page_table: ttnn.Tensor,
     ):
         p = f"language_model.model.layers.{layer_idx}."
         self.attn_norm = RMSNorm(state_dict[f"{p}input_layernorm.weight"], config.rms_norm_eps, parallel)
@@ -445,7 +484,8 @@ class DecoderLayer:
             cos_cache_local,
             sin_cache_local,
             parallel,
-            max_seq_len,
+            paged_attention_config,
+            page_table,
         )
         self.mlp = MLP(layer_idx, state_dict, parallel)
 
@@ -476,14 +516,13 @@ class TtnnGemma3ForCausalLM(torch.nn.Module, GenerationMixin):
     HuggingFace `generate()`-compatible via `GenerationMixin`.
     """
 
-    def __init__(self, hf_model, tt_device, max_seq_len: int = 2048):
+    def __init__(self, hf_model, tt_device, max_seq_len: Optional[int] = None):
         super().__init__()
 
         self.tt_device = tt_device
         self.hf_config = hf_model.config
         self.tt_config = ModelConfig.from_hf(hf_model.config)
-        self.max_seq_len = max_seq_len
-        self.cache_seq_len = min(max_seq_len, MAX_CACHE_SEQ_LEN)
+        self.max_seq_len = resolve_max_seq_len(self.hf_config, max_seq_len)
         self._pos = 0
 
         if self.tt_config.hidden_activation != "gelu_pytorch_tanh":
@@ -540,13 +579,13 @@ class TtnnGemma3ForCausalLM(torch.nn.Module, GenerationMixin):
         print("  Computing RoPE cache...")
         cos_global, sin_global = compute_rope_cache(
             self.tt_config.head_dim,
-            self.cache_seq_len,
+            self.max_seq_len,
             rope_theta=self.tt_config.rope_theta,
             rope_scaling=self.tt_config.rope_scaling,
         )
         cos_local, sin_local = compute_rope_cache(
             self.tt_config.head_dim,
-            self.cache_seq_len,
+            self.max_seq_len,
             rope_theta=self.tt_config.rope_local_base_freq,
             rope_scaling=None,
         )
@@ -583,6 +622,18 @@ class TtnnGemma3ForCausalLM(torch.nn.Module, GenerationMixin):
             mesh_mapper=self.parallel.replicate_mapper,
         )
 
+        max_num_blocks = math.ceil(self.max_seq_len / PAGED_BLOCK_SIZE)
+        self.paged_attention_config = PagedAttentionConfig(PAGED_BLOCK_SIZE, max_num_blocks)
+        page_table = torch.arange(max_num_blocks, dtype=torch.int32).repeat(TILE_SIZE, 1)
+        self.page_table = ttnn.as_tensor(
+            page_table,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+
         print(f"  Loading {self.tt_config.num_hidden_layers} layers...")
         self.layers = [
             DecoderLayer(
@@ -594,7 +645,8 @@ class TtnnGemma3ForCausalLM(torch.nn.Module, GenerationMixin):
                 self.cos_cache_local,
                 self.sin_cache_local,
                 self.parallel,
-                self.cache_seq_len,
+                self.paged_attention_config,
+                self.page_table,
             )
             for i in range(self.tt_config.num_hidden_layers)
         ]
@@ -648,16 +700,15 @@ class TtnnGemma3ForCausalLM(torch.nn.Module, GenerationMixin):
             assert seq_len == 1, "Only 1-token decode supported when using cache"
 
         start_pos = self._pos
-        if start_pos + seq_len > self.cache_seq_len:
-            raise ValueError(
-                f"sequence length {start_pos + seq_len} exceeds cache length {self.cache_seq_len}; "
-                "increase MAX_CACHE_SEQ_LEN if memory allows"
-            )
+        if start_pos + seq_len > self.max_seq_len:
+            raise ValueError(f"sequence length {start_pos + seq_len} exceeds max_seq_len {self.max_seq_len}")
 
         cur_pos_tensor = None
         if seq_len == 1:
+            cur_pos = torch.full((TILE_SIZE,), -1, dtype=torch.int32)
+            cur_pos[0] = start_pos
             cur_pos_tensor = ttnn.from_torch(
-                torch.full((TILE_SIZE,), start_pos, dtype=torch.int32),
+                cur_pos,
                 dtype=ttnn.int32,
                 device=self.tt_device,
                 mesh_mapper=self.parallel.replicate_mapper,
@@ -699,6 +750,6 @@ class TtnnGemma3ForCausalLM(torch.nn.Module, GenerationMixin):
         )
 
 
-def build_model(hf_model, tt_device, max_seq_len: int = 2048) -> TtnnGemma3ForCausalLM:
+def build_model(hf_model, tt_device, max_seq_len: Optional[int] = None) -> TtnnGemma3ForCausalLM:
     """Build the ttnn model from a HuggingFace reference model."""
     return TtnnGemma3ForCausalLM(hf_model, tt_device, max_seq_len)


### PR DESCRIPTION
Increase max_seq_len / KV cache capacity on t3000.

Current MODELS.md: Top-1 92%, Top-5 100%, Seq len 256.
Target: Seq len 40960 (match n150 row) if it fits; otherwise pick the highest that fits DRAM and document why.

Requirements:
- Keep/introduce paged attention + paged KV cache.
- Run demo + long eval with --max_seq_len <new_seq_len> and update MODELS.md + demo.log/eval.log + MODEL_BRINGUP.md.

Fixes #109
