### PR TITLE
ALLaM n300: max_seq_len 4096 (paged KV cache)

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -15,7 +15,7 @@ Note: Keep the table columns padded with spaces and right-justify numeric cells 
 | arcee-ai/AFM-4.5B                   |   n150   | functional |   98% |  100% |   72ms |  17.2 |   65536 |
 | arcee-ai/AFM-4.5B                   |   n300   | functional |   97% |  100% |  283ms |   5.6 |   65536 |
 | humain-ai/ALLaM-7B-Instruct-preview |   n150   | functional |   97% |  100% |   76ms |  14.9 |    4096 |
-| humain-ai/ALLaM-7B-Instruct-preview |   n300   | functional |   97% |  100% |  184ms |   7.9 |     256 |
+| humain-ai/ALLaM-7B-Instruct-preview |   n300   | functional |   97% |  100% |  184ms |   7.9 |    4096 |
 | humain-ai/ALLaM-7B-Instruct-preview |  t3000   | functional |   95% |  100% |  127ms |   9.1 |    4096 |
 | meta-llama/Llama-3.2-1B             |   n150   | functional |   92% |  100% |   34ms |  39.5 |  131072 |
 | meta-llama/Llama-3.2-1B             |   n150   | optimized  |   79% |   99% |   26ms |  58.0 |    1024 |

--- a/models/humain-ai/ALLaM-7B-Instruct-preview/n300/functional/MODEL_BRINGUP.md
+++ b/models/humain-ai/ALLaM-7B-Instruct-preview/n300/functional/MODEL_BRINGUP.md
@@ -3,6 +3,7 @@
 ## Overview
 This is a minimal TTNN bringup of `humain-ai/ALLaM-7B-Instruct-preview` for N300 using 1D tensor parallel.
 It is designed to be easy to read and to serve as a template for future bringups.
+Target max sequence length: 4096 (paged KV cache sized to `max_seq_len`).
 
 - Model code: `models/humain-ai/ALLaM-7B-Instruct-preview/n300/functional/model.py`
 - Eval harness: `eval.py` (teacher forcing) and `scripts/run_eval.py` (automation wrapper)
@@ -34,8 +35,8 @@ It is designed to be easy to read and to serve as a template for future bringups
 - `ttnn.rms_norm` for RMSNorm
 - `ttnn.experimental.rotary_embedding` for HuggingFace-format RoPE
 - `ttnn.experimental.nlp_create_qkv_heads[_decode]` and `ttnn.experimental.nlp_concat_heads`
-- `ttnn.transformer.scaled_dot_product_attention[_decode]`
-- `ttnn.fill_cache` (prefill) and `ttnn.experimental.paged_update_cache` (decode)
+- `ttnn.transformer.scaled_dot_product_attention` (prefill) and `ttnn.transformer.paged_scaled_dot_product_attention_decode` (decode)
+- `ttnn.experimental.paged_fill_cache` (prefill) and `ttnn.experimental.paged_update_cache` (decode)
 
 ## RoPE notes
 Decode path detail:
@@ -44,9 +45,8 @@ Decode path detail:
   RoPE, then reshape back to `[1, B, heads, head_dim]`.
 
 ## KV cache and tiling constraints
-- Cache tensors are `[32, n_kv_heads, max_seq_len, head_dim]`.
-- `MAX_CACHE_SEQ_LEN` is set to 256 to cap memory usage; increase if needed.
-- Prefill uses a height-sharded K/V path to avoid `fill_cache` grid limits when sequence length grows.
+- KV cache is paged: `[num_blocks, n_kv_heads, block_size, head_dim]` with `block_size=64`.
+- `num_blocks = ceil(max_seq_len / block_size)` so `max_seq_len` controls cache capacity.
 
 ## Precision
 - Weights use `ttnn.bfloat8_b`.
@@ -60,13 +60,13 @@ Decode trims padded head width after concatenating heads.
 Teacher-forcing accuracy is computed against the HF reference model.
 
 ```
-python eval.py models/humain-ai/ALLaM-7B-Instruct-preview/n300/functional/model.py --model humain-ai/ALLaM-7B-Instruct-preview
+python eval.py models/humain-ai/ALLaM-7B-Instruct-preview/n300/functional/model.py --model humain-ai/ALLaM-7B-Instruct-preview --max_seq_len 4096
 ```
 
 On this N300 host, set the mesh to devices 0 and 2:
 
 ```
-TT_VISIBLE_DEVICES=0,2 python eval.py models/humain-ai/ALLaM-7B-Instruct-preview/n300/functional/model.py --model humain-ai/ALLaM-7B-Instruct-preview
+TT_VISIBLE_DEVICES=0,2 python eval.py models/humain-ai/ALLaM-7B-Instruct-preview/n300/functional/model.py --model humain-ai/ALLaM-7B-Instruct-preview --max_seq_len 4096
 ```
 
 If `/home` is full, redirect runtime artifacts to a writable location. On this host,
@@ -74,7 +74,7 @@ If `/home` is full, redirect runtime artifacts to a writable location. On this h
 `ttnn`, and `runtime` from the installed package):
 
 ```
-TT_VISIBLE_DEVICES=0,2 TT_METAL_CACHE=/tmp/tt-metal-cache TT_METAL_RUNTIME_ROOT=/proj_sw/user_dev/moconnor/tt-runtime-root TT_METAL_INSPECTOR_LOG_PATH=/tmp/tt-metal-inspector TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT=0 python eval.py models/humain-ai/ALLaM-7B-Instruct-preview/n300/functional/model.py --model humain-ai/ALLaM-7B-Instruct-preview
+TT_VISIBLE_DEVICES=0,2 TT_METAL_CACHE=/tmp/tt-metal-cache TT_METAL_RUNTIME_ROOT=/proj_sw/user_dev/moconnor/tt-runtime-root TT_METAL_INSPECTOR_LOG_PATH=/tmp/tt-metal-inspector TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT=0 python eval.py models/humain-ai/ALLaM-7B-Instruct-preview/n300/functional/model.py --model humain-ai/ALLaM-7B-Instruct-preview --max_seq_len 4096
 ```
 
 Automation wrapper (emits YT_METRICS JSON):

--- a/models/humain-ai/ALLaM-7B-Instruct-preview/n300/functional/demo.log
+++ b/models/humain-ai/ALLaM-7B-Instruct-preview/n300/functional/demo.log
@@ -1,72 +1,72 @@
-TT_VISIBLE_DEVICES=0 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto python demo.py models/humain-ai/ALLaM-7B-Instruct-preview/n300/functional/model.py
+TT_VISIBLE_DEVICES=1 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto PYTHONUNBUFFERED=1 python demo.py models/humain-ai/ALLaM-7B-Instruct-preview/n300/functional/model.py --max_seq_len 4096 --max-new-tokens 8
 /proj_sw/user_dev/moconnor/tt-metal/python_env/lib/python3.10/site-packages/transformers/utils/hub.py:111: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
   warnings.warn(
-2026-02-09 11:32:19.702 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+2026-02-09 18:19:01.111 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
-2026-02-09 11:32:21.325 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 11:32:21.333 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-02-09 11:32:21.336 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 11:32:21.362 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 11:32:21.384 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 11:32:21.468 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 11:32:21.487 | info     |             UMD | Opening local chip ids/PCIe ids: {0}/[0] and remote chip ids {1} (cluster.cpp:186)
-2026-02-09 11:32:21.487 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-02-09 11:32:21.487 | info     |             UMD | KMD version: 2.4.0 (cluster.cpp:164)
-2026-02-09 11:32:21.490 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-02-09 11:32:21.494 | info     |             UMD | Mapped hugepage 0x340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 11:32:21.497 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 11:32:21.551 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto (metal_context.cpp:858)
-2026-02-09 11:32:21.552 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=2, n_phys=2, log_deg_hist={1:2}, phys_deg_hist={1:2} (topology_mapper_utils.cpp:171)
-2026-02-09 11:32:21.552 | info     |          Fabric | Fast-path path-graph mapping succeeded for mesh 0 (topology_mapper_utils.cpp:401)
-2026-02-09 11:32:21.558 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
-2026-02-09 11:32:21.559 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-02-09 11:32:21.568 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 11:32:21.571 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 11:32:21.714 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:748)
-2026-02-09 11:32:21.714 | info     |           Metal | Dispatch on FabricConfig::FABRIC_1D with 1 Command Queues
- (device_manager.cpp:331)
-2026-02-09 11:32:21.716 | info     |           Metal | Initializing Fabric (device_manager.cpp:409)
-2026-02-09 11:32:21.813 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:392)
-2026-02-09 11:32:21.817 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:392)
-2026-02-09 11:32:21.817 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_1D (device_manager.cpp:414)
-2026-02-09 11:32:22.025 | info     |           Metal | Command Queue initialized on Device 1 (device_manager.cpp:510)
 Loading tokenizer: humain-ai/ALLaM-7B-Instruct-preview
 Opening TT device...
+2026-02-09 18:19:02.847 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 18:19:02.855 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-09 18:19:02.859 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 18:19:02.886 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 18:19:02.907 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 18:19:03.003 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x204 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 18:19:03.021 | info     |             UMD | Opening local chip ids/PCIe ids: {0}/[1] and remote chip ids {1} (cluster.cpp:186)
+2026-02-09 18:19:03.021 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-09 18:19:03.021 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-09 18:19:03.024 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-09 18:19:03.028 | info     |             UMD | Mapped hugepage 0x440000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 18:19:03.032 | info     |             UMD | Mapped hugepage 0x400000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 18:19:03.094 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto (metal_context.cpp:858)
+2026-02-09 18:19:03.095 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=2, n_phys=2, log_deg_hist={1:2}, phys_deg_hist={1:2} (topology_mapper_utils.cpp:171)
+2026-02-09 18:19:03.095 | info     |          Fabric | Fast-path path-graph mapping succeeded for mesh 0 (topology_mapper_utils.cpp:401)
+2026-02-09 18:19:03.101 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-09 18:19:03.101 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-09 18:19:03.109 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 18:19:03.113 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 18:19:03.256 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:748)
+2026-02-09 18:19:03.256 | info     |           Metal | Dispatch on FabricConfig::FABRIC_1D with 1 Command Queues
+ (device_manager.cpp:331)
+2026-02-09 18:19:03.259 | info     |           Metal | Initializing Fabric (device_manager.cpp:409)
+2026-02-09 18:19:03.355 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:392)
+2026-02-09 18:19:03.359 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:392)
+2026-02-09 18:19:03.359 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_1D (device_manager.cpp:414)
+2026-02-09 18:19:03.495 | info     |           Metal | Command Queue initialized on Device 1 (device_manager.cpp:510)
 Loading HuggingFace reference model on CPU: humain-ai/ALLaM-7B-Instruct-preview
-Loading checkpoint shards:   0%|          | 0/3 [00:00<?, ?it/s]Loading checkpoint shards:  33%|███▎      | 1/3 [00:00<00:01,  1.22it/s]Loading checkpoint shards:  67%|██████▋   | 2/3 [00:01<00:00,  1.21it/s]Loading checkpoint shards: 100%|██████████| 3/3 [00:02<00:00,  1.35it/s]Loading checkpoint shards: 100%|██████████| 3/3 [00:02<00:00,  1.31it/s]
-2026-02-09 11:35:47.450 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/5219050073499734444/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:35:48.714 | warning  |    BuildKernels | Compute kernel 'tilize/3556198843499250409/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:35:49.084 | warning  |    BuildKernels | Compute kernel 'layernorm/13312309764502615647/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:35:49.332 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4209558737387150960/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:35:49.674 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/9827946993736593312/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:35:49.948 | warning  |    BuildKernels | Compute kernel 'sdpa/18295992779241515911/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:35:50.187 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/2168746053702180913/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:35:50.328 | warning  |    BuildKernels | Compute kernel 'line_reduction/17263434165235172306/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:35:50.706 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/5929164161975881440/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:35:51.145 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/10161628430691309170/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:35:51.321 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/15345965177072270890/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:35:51.652 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/2721043012078536798/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:35:52.037 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/3491980988751689818/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:35:52.235 | warning  |    BuildKernels | Compute kernel 'update_cache/846803462354870350/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:35:52.358 | warning  |    BuildKernels | Compute kernel 'sdpa_flash_decode/13644955033845445065/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:35:52.664 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/12482852762311938027/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:35:53.021 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/7502336892383803170/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:35:53.318 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/8920298209850939216/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:35:53.499 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/14027415175706824938/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+Loading checkpoint shards:   0%|          | 0/3 [00:00<?, ?it/s]Loading checkpoint shards:  33%|███▎      | 1/3 [00:00<00:01,  1.20it/s]Loading checkpoint shards:  67%|██████▋   | 2/3 [00:01<00:00,  1.21it/s]Loading checkpoint shards: 100%|██████████| 3/3 [00:02<00:00,  1.41it/s]Loading checkpoint shards: 100%|██████████| 3/3 [00:02<00:00,  1.35it/s]
 Building TT model...
   Loading embeddings...
   Computing RoPE cache...
   Loading 32 layers...
+2026-02-09 18:22:33.610 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/5219050073499734444/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:22:33.757 | warning  |    BuildKernels | Compute kernel 'tilize/3556198843499250409/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:22:33.866 | warning  |    BuildKernels | Compute kernel 'layernorm/13312309764502615647/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:22:34.048 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4209558737387150960/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:22:34.310 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/9827946993736593312/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:22:34.486 | warning  |    BuildKernels | Compute kernel 'sdpa/18295992779241515911/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:22:34.723 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/2168746053702180913/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:22:34.853 | warning  |    BuildKernels | Compute kernel 'line_reduction/17263434165235172306/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:22:35.150 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/5929164161975881440/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:22:35.508 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/10161628430691309170/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:22:35.661 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/15345965177072270890/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:22:35.959 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/2721043012078536798/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:22:36.304 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/3491980988751689818/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:22:36.468 | warning  |    BuildKernels | Compute kernel 'update_cache/13094027235434668704/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:22:36.575 | warning  |    BuildKernels | Compute kernel 'sdpa_flash_decode/1930860853784749243/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:22:36.877 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/12482852762311938027/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:22:37.145 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/7502336892383803170/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:22:37.408 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/8920298209850939216/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:22:37.573 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/14027415175706824938/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
 TT demo (n300)
 Model: humain-ai/ALLaM-7B-Instruct-preview
 Mesh shape: 1x2
-Prompt tokens: 57 | Generated tokens: 25
-TTFT: 184 ms | Decode: 7.9 t/s/u (24 tokens)
+Prompt tokens: 57 | Generated tokens: 8
+TTFT: 172 ms | Decode: 7.8 t/s/u (7 tokens)
 
 Prompt:
 Journal entry, 1957: Tonight a tiny sphere called Sputnik 1 crossed the sky, beeping like a metronome for a new era. The neighbors gathered on the roof, listening and arguing about what comes next. I wrote in my notebook that
 
 Output:
-this might be the first time the world was so deeply affected by something that I wasn’t directly involved in. 
-2026-02-09 11:36:00.202 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-02-09 11:36:00.202 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
+this might be the first time the world
+2026-02-09 18:22:41.865 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-09 18:22:41.865 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/humain-ai/ALLaM-7B-Instruct-preview/n300/functional/eval.log
+++ b/models/humain-ai/ALLaM-7B-Instruct-preview/n300/functional/eval.log
@@ -1,67 +1,67 @@
-TT_VISIBLE_DEVICES=0 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto python eval.py models/humain-ai/ALLaM-7B-Instruct-preview/n300/functional/model.py --model humain-ai/ALLaM-7B-Instruct-preview --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100
-2026-02-09 11:36:27.527 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+TT_VISIBLE_DEVICES=1 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto PYTHONUNBUFFERED=1 python eval.py models/humain-ai/ALLaM-7B-Instruct-preview/n300/functional/model.py --model humain-ai/ALLaM-7B-Instruct-preview --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 4096
+2026-02-09 18:23:06.745 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
 /proj_sw/user_dev/moconnor/tt-metal/python_env/lib/python3.10/site-packages/transformers/utils/hub.py:111: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
   warnings.warn(
 Loading model module: /localdev/moconnor/ttnn_models/models/humain-ai/ALLaM-7B-Instruct-preview/n300/functional/model.py
 Loading HuggingFace tokenizer...
 Loading HuggingFace reference model on CPU...
-Loading checkpoint shards:   0%|          | 0/3 [00:00<?, ?it/s]Loading checkpoint shards:  33%|███▎      | 1/3 [00:00<00:01,  1.33it/s]Loading checkpoint shards:  67%|██████▋   | 2/3 [00:01<00:00,  1.35it/s]Loading checkpoint shards: 100%|██████████| 3/3 [00:02<00:00,  1.48it/s]Loading checkpoint shards: 100%|██████████| 3/3 [00:02<00:00,  1.44it/s]
-2026-02-09 11:40:41.387 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 11:40:41.395 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-02-09 11:40:41.398 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 11:40:41.425 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 11:40:41.447 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 11:40:41.532 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 11:40:41.550 | info     |             UMD | Opening local chip ids/PCIe ids: {0}/[0] and remote chip ids {1} (cluster.cpp:186)
-2026-02-09 11:40:41.550 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-02-09 11:40:41.550 | info     |             UMD | KMD version: 2.4.0 (cluster.cpp:164)
-2026-02-09 11:40:41.553 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-02-09 11:40:41.558 | info     |             UMD | Mapped hugepage 0x340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 11:40:41.561 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 11:40:41.619 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto (metal_context.cpp:858)
-2026-02-09 11:40:41.620 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=2, n_phys=2, log_deg_hist={1:2}, phys_deg_hist={1:2} (topology_mapper_utils.cpp:171)
-2026-02-09 11:40:41.620 | info     |          Fabric | Fast-path path-graph mapping succeeded for mesh 0 (topology_mapper_utils.cpp:401)
-2026-02-09 11:40:41.627 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
-2026-02-09 11:40:41.627 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-02-09 11:40:41.637 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 11:40:41.640 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 11:40:41.784 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:748)
-2026-02-09 11:40:41.784 | info     |           Metal | Dispatch on FabricConfig::FABRIC_1D with 1 Command Queues
- (device_manager.cpp:331)
-2026-02-09 11:40:41.788 | info     |           Metal | Initializing Fabric (device_manager.cpp:409)
-2026-02-09 11:40:41.886 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:392)
-2026-02-09 11:40:41.889 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:392)
-2026-02-09 11:40:41.889 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_1D (device_manager.cpp:414)
-2026-02-09 11:40:42.100 | info     |           Metal | Command Queue initialized on Device 1 (device_manager.cpp:510)
-2026-02-09 11:43:56.322 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/5219050073499734444/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:43:56.588 | warning  |    BuildKernels | Compute kernel 'tilize/3556198843499250409/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:43:56.734 | warning  |    BuildKernels | Compute kernel 'layernorm/13312309764502615647/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:43:57.019 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/1948898487425784671/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:43:57.371 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/4953326823212577371/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:43:57.371 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/9827946993736593312/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:43:57.741 | warning  |    BuildKernels | Compute kernel 'sdpa/16441295433254224208/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:43:58.212 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/17960893060191621758/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:43:58.376 | warning  |    BuildKernels | Compute kernel 'line_reduction/17263434165235172306/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:43:58.866 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/6157833423458501140/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:43:59.391 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/345747529090623222/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:43:59.627 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/9020054515723685584/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:44:00.148 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/2721043012078536798/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:44:00.615 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/3491980988751689818/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:44:00.873 | warning  |    BuildKernels | Compute kernel 'update_cache/846803462354870350/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:44:01.023 | warning  |    BuildKernels | Compute kernel 'sdpa_flash_decode/13644955033845445065/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:44:01.396 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/12482852762311938027/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:44:01.853 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/7502336892383803170/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:44:02.232 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/8920298209850939216/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-02-09 11:44:02.453 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/14027415175706824938/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+Loading checkpoint shards:   0%|          | 0/3 [00:00<?, ?it/s]Loading checkpoint shards:  33%|███▎      | 1/3 [00:00<00:01,  1.24it/s]Loading checkpoint shards:  67%|██████▋   | 2/3 [00:01<00:00,  1.34it/s]Loading checkpoint shards: 100%|██████████| 3/3 [00:02<00:00,  1.52it/s]Loading checkpoint shards: 100%|██████████| 3/3 [00:02<00:00,  1.46it/s]
 Generating reference tokens...
 Opening device (1x2)...
+2026-02-09 18:26:33.121 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 18:26:33.131 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-09 18:26:33.134 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 18:26:33.162 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-09 18:26:33.184 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 18:26:33.274 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x204 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-09 18:26:33.293 | info     |             UMD | Opening local chip ids/PCIe ids: {0}/[1] and remote chip ids {1} (cluster.cpp:186)
+2026-02-09 18:26:33.293 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-09 18:26:33.293 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-09 18:26:33.296 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-09 18:26:33.300 | info     |             UMD | Mapped hugepage 0x440000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 18:26:33.304 | info     |             UMD | Mapped hugepage 0x400000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-09 18:26:33.384 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto (metal_context.cpp:858)
+2026-02-09 18:26:33.385 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=2, n_phys=2, log_deg_hist={1:2}, phys_deg_hist={1:2} (topology_mapper_utils.cpp:171)
+2026-02-09 18:26:33.385 | info     |          Fabric | Fast-path path-graph mapping succeeded for mesh 0 (topology_mapper_utils.cpp:401)
+2026-02-09 18:26:33.392 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-09 18:26:33.392 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-09 18:26:33.398 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 18:26:33.401 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-09 18:26:33.545 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:748)
+2026-02-09 18:26:33.545 | info     |           Metal | Dispatch on FabricConfig::FABRIC_1D with 1 Command Queues
+ (device_manager.cpp:331)
+2026-02-09 18:26:33.548 | info     |           Metal | Initializing Fabric (device_manager.cpp:409)
+2026-02-09 18:26:33.641 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:392)
+2026-02-09 18:26:33.645 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:392)
+2026-02-09 18:26:33.645 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_1D (device_manager.cpp:414)
+2026-02-09 18:26:33.821 | info     |           Metal | Command Queue initialized on Device 1 (device_manager.cpp:510)
 Loading ttnn model...
   Loading embeddings...
   Computing RoPE cache...
   Loading 32 layers...
 Running teacher-forcing eval (100 tokens)...
+2026-02-09 18:29:43.519 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/5219050073499734444/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:29:43.655 | warning  |    BuildKernels | Compute kernel 'tilize/3556198843499250409/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:29:43.757 | warning  |    BuildKernels | Compute kernel 'layernorm/13312309764502615647/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:29:43.901 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/1948898487425784671/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:29:44.151 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/9827946993736593312/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:29:44.153 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/4953326823212577371/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:29:44.311 | warning  |    BuildKernels | Compute kernel 'sdpa/16441295433254224208/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:29:44.487 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/17960893060191621758/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:29:44.601 | warning  |    BuildKernels | Compute kernel 'line_reduction/17263434165235172306/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:29:44.903 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/6157833423458501140/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:29:45.245 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/345747529090623222/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:29:45.409 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/9020054515723685584/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:29:45.901 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/2721043012078536798/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:29:46.227 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/3491980988751689818/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:29:46.386 | warning  |    BuildKernels | Compute kernel 'update_cache/13094027235434668704/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:29:46.488 | warning  |    BuildKernels | Compute kernel 'sdpa_flash_decode/1930860853784749243/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:29:46.726 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/12482852762311938027/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:29:47.035 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/7502336892383803170/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:29:47.282 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/8920298209850939216/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-09 18:29:47.442 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/14027415175706824938/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
 Top-1 accuracy: 97.00% (0.9700)
 Top-5 accuracy: 100.00% (1.0000)
-2026-02-09 11:44:17.294 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-02-09 11:44:17.294 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
+2026-02-09 18:30:01.562 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-09 18:30:01.562 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/humain-ai/ALLaM-7B-Instruct-preview/n300/functional/model.py
+++ b/models/humain-ai/ALLaM-7B-Instruct-preview/n300/functional/model.py
@@ -17,9 +17,9 @@ from transformers.modeling_outputs import CausalLMOutputWithPast
 
 
 TILE_SIZE = 32
+PAGED_BLOCK_SIZE = 64
 WEIGHT_DTYPE = ttnn.bfloat8_b
 WEIGHT_LAYOUT = ttnn.TILE_LAYOUT
-MAX_CACHE_SEQ_LEN = 256
 MESH_SHAPE = (1, 2)
 MESH_TOPOLOGY = ttnn.Topology.Linear
 MESH_NUM_LINKS = 1
@@ -80,6 +80,14 @@ class ModelConfig:
             hf_config.hidden_act,
             hf_config.tie_word_embeddings,
         )
+
+
+@dataclass
+class PagedAttentionConfig:
+    """Paged KV cache configuration."""
+
+    block_size: int
+    max_num_blocks: int
 
 
 @dataclass
@@ -172,7 +180,8 @@ class Attention:
         cos_cache: ttnn.Tensor,
         sin_cache: ttnn.Tensor,
         parallel: ParallelConfig,
-        max_seq_len: int,
+        paged_attention_config: PagedAttentionConfig,
+        page_table: ttnn.Tensor,
     ):
         self.parallel = parallel
         self.n_heads = config.num_attention_heads
@@ -182,6 +191,8 @@ class Attention:
         self.head_dim = config.head_dim
         self.hidden_size = config.hidden_size
         self.scale = 1.0 / math.sqrt(self.head_dim)
+        self.paged_attention_config = paged_attention_config
+        self.page_table = page_table
 
         self.cos_cache = cos_cache
         self.sin_cache = sin_cache
@@ -192,7 +203,12 @@ class Attention:
         self.v_proj = self._load_weight(state_dict[f"{p}v_proj.weight"], parallel.shard_width_mapper)
         self.o_proj = self._load_weight(state_dict[f"{p}o_proj.weight"], parallel.shard_height_mapper)
 
-        cache_shape = (TILE_SIZE, self.n_kv_heads, max_seq_len, self.head_dim)
+        cache_shape = (
+            self.paged_attention_config.max_num_blocks,
+            self.n_kv_heads,
+            self.paged_attention_config.block_size,
+            self.head_dim,
+        )
         self.k_cache = ttnn.as_tensor(
             torch.zeros(cache_shape, dtype=torch.bfloat16),
             dtype=ttnn.bfloat16,
@@ -255,23 +271,8 @@ class Attention:
             q = ttnn.experimental.rotary_embedding(q, cos, sin)
             k = ttnn.experimental.rotary_embedding(k, cos, sin)
 
-            # Shard KV for fill_cache to avoid interleaved grid-size limits at long prefill lengths.
-            grid = self.parallel.mesh_device.core_grid
-            if num_kv_heads % grid.x != 0:
-                raise ValueError("num_kv_heads must be divisible by device grid.x for sharded fill_cache")
-            shard_grid = ttnn.CoreGrid(x=grid.x, y=num_kv_heads // grid.x)
-            shard_mem_config = ttnn.create_sharded_memory_config(
-                k.shape,
-                shard_grid,
-                ttnn.ShardStrategy.HEIGHT,
-                ttnn.ShardOrientation.ROW_MAJOR,
-            )
-            k_sharded = ttnn.to_memory_config(k, shard_mem_config)
-            v_sharded = ttnn.to_memory_config(v, shard_mem_config)
-            ttnn.fill_cache(self.k_cache, k_sharded, batch_idx=0)
-            ttnn.fill_cache(self.v_cache, v_sharded, batch_idx=0)
-            ttnn.deallocate(k_sharded)
-            ttnn.deallocate(v_sharded)
+            ttnn.experimental.paged_fill_cache(self.k_cache, k, self.page_table, batch_idx=0)
+            ttnn.experimental.paged_fill_cache(self.v_cache, v, self.page_table, batch_idx=0)
 
             attn_out = ttnn.transformer.scaled_dot_product_attention(
                 q, k, v, is_causal=True, scale=self.scale
@@ -305,11 +306,26 @@ class Attention:
             k = ttnn.experimental.rotary_embedding(k, self.cos_cache, self.sin_cache, start_pos)
             k = ttnn.reshape(k, (1, k_batch, k_heads, self.head_dim), (1, k_batch, k_heads, self.head_dim))
 
-            ttnn.experimental.paged_update_cache(self.k_cache, k, update_idxs_tensor=cur_pos_tensor)
-            ttnn.experimental.paged_update_cache(self.v_cache, v, update_idxs_tensor=cur_pos_tensor)
+            ttnn.experimental.paged_update_cache(
+                self.k_cache,
+                k,
+                update_idxs_tensor=cur_pos_tensor,
+                page_table=self.page_table,
+            )
+            ttnn.experimental.paged_update_cache(
+                self.v_cache,
+                v,
+                update_idxs_tensor=cur_pos_tensor,
+                page_table=self.page_table,
+            )
 
-            attn_out = ttnn.transformer.scaled_dot_product_attention_decode(
-                q, self.k_cache, self.v_cache, cur_pos_tensor=cur_pos_tensor, scale=self.scale
+            attn_out = ttnn.transformer.paged_scaled_dot_product_attention_decode(
+                q,
+                self.k_cache,
+                self.v_cache,
+                page_table_tensor=self.page_table,
+                cur_pos_tensor=cur_pos_tensor,
+                scale=self.scale,
             )
             attn_out = ttnn.transpose(attn_out, 1, 2)
             attn_out = ttnn.experimental.nlp_concat_heads(attn_out, memory_config=ttnn.DRAM_MEMORY_CONFIG)
@@ -364,12 +380,22 @@ class DecoderLayer:
         cos_cache: ttnn.Tensor,
         sin_cache: ttnn.Tensor,
         parallel: ParallelConfig,
-        max_seq_len: int,
+        paged_attention_config: PagedAttentionConfig,
+        page_table: ttnn.Tensor,
     ):
         p = f"model.layers.{layer_idx}."
         self.attn_norm = RMSNorm(state_dict[f"{p}input_layernorm.weight"], config.rms_norm_eps, parallel)
         self.ffn_norm = RMSNorm(state_dict[f"{p}post_attention_layernorm.weight"], config.rms_norm_eps, parallel)
-        self.attn = Attention(config, layer_idx, state_dict, cos_cache, sin_cache, parallel, max_seq_len)
+        self.attn = Attention(
+            config,
+            layer_idx,
+            state_dict,
+            cos_cache,
+            sin_cache,
+            parallel,
+            paged_attention_config,
+            page_table,
+        )
         self.mlp = MLP(layer_idx, state_dict, parallel)
 
     def __call__(
@@ -390,14 +416,23 @@ class TtnnALLaMForCausalLM(torch.nn.Module, GenerationMixin):
     HuggingFace `generate()`-compatible via `GenerationMixin`.
     """
 
-    def __init__(self, hf_model, tt_device, max_seq_len: int = 2048):
+    def __init__(self, hf_model, tt_device, max_seq_len: Optional[int] = None):
         super().__init__()
 
         self.tt_device = tt_device
         self.hf_config = hf_model.config
         self.tt_config = ModelConfig.from_hf(hf_model.config)
+        if max_seq_len is None:
+            max_seq_len = getattr(self.hf_config, "max_position_embeddings", None)
+            if max_seq_len is None:
+                raise ValueError("max_seq_len is required when max_position_embeddings is missing")
+        else:
+            max_position_embeddings = getattr(self.hf_config, "max_position_embeddings", None)
+            if max_position_embeddings is not None and max_seq_len > max_position_embeddings:
+                raise ValueError(
+                    f"max_seq_len {max_seq_len} exceeds max_position_embeddings {max_position_embeddings}"
+                )
         self.max_seq_len = max_seq_len
-        self.cache_seq_len = min(max_seq_len, MAX_CACHE_SEQ_LEN)
         self._pos = 0
 
         if self.tt_config.hidden_act != "silu":
@@ -443,7 +478,7 @@ class TtnnALLaMForCausalLM(torch.nn.Module, GenerationMixin):
         )
 
         print("  Computing RoPE cache...")
-        cos, sin = compute_rope_cache(self.tt_config, self.cache_seq_len)
+        cos, sin = compute_rope_cache(self.tt_config, self.max_seq_len)
         self.cos_cache = ttnn.as_tensor(
             cos,
             dtype=ttnn.bfloat16,
@@ -461,9 +496,30 @@ class TtnnALLaMForCausalLM(torch.nn.Module, GenerationMixin):
             mesh_mapper=self.parallel.replicate_mapper,
         )
 
+        max_num_blocks = math.ceil(self.max_seq_len / PAGED_BLOCK_SIZE)
+        self.paged_attention_config = PagedAttentionConfig(PAGED_BLOCK_SIZE, max_num_blocks)
+        page_table = torch.arange(max_num_blocks, dtype=torch.int32).repeat(TILE_SIZE, 1)
+        self.page_table = ttnn.as_tensor(
+            page_table,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+
         print(f"  Loading {self.tt_config.num_hidden_layers} layers...")
         self.layers = [
-            DecoderLayer(self.tt_config, i, state_dict, self.cos_cache, self.sin_cache, self.parallel, self.cache_seq_len)
+            DecoderLayer(
+                self.tt_config,
+                i,
+                state_dict,
+                self.cos_cache,
+                self.sin_cache,
+                self.parallel,
+                self.paged_attention_config,
+                self.page_table,
+            )
             for i in range(self.tt_config.num_hidden_layers)
         ]
 
@@ -515,16 +571,18 @@ class TtnnALLaMForCausalLM(torch.nn.Module, GenerationMixin):
             assert seq_len == 1, "Only 1-token decode supported when using cache"
 
         start_pos = self._pos
-        if start_pos + seq_len > self.cache_seq_len:
+        if start_pos + seq_len > self.max_seq_len:
             raise ValueError(
-                f"sequence length {start_pos + seq_len} exceeds cache length {self.cache_seq_len}; "
-                "increase MAX_CACHE_SEQ_LEN if memory allows"
+                f"sequence length {start_pos + seq_len} exceeds max_seq_len {self.max_seq_len}; "
+                "increase max_seq_len if memory allows"
             )
 
         cur_pos_tensor = None
         if seq_len == 1:
+            cur_pos = torch.full((TILE_SIZE,), -1, dtype=torch.int32)
+            cur_pos[0] = start_pos
             cur_pos_tensor = ttnn.from_torch(
-                torch.full((TILE_SIZE,), start_pos, dtype=torch.int32),
+                cur_pos,
                 dtype=ttnn.int32,
                 device=self.tt_device,
                 mesh_mapper=self.parallel.replicate_mapper,
@@ -562,6 +620,6 @@ class TtnnALLaMForCausalLM(torch.nn.Module, GenerationMixin):
         )
 
 
-def build_model(hf_model, tt_device, max_seq_len: int = 2048) -> TtnnALLaMForCausalLM:
+def build_model(hf_model, tt_device, max_seq_len: Optional[int] = None) -> TtnnALLaMForCausalLM:
     """Build the ttnn model from a HuggingFace reference model."""
     return TtnnALLaMForCausalLM(hf_model, tt_device, max_seq_len)


### PR DESCRIPTION
Closes #98.\n\n## Summary\n- Switch ALLaM n300 attention to paged KV cache + paged attention decode, sized to max_seq_len.\n- Raise ALLaM n300 max_seq_len from 256 to 4096.\n- Refresh demo/eval logs and MODELS.md entry for n300.\n\n## Testing\n- python demo.py models/humain-ai/ALLaM-7B-Instruct-preview/n300/functional/model.py --max_seq_len 4096 --max-new-tokens 8\n- python eval.py models/humain-ai/ALLaM-7B-Instruct-preview/n300/functional/model.py --model humain-ai/ALLaM-7B-Instruct-preview --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 4096