### PR TITLE
Use codexapi --quiet in worker loop

### DIFF
--- a/scripts/worker.sh
+++ b/scripts/worker.sh
@@ -90,7 +90,8 @@ while true; do
         continue
     fi
     only_matching="/${system}/"
-    # Ensure codexapi output is flushed promptly to nohup logs.
-    PYTHONUNBUFFERED=1 codexapi task  -p https://github.com/users/yieldthought/projects/6 -n "$agent_name" --only-matching "$only_matching" "${task_files[@]}"
+    # Ensure codexapi output is flushed promptly to nohup logs. Use --quiet to
+    # reduce verifier parsing noise in worker logs.
+    PYTHONUNBUFFERED=1 codexapi task --quiet -p https://github.com/users/yieldthought/projects/6 -n "$agent_name" --only-matching "$only_matching" "${task_files[@]}"
     sleep 60
 done


### PR DESCRIPTION
## Summary
- update `scripts/worker.sh` to run `codexapi task --quiet ...`
- keep existing worker loop behavior, task matching, and repo sync unchanged

## Why
Watcher notes have repeatedly called out estimate/checker JSON parse failures in long-running worker loops. `--quiet` reduces verifier progress noise and helps keep machine-consumed output parseable.

## Validation
- `bash -n scripts/worker.sh`
