### PR TITLE
Add strict JSON output mode to run_eval

### DIFF
--- a/scripts/run_eval.py
+++ b/scripts/run_eval.py
@@ -34,6 +34,15 @@ DEFAULT_PREFILL_LEN = 20
 DEFAULT_DECODE_LEN = 20
 
 
+def emit_metrics(metrics: dict, output_format: str) -> None:
+    """Emit metrics in the requested output format."""
+    payload = json.dumps(metrics)
+    if output_format == "json":
+        print(payload)
+        return
+    print(f"YT_METRICS={payload}")
+
+
 def resolve_model_path(repo_root: pathlib.Path, hf_model_id: str, system: str) -> pathlib.Path:
     """Resolve model.py path using the HF model id as the directory convention."""
     model_path = repo_root / "models" / hf_model_id / system / "functional" / "model.py"
@@ -242,6 +251,11 @@ def main():
     parser.add_argument("--batch", type=int, default=1)
     parser.add_argument("--trace", type=int, default=0)
     parser.add_argument("--cache-dir", default=None)
+    parser.add_argument(
+        "--output-format",
+        choices=["yt_metrics", "json"],
+        default=os.environ.get("YT_OUTPUT_FORMAT", "yt_metrics"),
+    )
     args = parser.parse_args()
 
     if args.batch != 1:
@@ -292,7 +306,7 @@ def main():
                 "batch": args.batch,
                 "total": int(total),
             }
-            print(f"YT_METRICS={json.dumps(metrics)}")
+            emit_metrics(metrics, args.output_format)
             continue
 
         model_path = resolve_model_path(repo_root, args.hf_model, args.system)
@@ -327,7 +341,7 @@ def main():
                 "batch": args.batch,
                 "total": int(total),
             }
-            print(f"YT_METRICS={json.dumps(metrics)}")
+            emit_metrics(metrics, args.output_format)
 
 
 if __name__ == "__main__":

--- a/tests/test_eval_smoke.py
+++ b/tests/test_eval_smoke.py
@@ -6,9 +6,14 @@ import sys
 
 def parse_metrics(output: str):
     for line in output.splitlines():
-        if line.startswith("YT_METRICS="):
-            payload = line.split("=", 1)[1].strip()
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("YT_METRICS="):
+            payload = stripped.split("=", 1)[1].strip()
             return json.loads(payload)
+        if stripped.startswith("{"):
+            return json.loads(stripped)
     return None
 
 
@@ -33,6 +38,36 @@ def test_run_eval_hf_smoke(tmp_path):
     output_lines = [line for line in result.stdout.splitlines() if line.strip()]
     assert output_lines
     assert output_lines[0].startswith("YT_METRICS=")
+    metrics = parse_metrics(result.stdout)
+    assert metrics is not None
+    assert metrics["mode"] == "hf"
+    assert metrics["top1"] >= 0.99
+    assert metrics["top5"] >= 0.99
+
+
+def test_run_eval_hf_smoke_json_output(tmp_path):
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    cache_dir = tmp_path / "hf_cache"
+    cmd = [
+        sys.executable,
+        "scripts/run_eval.py",
+        "--mode",
+        "hf",
+        "--hf-model",
+        "sshleifer/tiny-gpt2",
+        "--prefill-len",
+        "8",
+        "--decode-len",
+        "4",
+        "--output-format",
+        "json",
+        "--cache-dir",
+        str(cache_dir),
+    ]
+    result = subprocess.run(cmd, cwd=repo_root, capture_output=True, text=True, check=True)
+    output_lines = [line for line in result.stdout.splitlines() if line.strip()]
+    assert output_lines
+    assert output_lines[0].strip().startswith("{")
     metrics = parse_metrics(result.stdout)
     assert metrics is not None
     assert metrics["mode"] == "hf"


### PR DESCRIPTION
## Summary
- add `--output-format` to `scripts/run_eval.py` with two supported values:
  - `yt_metrics` (existing `YT_METRICS=...` behavior)
  - `json` (strict raw JSON object output)
- add `emit_metrics()` helper to centralize output formatting
- update `tests/test_eval_smoke.py` parser to accept both formats
- add a new smoke test that validates strict JSON output mode

## Why
Some checkers consume stdout with `json.loads(...)` and fail when output starts with `YT_METRICS=`. This keeps backward compatibility while providing a strict JSON mode for JSON-only parsers.

## Validation
- `pytest -q tests/test_eval_smoke.py -q`
- `/proj_sw/user_dev/moconnor/tt-metal/python_env/bin/python scripts/run_eval.py --mode hf --hf-model sshleifer/tiny-gpt2 --prefill-len 8 --decode-len 4 --output-format json`
- `/proj_sw/user_dev/moconnor/tt-metal/python_env/bin/python scripts/run_eval.py --mode hf --hf-model sshleifer/tiny-gpt2 --prefill-len 8 --decode-len 4`
