### PR TITLE
Default run_eval output to strict JSON

### DIFF
--- a/scripts/run_eval.py
+++ b/scripts/run_eval.py
@@ -254,7 +254,7 @@ def main():
     parser.add_argument(
         "--output-format",
         choices=["yt_metrics", "json"],
-        default=os.environ.get("YT_OUTPUT_FORMAT", "yt_metrics"),
+        default=os.environ.get("YT_OUTPUT_FORMAT", "json"),
     )
     args = parser.parse_args()
 

--- a/tests/test_eval_smoke.py
+++ b/tests/test_eval_smoke.py
@@ -37,7 +37,7 @@ def test_run_eval_hf_smoke(tmp_path):
     result = subprocess.run(cmd, cwd=repo_root, capture_output=True, text=True, check=True)
     output_lines = [line for line in result.stdout.splitlines() if line.strip()]
     assert output_lines
-    assert output_lines[0].startswith("YT_METRICS=")
+    assert output_lines[0].strip().startswith("{")
     metrics = parse_metrics(result.stdout)
     assert metrics is not None
     assert metrics["mode"] == "hf"
@@ -45,7 +45,7 @@ def test_run_eval_hf_smoke(tmp_path):
     assert metrics["top5"] >= 0.99
 
 
-def test_run_eval_hf_smoke_json_output(tmp_path):
+def test_run_eval_hf_smoke_yt_metrics_output(tmp_path):
     repo_root = pathlib.Path(__file__).resolve().parents[1]
     cache_dir = tmp_path / "hf_cache"
     cmd = [
@@ -60,14 +60,14 @@ def test_run_eval_hf_smoke_json_output(tmp_path):
         "--decode-len",
         "4",
         "--output-format",
-        "json",
+        "yt_metrics",
         "--cache-dir",
         str(cache_dir),
     ]
     result = subprocess.run(cmd, cwd=repo_root, capture_output=True, text=True, check=True)
     output_lines = [line for line in result.stdout.splitlines() if line.strip()]
     assert output_lines
-    assert output_lines[0].strip().startswith("{")
+    assert output_lines[0].strip().startswith("YT_METRICS=")
     metrics = parse_metrics(result.stdout)
     assert metrics is not None
     assert metrics["mode"] == "hf"


### PR DESCRIPTION
## Summary
- switch `scripts/run_eval.py` default `--output-format` from `yt_metrics` to `json`
- keep backward compatibility via explicit `--output-format yt_metrics`
- update smoke tests:
  - default mode expects raw JSON first line
  - explicit yt_metrics mode expects `YT_METRICS=` first line

## Why
Some automated checkers call `json.loads(stdout)` directly. With the old default prefix (`YT_METRICS=`), parsing failed at column 1. Making JSON the default removes that failure while preserving legacy mode for existing consumers.

## Validation
- `pytest -q tests/test_eval_smoke.py -q`
- `/proj_sw/user_dev/moconnor/tt-metal/python_env/bin/python scripts/run_eval.py --mode hf --hf-model sshleifer/tiny-gpt2 --prefill-len 8 --decode-len 4`
- `/proj_sw/user_dev/moconnor/tt-metal/python_env/bin/python scripts/run_eval.py --mode hf --hf-model sshleifer/tiny-gpt2 --prefill-len 8 --decode-len 4 --output-format yt_metrics`
