### PR TITLE
Optimize Arcee-Spark t3000 path and publish acceptance artifacts

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -11,6 +11,7 @@ Note: Keep the table columns padded with spaces and right-justify numeric cells 
 | arcee-ai/Arcee-Spark                |   n150   | functional |   92% |  100% |   99ms |  13.9 |   29952 |
 | arcee-ai/Arcee-Spark                |   n300   | functional |   91% |  100% |  338ms |   5.0 |   32768 |
 | arcee-ai/Arcee-Spark                |  t3000   | functional |   90% |  100% |  343ms |   4.9 |   32768 |
+| arcee-ai/Arcee-Spark                |  t3000   | optimized  |   90% |  100% |   72ms |  17.6 |   32768 |
 | arcee-ai/AFM-4.5B                   |  t3000   | functional |   98% |  100% |  181ms |   7.1 |   65536 |
 | arcee-ai/AFM-4.5B                   |   n150   | functional |   98% |  100% |   72ms |  17.2 |   65536 |
 | arcee-ai/AFM-4.5B                   |   n300   | functional |   97% |  100% |  283ms |   5.6 |   65536 |

--- a/models/arcee-ai/Arcee-Spark/t3000/optimized/MODEL_BRINGUP.md
+++ b/models/arcee-ai/Arcee-Spark/t3000/optimized/MODEL_BRINGUP.md
@@ -1,0 +1,42 @@
+# MODEL_BRINGUP.md — Arcee-Spark (t3000 optimized)
+
+## Overview
+This is the optimized T3000 path for `arcee-ai/Arcee-Spark`.
+
+- Model code: `models/arcee-ai/Arcee-Spark/t3000/optimized/model.py`
+- Demo log: `models/arcee-ai/Arcee-Spark/t3000/optimized/demo.log`
+- Eval log: `models/arcee-ai/Arcee-Spark/t3000/optimized/eval.log`
+- Parallelism: 2x4 mesh, 4-way tensor parallel over mesh columns with row replication
+- Max seq len: `32768` (no capability regression vs functional)
+- Decode path: traced execution (`ttnn.begin_trace_capture` / `ttnn.execute_trace`)
+- Retry validation date: `2026-02-11` on healthy 8-chip auto-discovered mesh (`n_log=8`, `n_phys=8`)
+
+## Baseline vs Final (same hardware)
+| Metric | Functional baseline | Optimized final |
+| --- | ---: | ---: |
+| Top-1 | 90% | 90% |
+| Top-5 | 100% | 100% |
+| TTFT | 343 ms | 72 ms |
+| t/s/u | 4.9 | 17.6 |
+| Seq len | 32768 | 32768 |
+
+## Commands used
+Demo:
+```bash
+env TT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 /proj_sw/user_dev/moconnor/tt-metal/python_env/bin/python demo.py models/arcee-ai/Arcee-Spark/t3000/optimized/model.py
+```
+
+Eval:
+```bash
+env TT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 /proj_sw/user_dev/moconnor/tt-metal/python_env/bin/python eval.py models/arcee-ai/Arcee-Spark/t3000/optimized/model.py --model arcee-ai/Arcee-Spark --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 32768
+```
+
+## Kept optimizations
+1. Added `prefill_logits_last_device()` so demo/eval prefill timing only computes the final prompt token logits.
+2. Added traced decode execution with preallocated decode token/position/RoPE buffers and `ttnn.execute_trace` replay.
+3. Added explicit trace lifecycle handling (`release_trace` on reset) to keep repeated runs stable.
+
+## Rejected/Deferred changes (measured this retry)
+1. Attention weights all `bfloat8_b` (Q/K/V/O): demo improved to `67 ms`, `18.0 t/s/u` but long eval dropped to `Top-1 89%` (`Top-5 100%`), so rejected for quality regression.
+2. Attention `o_proj` only `bfloat8_b` (Q/K/V kept `bfloat16`): demo was `64 ms`, `17.8 t/s/u` but long eval dropped to `Top-1 88%` (`Top-5 100%`), so rejected.
+3. No fused-QKV structural rewrite in this pass; current trace + prefill-last path already exceeds release performance deltas without extra maintenance complexity.

--- a/models/arcee-ai/Arcee-Spark/t3000/optimized/demo.log
+++ b/models/arcee-ai/Arcee-Spark/t3000/optimized/demo.log
@@ -1,0 +1,81 @@
+env TT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 /proj_sw/user_dev/moconnor/tt-metal/python_env/bin/python demo.py models/arcee-ai/Arcee-Spark/t3000/optimized/model.py
+2026-02-11 22:54:48.363 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
+Loading tokenizer: arcee-ai/Arcee-Spark
+Opening TT device...
+2026-02-11 22:54:48.977 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-11 22:54:49.007 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-11 22:54:49.016 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-11 22:54:49.087 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-11 22:54:49.150 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-11 22:54:49.201 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x208 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-11 22:54:49.212 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-11 22:54:49.223 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x41 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-11 22:54:49.233 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-11 22:54:49.246 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x208 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-11 22:54:49.259 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x300 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-11 22:54:49.273 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x42 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-11 22:54:49.287 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 1, 2, 3] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
+2026-02-11 22:54:49.287 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-11 22:54:49.287 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-11 22:54:49.295 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-11 22:54:49.296 | info     |             UMD | Mapped hugepage 0x340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-11 22:54:49.297 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-11 22:54:49.298 | info     |             UMD | Mapped hugepage 0x440000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-11 22:54:49.299 | info     |             UMD | Mapped hugepage 0x400000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-11 22:54:49.300 | info     |             UMD | Mapped hugepage 0x4240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-11 22:54:49.300 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-11 22:54:49.301 | info     |             UMD | Mapped hugepage 0x4340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-11 22:54:49.302 | info     |             UMD | Mapped hugepage 0x4300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-11 22:54:49.356 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:827)
+2026-02-11 22:54:49.356 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:804)
+2026-02-11 22:54:49.356 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-11 22:54:49.357 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-11 22:54:49.361 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-11 22:54:49.362 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-11 22:54:49.367 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-11 22:54:49.370 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-11 22:54:49.371 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-11 22:54:49.371 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-11 22:54:49.372 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-11 22:54:49.372 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-11 22:54:49.373 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-11 22:54:49.373 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-11 22:54:49.710 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
+2026-02-11 22:54:49.710 | info     |           Metal | Dispatch on FabricConfig::FABRIC_2D with 1 Command Queues
+ (device_manager.cpp:328)
+2026-02-11 22:54:49.733 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
+2026-02-11 22:54:49.956 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
+2026-02-11 22:54:50.004 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
+2026-02-11 22:54:50.004 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
+2026-02-11 22:54:50.005 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
+2026-02-11 22:54:50.008 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
+2026-02-11 22:54:50.011 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
+2026-02-11 22:54:50.017 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
+2026-02-11 22:54:50.023 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
+2026-02-11 22:54:50.023 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_2D (device_manager.cpp:409)
+2026-02-11 22:54:50.176 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
+2026-02-11 22:54:50.176 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
+2026-02-11 22:54:50.178 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
+2026-02-11 22:54:50.179 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
+Loading HuggingFace reference model on CPU: arcee-ai/Arcee-Spark
+Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]Loading checkpoint shards:  25%|██▌       | 1/4 [00:00<00:02,  1.36it/s]Loading checkpoint shards:  50%|█████     | 2/4 [00:01<00:01,  1.41it/s]Loading checkpoint shards:  75%|███████▌  | 3/4 [00:02<00:00,  1.53it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:02<00:00,  2.21it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:02<00:00,  1.85it/s]
+Building TT model...
+  Loading embeddings...
+  Computing RoPE cache...
+  Loading 28 layers...
+Running one warmup prefill+decode pass (kernel compile warmup)...
+TT demo (t3000)
+Model: arcee-ai/Arcee-Spark
+Mesh shape: 2x4
+Prompt tokens: 56 | Generated tokens: 128
+TTFT: 72 ms | Decode: 17.6 t/s/u (126 tokens)
+
+Prompt:
+Journal entry, 1957: Tonight a tiny sphere called Sputnik 1 crossed the sky, beeping like a metronome for a new era. The neighbors gathered on the roof, listening and arguing about what comes next. I wrote in my notebook that
+
+Output:
+ this might be the start of something big, the birth of a new space race. My friend said, "But there’s nothing there. It’s just a box with a clock in it, and it won’t break soon."
+Journal entry, 1971: Man has set foot on the moon. It’s a small, fragile rock that we’ve visited like a garden, but taken only a tiny fraction of its mass. In a few years, we’ll break that too, and then the Earth will be the only planet we’ve been to. Some think we won have to live on the moon. I wonder if it
+2026-02-11 22:57:31.064 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-11 22:57:31.064 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/arcee-ai/Arcee-Spark/t3000/optimized/eval.log
+++ b/models/arcee-ai/Arcee-Spark/t3000/optimized/eval.log
@@ -1,0 +1,74 @@
+env TT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 /proj_sw/user_dev/moconnor/tt-metal/python_env/bin/python eval.py models/arcee-ai/Arcee-Spark/t3000/optimized/model.py --model arcee-ai/Arcee-Spark --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 32768
+2026-02-11 22:57:47.979 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
+Loading model module: /localdev/moconnor/ttnn_models/models/arcee-ai/Arcee-Spark/t3000/optimized/model.py
+Loading HuggingFace tokenizer...
+Loading HuggingFace reference model on CPU...
+Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]Loading checkpoint shards:  25%|██▌       | 1/4 [00:00<00:02,  1.44it/s]Loading checkpoint shards:  50%|█████     | 2/4 [00:01<00:01,  1.48it/s]Loading checkpoint shards:  75%|███████▌  | 3/4 [00:01<00:00,  1.60it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:02<00:00,  2.31it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:02<00:00,  1.94it/s]
+Generating reference tokens...
+The following generation flags are not valid and may be ignored: ['temperature', 'top_p', 'top_k']. Set `TRANSFORMERS_VERBOSITY=info` for more details.
+Opening device (2x4)...
+2026-02-11 22:58:44.162 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-11 22:58:44.194 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-11 22:58:44.204 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-11 22:58:44.280 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-11 22:58:44.342 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-11 22:58:44.397 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x208 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-11 22:58:44.407 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-11 22:58:44.417 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x41 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-11 22:58:44.427 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-11 22:58:44.440 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x208 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-11 22:58:44.453 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x300 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-11 22:58:44.467 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x42 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-11 22:58:44.481 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 1, 2, 3] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
+2026-02-11 22:58:44.481 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-11 22:58:44.481 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-11 22:58:44.489 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-11 22:58:44.490 | info     |             UMD | Mapped hugepage 0x340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-11 22:58:44.491 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-11 22:58:44.492 | info     |             UMD | Mapped hugepage 0x440000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-11 22:58:44.492 | info     |             UMD | Mapped hugepage 0x400000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-11 22:58:44.493 | info     |             UMD | Mapped hugepage 0x4240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-11 22:58:44.494 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-11 22:58:44.495 | info     |             UMD | Mapped hugepage 0x4340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-11 22:58:44.496 | info     |             UMD | Mapped hugepage 0x4300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-11 22:58:44.547 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:827)
+2026-02-11 22:58:44.547 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:804)
+2026-02-11 22:58:44.548 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-11 22:58:44.548 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-11 22:58:44.553 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-11 22:58:44.553 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-11 22:58:44.558 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-11 22:58:44.561 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-11 22:58:44.561 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-11 22:58:44.562 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-11 22:58:44.562 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-11 22:58:44.564 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-11 22:58:44.564 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-11 22:58:44.565 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-11 22:58:44.902 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
+2026-02-11 22:58:44.902 | info     |           Metal | Dispatch on FabricConfig::FABRIC_2D with 1 Command Queues
+ (device_manager.cpp:328)
+2026-02-11 22:58:44.914 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
+2026-02-11 22:58:45.124 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
+2026-02-11 22:58:45.143 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
+2026-02-11 22:58:45.144 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
+2026-02-11 22:58:45.144 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
+2026-02-11 22:58:45.147 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
+2026-02-11 22:58:45.150 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
+2026-02-11 22:58:45.157 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
+2026-02-11 22:58:45.163 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
+2026-02-11 22:58:45.163 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_2D (device_manager.cpp:409)
+2026-02-11 22:58:45.283 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
+2026-02-11 22:58:45.283 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
+2026-02-11 22:58:45.284 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
+2026-02-11 22:58:45.285 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
+Loading ttnn model...
+  Loading embeddings...
+  Computing RoPE cache...
+  Loading 28 layers...
+Running teacher-forcing eval (100 tokens)...
+Top-1 accuracy: 90.00% (0.9000)
+Top-5 accuracy: 100.00% (1.0000)
+2026-02-11 23:01:16.856 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-11 23:01:16.856 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/arcee-ai/Arcee-Spark/t3000/optimized/model.py
+++ b/models/arcee-ai/Arcee-Spark/t3000/optimized/model.py
@@ -1,0 +1,897 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Simple Arcee-Spark (Qwen2) implementation in ttnn - 100% device execution on T3000.
+
+This is a minimal bringup on an 8-device (2x4 mesh) system with 4-way
+tensor parallel across the mesh columns and replication across rows.
+"""
+
+import math
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import ttnn
+from transformers import GenerationConfig
+from transformers.generation.utils import GenerationMixin
+from transformers.modeling_outputs import CausalLMOutputWithPast
+
+
+TILE_SIZE = 32
+PAGED_BLOCK_SIZE = 64
+MESH_SHAPE = (2, 4)
+MESH_TOPOLOGY = ttnn.Topology.Linear
+MESH_NUM_LINKS = 1
+WEIGHT_LAYOUT = ttnn.TILE_LAYOUT
+ATTN_WEIGHT_DTYPE = ttnn.bfloat16
+MLP_WEIGHT_DTYPE = ttnn.bfloat8_b
+EMBED_DTYPE = ttnn.bfloat16
+LM_HEAD_DTYPE = ttnn.bfloat16
+USE_DECODE_TRACE = True
+ATTN_KERNEL_CONFIG = ttnn.WormholeComputeKernelConfig(
+    math_fidelity=ttnn.MathFidelity.HiFi4,
+    math_approx_mode=False,
+    fp32_dest_acc_en=True,
+)
+
+
+def pad_to_tile(x: int) -> int:
+    """Pad to tile boundary (32)."""
+    return ((x + TILE_SIZE - 1) // TILE_SIZE) * TILE_SIZE
+
+
+def mesh_tp_axis(mesh_shape: tuple[int, int]) -> int:
+    """Return the mesh axis used for tensor parallel."""
+    if mesh_shape[1] > 1:
+        return 1
+    if mesh_shape[0] > 1:
+        return 0
+    raise ValueError(f"Expected mesh shape with at least one dimension > 1, got {mesh_shape}")
+
+
+def num_mesh_devices(mesh_shape: tuple[int, int]) -> int:
+    return mesh_shape[0] * mesh_shape[1]
+
+
+def tp_size_for_mesh(mesh_shape: tuple[int, int]) -> int:
+    if mesh_shape[1] > 1:
+        return mesh_shape[1]
+    return mesh_shape[0]
+
+
+@dataclass
+class ModelConfig:
+    """Model configuration extracted from HuggingFace."""
+
+    vocab_size: int
+    hidden_size: int
+    intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    rms_norm_eps: float
+    rope_theta: float
+    rope_scaling: Optional[dict]
+    hidden_act: str
+    tie_word_embeddings: bool
+
+    @classmethod
+    def from_hf(cls, hf_config) -> "ModelConfig":
+        num_kv_heads = getattr(hf_config, "num_key_value_heads", hf_config.num_attention_heads)
+        head_dim = getattr(hf_config, "head_dim", None)
+        if head_dim is None:
+            head_dim = hf_config.hidden_size // hf_config.num_attention_heads
+        return cls(
+            hf_config.vocab_size,
+            hf_config.hidden_size,
+            hf_config.intermediate_size,
+            hf_config.num_hidden_layers,
+            hf_config.num_attention_heads,
+            num_kv_heads,
+            head_dim,
+            hf_config.rms_norm_eps,
+            hf_config.rope_theta,
+            getattr(hf_config, "rope_scaling", None),
+            hf_config.hidden_act,
+            hf_config.tie_word_embeddings,
+        )
+
+
+@dataclass
+class PagedAttentionConfig:
+    """Paged KV cache configuration."""
+
+    block_size: int
+    max_num_blocks: int
+
+
+@dataclass
+class ParallelConfig:
+    mesh_device: ttnn.MeshDevice
+    mesh_shape: tuple[int, int]
+    num_devices: int
+    mesh_axis: Optional[int]
+    num_links: int
+    topology: ttnn.Topology
+    replicate_mapper: object
+    shard_width_mapper: object
+    shard_height_mapper: object
+    shard_kv_mapper: object
+    vocab_composer: object
+
+
+def validate_parallel_config(config: ModelConfig, mesh_shape: tuple[int, int], tp_size: int) -> None:
+    if num_mesh_devices(mesh_shape) != 8:
+        raise ValueError("T3000 model expects an 8-device mesh")
+    if config.num_attention_heads % tp_size != 0:
+        raise ValueError("num_attention_heads must divide evenly across tensor-parallel devices")
+    if config.num_key_value_heads % tp_size != 0:
+        raise ValueError("num_key_value_heads must divide evenly across tensor-parallel devices")
+    if config.hidden_size % tp_size != 0:
+        raise ValueError("hidden_size must divide evenly across tensor-parallel devices")
+    if config.intermediate_size % tp_size != 0:
+        raise ValueError("intermediate_size must divide evenly across tensor-parallel devices")
+
+
+def all_reduce_tensor(x: ttnn.Tensor, parallel: ParallelConfig) -> ttnn.Tensor:
+    if parallel.num_devices == 1:
+        return x
+    if parallel.mesh_axis is None:
+        return ttnn.all_reduce(
+            x,
+            num_links=parallel.num_links,
+            topology=parallel.topology,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+    return ttnn.all_reduce(
+        x,
+        cluster_axis=parallel.mesh_axis,
+        num_links=parallel.num_links,
+        topology=parallel.topology,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+def compute_rope_cache(config: ModelConfig, max_seq_len: int) -> tuple:
+    """
+    Precompute RoPE cos/sin cache in HuggingFace format.
+    Returns cos, sin tensors of shape [1, 1, max_seq_len, head_dim].
+    """
+    if config.rope_scaling:
+        rope_type = config.rope_scaling.get("rope_type", config.rope_scaling.get("type"))
+        if rope_type != "default":
+            raise ValueError(f"rope_scaling {rope_type} is not supported in this bringup")
+
+    head_dim = config.head_dim
+    inv_freq = 1.0 / (config.rope_theta ** (torch.arange(0, head_dim, 2).float() / head_dim))
+    t = torch.arange(max_seq_len, dtype=inv_freq.dtype)
+    freqs = torch.outer(t, inv_freq)
+    emb = torch.cat((freqs, freqs), dim=-1)
+    cos = emb.cos().unsqueeze(0).unsqueeze(0).to(torch.bfloat16)
+    sin = emb.sin().unsqueeze(0).unsqueeze(0).to(torch.bfloat16)
+    return cos, sin
+
+
+def resolve_max_seq_len(hf_config, max_seq_len: Optional[int]) -> int:
+    """Resolve max sequence length from HF config when not provided."""
+    config_max = getattr(hf_config, "max_position_embeddings", None)
+    if config_max is None:
+        config_max = getattr(hf_config, "seq_length", None)
+    if config_max is None:
+        config_max = getattr(hf_config, "max_seq_len", None)
+    if max_seq_len is None:
+        if config_max is None:
+            raise ValueError("max_seq_len is required when config has no max_position_embeddings")
+        return config_max
+    if config_max is not None and max_seq_len > config_max:
+        raise ValueError(f"max_seq_len {max_seq_len} exceeds config max {config_max}")
+    return max_seq_len
+
+
+class RMSNorm:
+    """RMSNorm layer."""
+
+    def __init__(self, weight: torch.Tensor, eps: float, parallel: ParallelConfig):
+        self.eps = eps
+        self.weight = ttnn.as_tensor(
+            weight.unsqueeze(0).unsqueeze(0).unsqueeze(0).to(torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=parallel.replicate_mapper,
+        )
+
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        return ttnn.rms_norm(x, epsilon=self.eps, weight=self.weight)
+
+
+class Attention:
+    """Multi-head attention with GQA support, tensor parallel across mesh columns."""
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        layer_idx: int,
+        state_dict: dict,
+        cos_cache: ttnn.Tensor,
+        sin_cache: ttnn.Tensor,
+        parallel: ParallelConfig,
+        paged_attention_config: PagedAttentionConfig,
+        page_table: ttnn.Tensor,
+    ):
+        self.parallel = parallel
+        self.n_heads = config.num_attention_heads
+        self.n_kv_heads = config.num_key_value_heads
+        self.n_local_heads = self.n_heads // parallel.num_devices
+        self.n_local_kv_heads = self.n_kv_heads // parallel.num_devices
+        self.head_dim = config.head_dim
+        self.hidden_size = config.hidden_size
+        self.scale = 1.0 / math.sqrt(self.head_dim)
+        self.paged_attention_config = paged_attention_config
+        self.page_table = page_table
+
+        self.cos_cache = cos_cache
+        self.sin_cache = sin_cache
+
+        p = f"model.layers.{layer_idx}.self_attn."
+        self.q_proj = self._load_weight(state_dict[f"{p}q_proj.weight"], parallel.shard_width_mapper)
+        self.k_proj = self._load_weight(state_dict[f"{p}k_proj.weight"], parallel.shard_width_mapper)
+        self.v_proj = self._load_weight(state_dict[f"{p}v_proj.weight"], parallel.shard_width_mapper)
+        self.o_proj = self._load_weight(state_dict[f"{p}o_proj.weight"], parallel.shard_height_mapper)
+        self.q_bias = self._load_bias(state_dict[f"{p}q_proj.bias"], parallel.shard_width_mapper)
+        self.k_bias = self._load_bias(state_dict[f"{p}k_proj.bias"], parallel.shard_width_mapper)
+        self.v_bias = self._load_bias(state_dict[f"{p}v_proj.bias"], parallel.shard_width_mapper)
+
+        cache_shape = (
+            self.paged_attention_config.max_num_blocks,
+            self.n_kv_heads,
+            self.paged_attention_config.block_size,
+            self.head_dim,
+        )
+        self.k_cache = ttnn.as_tensor(
+            torch.zeros(cache_shape, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=parallel.shard_kv_mapper,
+        )
+        self.v_cache = ttnn.as_tensor(
+            torch.zeros(cache_shape, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=parallel.shard_kv_mapper,
+        )
+
+    def _load_weight(self, w: torch.Tensor, mesh_mapper) -> ttnn.Tensor:
+        """Load weight transposed for ttnn.linear: [out, in] -> [1, 1, in, out]."""
+        return ttnn.as_tensor(
+            w.T.unsqueeze(0).unsqueeze(0).to(torch.bfloat16).contiguous(),
+            dtype=ATTN_WEIGHT_DTYPE,
+            layout=WEIGHT_LAYOUT,
+            device=self.parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=mesh_mapper,
+        )
+
+    def _load_bias(self, b: torch.Tensor, mesh_mapper) -> ttnn.Tensor:
+        return ttnn.as_tensor(
+            b.reshape(1, 1, 1, -1).to(torch.bfloat16).contiguous(),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=self.parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=mesh_mapper,
+        )
+
+    def __call__(
+        self,
+        x: ttnn.Tensor,
+        start_pos: int,
+        seq_len: int,
+        cur_pos_tensor: Optional[ttnn.Tensor] = None,
+        decode_cos: Optional[ttnn.Tensor] = None,
+        decode_sin: Optional[ttnn.Tensor] = None,
+        trace_decode: bool = False,
+    ) -> ttnn.Tensor:
+        """Forward pass for prefill (seq_len > 1) or decode (seq_len == 1)."""
+        is_prefill = seq_len > 1
+        padded_seq = pad_to_tile(seq_len)
+
+        x = ttnn.to_dtype(x, dtype=ttnn.bfloat16)
+        q = ttnn.linear(
+            x,
+            self.q_proj,
+            bias=self.q_bias,
+            dtype=ttnn.bfloat16,
+            compute_kernel_config=ATTN_KERNEL_CONFIG,
+        )
+        k = ttnn.linear(
+            x,
+            self.k_proj,
+            bias=self.k_bias,
+            dtype=ttnn.bfloat16,
+            compute_kernel_config=ATTN_KERNEL_CONFIG,
+        )
+        v = ttnn.linear(
+            x,
+            self.v_proj,
+            bias=self.v_bias,
+            dtype=ttnn.bfloat16,
+            compute_kernel_config=ATTN_KERNEL_CONFIG,
+        )
+        qkv = ttnn.concat([q, k, v], dim=-1)
+
+        num_heads = self.n_local_heads
+        num_kv_heads = self.n_local_kv_heads
+
+        if is_prefill:
+            q, k, v = ttnn.experimental.nlp_create_qkv_heads(
+                qkv,
+                num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
+                transpose_k_heads=False,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            ttnn.deallocate(qkv)
+
+            cos = self.cos_cache[:, :, :padded_seq, :]
+            sin = self.sin_cache[:, :, :padded_seq, :]
+            q = ttnn.experimental.rotary_embedding(q, cos, sin)
+            k = ttnn.experimental.rotary_embedding(k, cos, sin)
+
+            ttnn.experimental.paged_fill_cache(self.k_cache, k, self.page_table, batch_idx=0)
+            ttnn.experimental.paged_fill_cache(self.v_cache, v, self.page_table, batch_idx=0)
+
+            attn_out = ttnn.transformer.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                is_causal=True,
+                scale=self.scale,
+                compute_kernel_config=ATTN_KERNEL_CONFIG,
+            )
+            attn_out = ttnn.experimental.nlp_concat_heads(attn_out, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        else:
+            if cur_pos_tensor is None:
+                raise ValueError("cur_pos_tensor is required for decode")
+
+            q, k, v = ttnn.experimental.nlp_create_qkv_heads_decode(
+                qkv,
+                num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            if not trace_decode:
+                ttnn.deallocate(qkv)
+
+            q_batch = q.shape[1]
+            q_heads = q.shape[2]
+            q_bh = q_batch * q_heads
+            q_bh_padded = pad_to_tile(q_bh)
+            q = ttnn.reshape(q, (1, 1, q_bh, self.head_dim), (1, 1, q_bh_padded, self.head_dim))
+            if decode_cos is None or decode_sin is None:
+                q = ttnn.experimental.rotary_embedding(q, self.cos_cache, self.sin_cache, start_pos)
+            else:
+                q = ttnn.experimental.rotary_embedding(q, decode_cos, decode_sin)
+            q = ttnn.reshape(q, (1, q_batch, q_heads, self.head_dim), (1, q_batch, q_heads, self.head_dim))
+
+            k_batch = k.shape[1]
+            k_heads = k.shape[2]
+            k_bh = k_batch * k_heads
+            k_bh_padded = pad_to_tile(k_bh)
+            k = ttnn.reshape(k, (1, 1, k_bh, self.head_dim), (1, 1, k_bh_padded, self.head_dim))
+            if decode_cos is None or decode_sin is None:
+                k = ttnn.experimental.rotary_embedding(k, self.cos_cache, self.sin_cache, start_pos)
+            else:
+                k = ttnn.experimental.rotary_embedding(k, decode_cos, decode_sin)
+            k = ttnn.reshape(k, (1, k_batch, k_heads, self.head_dim), (1, k_batch, k_heads, self.head_dim))
+
+            ttnn.experimental.paged_update_cache(
+                self.k_cache,
+                k,
+                update_idxs_tensor=cur_pos_tensor,
+                page_table=self.page_table,
+            )
+            ttnn.experimental.paged_update_cache(
+                self.v_cache,
+                v,
+                update_idxs_tensor=cur_pos_tensor,
+                page_table=self.page_table,
+            )
+
+            attn_out = ttnn.transformer.paged_scaled_dot_product_attention_decode(
+                q,
+                self.k_cache,
+                self.v_cache,
+                page_table_tensor=self.page_table,
+                cur_pos_tensor=cur_pos_tensor,
+                scale=self.scale,
+                compute_kernel_config=ATTN_KERNEL_CONFIG,
+            )
+            attn_out = ttnn.transpose(attn_out, 1, 2)
+            attn_out = ttnn.experimental.nlp_concat_heads(attn_out, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+        expected_width = num_heads * self.head_dim
+        if attn_out.shape[-1] != expected_width:
+            attn_out = ttnn.slice(
+                attn_out,
+                (0, 0, 0, 0),
+                (attn_out.shape[0], attn_out.shape[1], attn_out.shape[2], expected_width),
+            )
+
+        out = ttnn.linear(attn_out, self.o_proj)
+        return all_reduce_tensor(out, self.parallel)
+
+
+class MLP:
+    """SwiGLU MLP with tensor parallel across mesh columns."""
+
+    def __init__(self, layer_idx: int, state_dict: dict, parallel: ParallelConfig):
+        p = f"model.layers.{layer_idx}.mlp."
+        self.parallel = parallel
+        self.gate_proj = self._load_weight(state_dict[f"{p}gate_proj.weight"], parallel.shard_width_mapper)
+        self.up_proj = self._load_weight(state_dict[f"{p}up_proj.weight"], parallel.shard_width_mapper)
+        self.down_proj = self._load_weight(state_dict[f"{p}down_proj.weight"], parallel.shard_height_mapper)
+
+    def _load_weight(self, w: torch.Tensor, mesh_mapper) -> ttnn.Tensor:
+        return ttnn.as_tensor(
+            w.T.unsqueeze(0).unsqueeze(0).to(torch.bfloat16).contiguous(),
+            dtype=MLP_WEIGHT_DTYPE,
+            layout=WEIGHT_LAYOUT,
+            device=self.parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=mesh_mapper,
+        )
+
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        gate = ttnn.silu(ttnn.linear(x, self.gate_proj))
+        up = ttnn.linear(x, self.up_proj)
+        out = ttnn.linear(ttnn.mul(gate, up), self.down_proj)
+        return all_reduce_tensor(out, self.parallel)
+
+
+class DecoderLayer:
+    """Single transformer layer."""
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        layer_idx: int,
+        state_dict: dict,
+        cos_cache: ttnn.Tensor,
+        sin_cache: ttnn.Tensor,
+        parallel: ParallelConfig,
+        paged_attention_config: PagedAttentionConfig,
+        page_table: ttnn.Tensor,
+    ):
+        p = f"model.layers.{layer_idx}."
+        self.attn_norm = RMSNorm(state_dict[f"{p}input_layernorm.weight"], config.rms_norm_eps, parallel)
+        self.ffn_norm = RMSNorm(state_dict[f"{p}post_attention_layernorm.weight"], config.rms_norm_eps, parallel)
+        self.attn = Attention(
+            config,
+            layer_idx,
+            state_dict,
+            cos_cache,
+            sin_cache,
+            parallel,
+            paged_attention_config,
+            page_table,
+        )
+        self.mlp = MLP(layer_idx, state_dict, parallel)
+
+    def __call__(
+        self,
+        x: ttnn.Tensor,
+        start_pos: int,
+        seq_len: int,
+        cur_pos_tensor: Optional[ttnn.Tensor] = None,
+        decode_cos: Optional[ttnn.Tensor] = None,
+        decode_sin: Optional[ttnn.Tensor] = None,
+        trace_decode: bool = False,
+    ) -> ttnn.Tensor:
+        x = ttnn.add(
+            x,
+            self.attn(
+                self.attn_norm(x),
+                start_pos,
+                seq_len,
+                cur_pos_tensor=cur_pos_tensor,
+                decode_cos=decode_cos,
+                decode_sin=decode_sin,
+                trace_decode=trace_decode,
+            ),
+        )
+        x = ttnn.add(x, self.mlp(self.ffn_norm(x)))
+        return x
+
+
+class TtnnQwen2ForCausalLM(torch.nn.Module, GenerationMixin):
+    """
+    Qwen2 model with 100% ttnn execution on T3000.
+    HuggingFace `generate()`-compatible via `GenerationMixin`.
+    """
+
+    def __init__(self, hf_model, tt_device, max_seq_len: Optional[int] = None):
+        super().__init__()
+
+        self.tt_device = tt_device
+        self.hf_config = hf_model.config
+        self.tt_config = ModelConfig.from_hf(hf_model.config)
+        self.max_seq_len = resolve_max_seq_len(self.hf_config, max_seq_len)
+        self._pos = 0
+
+        if self.tt_config.hidden_act != "silu":
+            raise ValueError(f"hidden_act {self.tt_config.hidden_act} is not supported in this bringup")
+        if getattr(self.hf_config, "use_sliding_window", False):
+            raise ValueError("sliding_window attention is not supported in this bringup")
+
+        self.config = self.hf_config
+        self.generation_config = GenerationConfig.from_model_config(self.config)
+        if self.generation_config.pad_token_id is None:
+            self.generation_config.pad_token_id = self.generation_config.eos_token_id
+        self._supports_cache_class = False
+        self.main_input_name = "input_ids"
+        self.register_buffer("_torch_dummy", torch.empty(0, dtype=torch.float32), persistent=False)
+
+        mesh_shape = tuple(tt_device.shape)
+        tp_size = tp_size_for_mesh(mesh_shape)
+        mesh_axis = mesh_tp_axis(mesh_shape)
+        validate_parallel_config(self.tt_config, mesh_shape, tp_size)
+
+        self.parallel = ParallelConfig(
+            mesh_device=tt_device,
+            mesh_shape=mesh_shape,
+            num_devices=tp_size,
+            mesh_axis=mesh_axis,
+            num_links=MESH_NUM_LINKS,
+            topology=MESH_TOPOLOGY,
+            replicate_mapper=ttnn.ReplicateTensorToMesh(tt_device),
+            shard_width_mapper=ttnn.ShardTensor2dMesh(tt_device, mesh_shape, dims=(None, 3)),
+            shard_height_mapper=ttnn.ShardTensor2dMesh(tt_device, mesh_shape, dims=(None, 2)),
+            shard_kv_mapper=ttnn.ShardTensor2dMesh(tt_device, mesh_shape, dims=(None, 1)),
+            vocab_composer=ttnn.ConcatMesh2dToTensor(tt_device, mesh_shape, dims=(0, 3)),
+        )
+
+        state_dict = hf_model.state_dict()
+
+        print("  Loading embeddings...")
+        self.embed = ttnn.as_tensor(
+            state_dict["model.embed_tokens.weight"].unsqueeze(0).unsqueeze(0).to(torch.bfloat16),
+            dtype=EMBED_DTYPE,
+            layout=WEIGHT_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+
+        print("  Computing RoPE cache...")
+        cos, sin = compute_rope_cache(self.tt_config, self.max_seq_len)
+        self.cos_cache_host = cos
+        self.sin_cache_host = sin
+        self.cos_cache = ttnn.as_tensor(
+            cos,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.sin_cache = ttnn.as_tensor(
+            sin,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+
+        max_num_blocks = math.ceil(self.max_seq_len / PAGED_BLOCK_SIZE)
+        self.paged_attention_config = PagedAttentionConfig(PAGED_BLOCK_SIZE, max_num_blocks)
+        page_table = torch.arange(max_num_blocks, dtype=torch.int32).repeat(TILE_SIZE, 1)
+        self.page_table = ttnn.as_tensor(
+            page_table,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.decode_token_buffer = ttnn.from_torch(
+            torch.zeros((1, 1, 1, TILE_SIZE), dtype=torch.int32),
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.decode_rope_seq = (self.tt_config.num_attention_heads // self.parallel.num_devices) * TILE_SIZE
+        self.decode_pos_buffer = ttnn.from_torch(
+            torch.zeros((TILE_SIZE,), dtype=torch.int32),
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.decode_cos_buffer = ttnn.from_torch(
+            torch.zeros((1, 1, self.decode_rope_seq, self.tt_config.head_dim), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.decode_sin_buffer = ttnn.from_torch(
+            torch.zeros((1, 1, self.decode_rope_seq, self.tt_config.head_dim), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.use_decode_trace = USE_DECODE_TRACE
+        self.decode_trace_id = None
+        self.decode_trace_logits = None
+
+        print(f"  Loading {self.tt_config.num_hidden_layers} layers...")
+        self.layers = [
+            DecoderLayer(
+                self.tt_config,
+                i,
+                state_dict,
+                self.cos_cache,
+                self.sin_cache,
+                self.parallel,
+                self.paged_attention_config,
+                self.page_table,
+            )
+            for i in range(self.tt_config.num_hidden_layers)
+        ]
+
+        self.norm = RMSNorm(state_dict["model.norm.weight"], self.tt_config.rms_norm_eps, self.parallel)
+        lm_head_weight = state_dict.get("lm_head.weight", state_dict["model.embed_tokens.weight"])
+        self.lm_head = ttnn.as_tensor(
+            lm_head_weight.T.unsqueeze(0).unsqueeze(0).to(torch.bfloat16).contiguous(),
+            dtype=LM_HEAD_DTYPE,
+            layout=WEIGHT_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.shard_width_mapper,
+        )
+
+        self._tt_past_key_values = object()
+
+    @property
+    def device(self) -> torch.device:
+        return self._torch_dummy.device
+
+    def _release_decode_trace(self) -> None:
+        if self.decode_trace_id is None:
+            return
+        ttnn.release_trace(self.tt_device, self.decode_trace_id)
+        self.decode_trace_id = None
+        self.decode_trace_logits = None
+
+    def reset(self):
+        """Reset position counter for new sequence."""
+        self._pos = 0
+        self._release_decode_trace()
+
+    def prepare_inputs_for_generation(self, input_ids, past_key_values=None, **kwargs):
+        if past_key_values is not None:
+            input_ids = input_ids[:, -1:]
+        return {"input_ids": input_ids, "past_key_values": past_key_values, "use_cache": True}
+
+    def _reorder_cache(self, past_key_values, beam_idx):
+        return past_key_values
+
+    def _logits_to_torch(self, logits: ttnn.Tensor) -> torch.Tensor:
+        if self.parallel.num_devices > 1:
+            return ttnn.to_torch(logits, mesh_composer=self.parallel.vocab_composer)
+        return ttnn.to_torch(logits)
+
+    def _forward_prefill(self, input_ids: torch.Tensor, start_pos: int, seq_len: int) -> ttnn.Tensor:
+        tokens = ttnn.from_torch(
+            input_ids.reshape(1, 1, 1, -1),
+            dtype=ttnn.uint32,
+            device=self.tt_device,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        h = ttnn.embedding(tokens, self.embed, layout=ttnn.TILE_LAYOUT)
+        for layer in self.layers:
+            h = layer(h, start_pos, seq_len)
+        h = self.norm(h)
+        return ttnn.linear(h, self.lm_head)
+
+    def _forward_prefill_last_logits(self, input_ids: torch.Tensor, start_pos: int, seq_len: int) -> ttnn.Tensor:
+        tokens = ttnn.from_torch(
+            input_ids.reshape(1, 1, 1, -1),
+            dtype=ttnn.uint32,
+            device=self.tt_device,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        h = ttnn.embedding(tokens, self.embed, layout=ttnn.TILE_LAYOUT)
+        for layer in self.layers:
+            h = layer(h, start_pos, seq_len)
+        h = self.norm(h)
+        last_token_idx = seq_len - 1
+        h_last = ttnn.slice(
+            h,
+            (0, 0, last_token_idx, 0),
+            (h.shape[0], h.shape[1], last_token_idx + 1, h.shape[-1]),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        ttnn.deallocate(h)
+        return ttnn.linear(h_last, self.lm_head)
+
+    def _update_decode_token_buffer(self, input_ids: torch.Tensor) -> None:
+        token_ids = torch.zeros((TILE_SIZE,), dtype=torch.int32)
+        token_ids[: input_ids.numel()] = input_ids.view(-1).to(torch.int32)
+        token_ids = token_ids.reshape(1, 1, 1, -1)
+        host_tokens = ttnn.from_torch(
+            token_ids,
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        ttnn.copy_host_to_device_tensor(host_tokens, self.decode_token_buffer)
+
+    def _update_decode_pos_buffer(self, start_pos: int) -> None:
+        pos = torch.full((TILE_SIZE,), -1, dtype=torch.int32)
+        pos[0] = start_pos
+        host_pos = ttnn.from_torch(
+            pos,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        ttnn.copy_host_to_device_tensor(host_pos, self.decode_pos_buffer)
+
+    def _update_decode_rope_buffers(self, start_pos: int) -> None:
+        cos_token = self.cos_cache_host[:, :, start_pos : start_pos + 1, :]
+        sin_token = self.sin_cache_host[:, :, start_pos : start_pos + 1, :]
+        cos_slice = cos_token.repeat(1, 1, self.decode_rope_seq, 1)
+        sin_slice = sin_token.repeat(1, 1, self.decode_rope_seq, 1)
+        host_cos = ttnn.from_torch(
+            cos_slice,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+        )
+        host_sin = ttnn.from_torch(
+            sin_slice,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+        )
+        ttnn.copy_host_to_device_tensor(host_cos, self.decode_cos_buffer)
+        ttnn.copy_host_to_device_tensor(host_sin, self.decode_sin_buffer)
+
+    def _forward_decode_device(self, start_pos: int, trace_decode: bool) -> ttnn.Tensor:
+        h = ttnn.embedding(self.decode_token_buffer, self.embed, layout=ttnn.TILE_LAYOUT)
+        for layer in self.layers:
+            h = layer(
+                h,
+                start_pos,
+                1,
+                cur_pos_tensor=self.decode_pos_buffer,
+                decode_cos=self.decode_cos_buffer,
+                decode_sin=self.decode_sin_buffer,
+                trace_decode=trace_decode,
+            )
+        h = self.norm(h)
+        h = ttnn.slice(
+            h,
+            (0, 0, 0, 0),
+            (h.shape[0], h.shape[1], 1, h.shape[-1]),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        return ttnn.linear(h, self.lm_head)
+
+    def _forward_decode(self, input_ids: torch.Tensor, start_pos: int) -> ttnn.Tensor:
+        self._update_decode_token_buffer(input_ids)
+        self._update_decode_pos_buffer(start_pos)
+        self._update_decode_rope_buffers(start_pos)
+
+        if self.use_decode_trace:
+            if self.decode_trace_id is None:
+                warmup_logits = self._forward_decode_device(start_pos, False)
+                ttnn.deallocate(warmup_logits)
+                self.decode_trace_id = ttnn.begin_trace_capture(self.tt_device)
+                self.decode_trace_logits = self._forward_decode_device(start_pos, True)
+                ttnn.end_trace_capture(self.tt_device, self.decode_trace_id)
+            else:
+                ttnn.execute_trace(self.tt_device, self.decode_trace_id, blocking=False)
+            return self.decode_trace_logits
+        return self._forward_decode_device(start_pos, False)
+
+    def _forward_device_logits(self, input_ids: torch.Tensor, past_key_values, use_cache: bool):
+        batch, seq_len = input_ids.shape
+        if batch != 1:
+            raise ValueError("Only batch=1 supported")
+
+        if past_key_values is None:
+            self.reset()
+        elif seq_len != 1:
+            raise ValueError("Only 1-token decode supported when using cache")
+
+        start_pos = self._pos
+        if start_pos + seq_len > self.max_seq_len:
+            raise ValueError(
+                f"sequence length {start_pos + seq_len} exceeds max sequence length {self.max_seq_len}"
+            )
+
+        if seq_len == 1:
+            logits = self._forward_decode(input_ids, start_pos)
+            padded_seq = 1
+        else:
+            padded_seq = pad_to_tile(seq_len)
+            if seq_len < padded_seq:
+                input_ids = torch.nn.functional.pad(input_ids, (0, padded_seq - seq_len), value=0)
+            logits = self._forward_prefill(input_ids, start_pos, seq_len)
+
+        self._pos = start_pos + seq_len
+        past = self._tt_past_key_values if use_cache else None
+        return logits, seq_len, padded_seq, past
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        past_key_values=None,
+        use_cache: bool = True,
+        cache_position: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> CausalLMOutputWithPast:
+        """Forward pass compatible with HuggingFace generate()."""
+        batch = input_ids.shape[0]
+        logits, seq_len, padded_seq, past = self._forward_device_logits(input_ids, past_key_values, use_cache)
+
+        logits_torch = self._logits_to_torch(logits)
+        if self.parallel.mesh_shape[0] > 1:
+            logits_torch = logits_torch.reshape(self.parallel.mesh_shape[0], batch, padded_seq, -1)[0]
+        logits_torch = logits_torch.reshape(batch, padded_seq, -1)[:, :seq_len, :]
+
+        if seq_len > 1 or not self.use_decode_trace:
+            ttnn.deallocate(logits)
+
+        return CausalLMOutputWithPast(
+            logits=logits_torch.float(),
+            past_key_values=past,
+        )
+
+    def prefill_logits_last_device(self, input_ids: torch.Tensor, use_cache: bool = True) -> tuple[torch.Tensor, object]:
+        batch, seq_len = input_ids.shape
+        if batch != 1:
+            raise ValueError("Only batch=1 supported")
+
+        self.reset()
+        start_pos = self._pos
+        if start_pos + seq_len > self.max_seq_len:
+            raise ValueError(
+                f"sequence length {start_pos + seq_len} exceeds max sequence length {self.max_seq_len}"
+            )
+
+        padded_seq = pad_to_tile(seq_len)
+        if seq_len < padded_seq:
+            input_ids = torch.nn.functional.pad(input_ids, (0, padded_seq - seq_len), value=0)
+
+        logits = self._forward_prefill_last_logits(input_ids, start_pos, seq_len)
+        self._pos = start_pos + seq_len
+
+        logits_torch = self._logits_to_torch(logits)
+        if self.parallel.mesh_shape[0] > 1:
+            logits_torch = logits_torch.reshape(self.parallel.mesh_shape[0], batch, 1, -1)[0]
+        logits_torch = logits_torch.reshape(batch, 1, -1)[:, 0, :].float()
+        ttnn.deallocate(logits)
+
+        past = self._tt_past_key_values if use_cache else None
+        return logits_torch, past
+
+
+def build_model(hf_model, tt_device, max_seq_len: Optional[int] = None) -> TtnnQwen2ForCausalLM:
+    """Build the ttnn model from a HuggingFace reference model."""
+    return TtnnQwen2ForCausalLM(hf_model, tt_device, max_seq_len)

--- a/scripts/run_eval.py
+++ b/scripts/run_eval.py
@@ -15,13 +15,19 @@ warnings.filterwarnings(
     message="Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.",
     category=FutureWarning,
 )
+warnings.filterwarnings(
+    "ignore",
+    message="Passing a tuple of `past_key_values` is deprecated",
+)
 os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
+os.environ.setdefault("TRANSFORMERS_NO_ADVISORY_WARNINGS", "1")
 
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from transformers.utils import logging as hf_logging
 
 hf_logging.disable_progress_bar()
+hf_logging.set_verbosity_error()
 
 
 DEFAULT_PREFILL_LEN = 20

--- a/tests/test_eval_smoke.py
+++ b/tests/test_eval_smoke.py
@@ -30,6 +30,9 @@ def test_run_eval_hf_smoke(tmp_path):
         str(cache_dir),
     ]
     result = subprocess.run(cmd, cwd=repo_root, capture_output=True, text=True, check=True)
+    output_lines = [line for line in result.stdout.splitlines() if line.strip()]
+    assert output_lines
+    assert output_lines[0].startswith("YT_METRICS=")
     metrics = parse_metrics(result.stdout)
     assert metrics is not None
     assert metrics["mode"] == "hf"


### PR DESCRIPTION
## Summary
- add `models/arcee-ai/Arcee-Spark/t3000/optimized/model.py` with traced decode execution and optimized bringup path
- add fresh optimized artifacts in `models/arcee-ai/Arcee-Spark/t3000/optimized/` (`demo.log`, `eval.log`, `MODEL_BRINGUP.md`)
- update `MODELS.md` optimized row for t3000 to measured healthy-mesh results (Top-1/Top-5 90/100, TTFT 72ms, t/s/u 17.6, seq 32768)
- evaluate and document rejected optimization candidates in `MODEL_BRINGUP.md` (BF8 attention variants regressed Top-1)
- harden JSON metrics output in `scripts/run_eval.py` and add smoke-test coverage to prevent non-JSON preamble before `YT_METRICS=`

## Validation
- `env TT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 /proj_sw/user_dev/moconnor/tt-metal/python_env/bin/python demo.py models/arcee-ai/Arcee-Spark/t3000/optimized/model.py`
- `env TT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 /proj_sw/user_dev/moconnor/tt-metal/python_env/bin/python eval.py models/arcee-ai/Arcee-Spark/t3000/optimized/model.py --model arcee-ai/Arcee-Spark --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 32768`
- `pytest -q tests/test_eval_smoke.py -q`

Fixes #131
