### PR TITLE
models/arcee-ai/AFM-4.5B/t3000/optimized

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -13,6 +13,7 @@ Note: Keep the table columns padded with spaces and right-justify numeric cells 
 | arcee-ai/Arcee-Spark                |  t3000   | functional |   90% |  100% |  343ms |   4.9 |   32768 |
 | arcee-ai/Arcee-Spark                |  t3000   | optimized  |   90% |  100% |   72ms |  17.6 |   32768 |
 | arcee-ai/AFM-4.5B                   |  t3000   | functional |   98% |  100% |  181ms |   7.1 |   65536 |
+| arcee-ai/AFM-4.5B                   |  t3000   | optimized  |   98% |  100% |   69ms |  29.0 |   65536 |
 | arcee-ai/AFM-4.5B                   |   n150   | functional |   98% |  100% |   72ms |  17.2 |   65536 |
 | arcee-ai/AFM-4.5B                   |   n300   | functional |   97% |  100% |  283ms |   5.6 |   65536 |
 | arcee-ai/AFM-4.5B                   |   n300   | optimized  |   99% |  100% |   56ms |  23.6 |   65536 |

--- a/models/arcee-ai/AFM-4.5B/t3000/optimized/MODEL_BRINGUP.md
+++ b/models/arcee-ai/AFM-4.5B/t3000/optimized/MODEL_BRINGUP.md
@@ -1,0 +1,61 @@
+# MODEL_BRINGUP.md — AFM-4.5B (t3000 optimized)
+
+## Overview
+This is the optimized T3000 path for `arcee-ai/AFM-4.5B`.
+
+- Model code: `models/arcee-ai/AFM-4.5B/t3000/optimized/model.py`
+- Demo log: `models/arcee-ai/AFM-4.5B/t3000/optimized/demo.log`
+- Eval log: `models/arcee-ai/AFM-4.5B/t3000/optimized/eval.log`
+- Parallelism: 1D tensor parallel across the 8-chip T3000 mesh with padded heads/KV heads
+- Max seq len: `65536` (no capability regression)
+- Decode path: traced execution (`ttnn.begin_trace_capture` / `ttnn.execute_trace`)
+
+## Baseline vs Final (same hardware)
+| Metric | Functional baseline | Optimized final |
+| --- | ---: | ---: |
+| Top-1 | 98% | 98% |
+| Top-5 | 100% | 100% |
+| TTFT | 181 ms | 69 ms |
+| t/s/u | 7.1 | 29.0 |
+| Seq len | 65536 | 65536 |
+
+## This optimization pass (same command + seed)
+| Metric | Starting optimized baseline | Final optimized |
+| --- | ---: | ---: |
+| TTFT | 77 ms | 69 ms |
+| t/s/u | 24.9 | 29.0 |
+
+## Commands used
+Demo:
+```bash
+env TT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
+  TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto \
+  TT_METAL_CACHE=/tmp/tt-metal-cache \
+  PYTHONUNBUFFERED=1 \
+  python -u demo.py models/arcee-ai/AFM-4.5B/t3000/optimized/model.py --seed 0
+```
+
+Eval:
+```bash
+env TT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
+  TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto \
+  TT_METAL_CACHE=/tmp/tt-metal-cache \
+  PYTHONUNBUFFERED=1 \
+  python -u eval.py models/arcee-ai/AFM-4.5B/t3000/optimized/model.py \
+    --model arcee-ai/AFM-4.5B \
+    --prompt_file prompts/bringup_eval_long.txt \
+    --max_new_tokens 100 \
+    --max_seq_len 65536
+```
+
+## Kept optimizations
+1. Fused attention QKV projection into one matmul (`self.qkv_proj`) with per-device Q/K/V chunk ordering that matches width sharding.
+2. Added `prefill_logits_last_device()` so demo/eval TTFT uses only final prompt-token logits.
+3. Added traced decode execution with preallocated decode token/position/RoPE buffers and `ttnn.execute_trace` replay.
+4. Moved decode attention intermediates to L1 where safe (`nlp_create_qkv_heads_decode`, paged decode SDPA, decode `nlp_concat_heads`).
+
+## Deferred changes
+1. Decode-specific `nlp_concat_heads_decode` migration was deferred in this pass. Current `nlp_concat_heads` decode path already meets the target and keeps the GQA/padded-head flow simple.
+
+## Environment note
+1. The default `tt-smi` wrapper at `/home/moconnor/bin/tt-smi` is broken on this host (`bad interpreter`). Use `/proj_sw/user_dev/moconnor/tt-metal/python_env/bin/tt-smi`.

--- a/models/arcee-ai/AFM-4.5B/t3000/optimized/demo.log
+++ b/models/arcee-ai/AFM-4.5B/t3000/optimized/demo.log
@@ -1,0 +1,84 @@
+COMMAND: env TT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto TT_METAL_CACHE=/tmp/tt-metal-cache PYTHONUNBUFFERED=1 python -u demo.py models/arcee-ai/AFM-4.5B/t3000/optimized/model.py --seed 0
+2026-02-12 01:04:45.622 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
+Loading tokenizer: arcee-ai/AFM-4.5B
+Opening TT device...
+2026-02-12 01:04:46.372 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 01:04:46.402 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-12 01:04:46.412 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 01:04:46.483 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 01:04:46.545 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 01:04:46.601 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x208 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 01:04:46.611 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 01:04:46.621 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x41 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 01:04:46.632 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 01:04:46.646 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x208 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 01:04:46.659 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x300 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 01:04:46.673 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x42 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 01:04:46.686 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 1, 2, 3] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
+2026-02-12 01:04:46.686 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-12 01:04:46.686 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-12 01:04:46.694 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-12 01:04:46.695 | info     |             UMD | Mapped hugepage 0x340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 01:04:46.696 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 01:04:46.697 | info     |             UMD | Mapped hugepage 0x440000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 01:04:46.698 | info     |             UMD | Mapped hugepage 0x400000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 01:04:46.699 | info     |             UMD | Mapped hugepage 0x4240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 01:04:46.699 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 01:04:46.701 | info     |             UMD | Mapped hugepage 0x4340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 01:04:46.701 | info     |             UMD | Mapped hugepage 0x4300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 01:04:46.757 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto (metal_context.cpp:822)
+2026-02-12 01:04:46.759 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-12 01:04:46.763 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-12 01:04:46.764 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-12 01:04:46.768 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 01:04:46.771 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 01:04:46.772 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 01:04:46.772 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 01:04:46.772 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 01:04:46.772 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 01:04:46.773 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 01:04:46.773 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 01:04:47.086 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
+2026-02-12 01:04:47.086 | info     |           Metal | Dispatch on FabricConfig::FABRIC_2D with 1 Command Queues
+ (device_manager.cpp:328)
+2026-02-12 01:04:47.100 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
+2026-02-12 01:04:47.250 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
+2026-02-12 01:04:47.280 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
+2026-02-12 01:04:47.281 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
+2026-02-12 01:04:47.281 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
+2026-02-12 01:04:47.284 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
+2026-02-12 01:04:47.288 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
+2026-02-12 01:04:47.294 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
+2026-02-12 01:04:47.301 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
+2026-02-12 01:04:47.301 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_2D (device_manager.cpp:409)
+2026-02-12 01:04:47.385 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
+2026-02-12 01:04:47.385 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
+2026-02-12 01:04:47.386 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
+2026-02-12 01:04:47.386 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
+Loading HuggingFace reference model on CPU: arcee-ai/AFM-4.5B
+Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:00<00:00,  1.43it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.58it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.56it/s]
+Building TT model...
+  Loading embeddings...
+  Computing RoPE cache...
+  Loading 36 layers...
+Running one warmup prefill+decode pass (kernel compile warmup)...
+TT demo (t3000)
+Model: arcee-ai/AFM-4.5B
+Mesh shape: 2x4
+Prompt tokens: 55 | Generated tokens: 128
+TTFT: 69 ms | Decode: 29.0 t/s/u (126 tokens)
+
+Prompt:
+Journal entry, 1957: Tonight a tiny sphere called Sputnik 1 crossed the sky, beeping like a metronome for a new era. The neighbors gathered on the roof, listening and arguing about what comes next. I wrote in my notebook that
+
+Output:
+ "in the future, we shall be controlled by a handful of scientific technocrats."
+
+Today in 2017, that handful has mutated into a flock of billionaires. They have more money — a lot more — than the Soviet Union did back in 1957.
+
+A handful of billionaires, now numbering about 2,000, control almost 70 percent of the entire global wealth in private assets, according to the Global Wealth Report released this week. That's 137 trillion dollars, and more than the gross domestic product of the entire world.
+
+The combined wealth of the billionaires in that list is almost 40 trillion dollars, about the same
+2026-02-12 01:06:49.784 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-12 01:06:49.784 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/arcee-ai/AFM-4.5B/t3000/optimized/eval.log
+++ b/models/arcee-ai/AFM-4.5B/t3000/optimized/eval.log
@@ -1,0 +1,71 @@
+COMMAND: env TT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto TT_METAL_CACHE=/tmp/tt-metal-cache PYTHONUNBUFFERED=1 python -u eval.py models/arcee-ai/AFM-4.5B/t3000/optimized/model.py --model arcee-ai/AFM-4.5B --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 65536
+2026-02-12 01:07:08.430 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
+Loading model module: /localdev/moconnor/ttnn_models/models/arcee-ai/AFM-4.5B/t3000/optimized/model.py
+Loading HuggingFace tokenizer...
+Loading HuggingFace reference model on CPU...
+Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:00<00:00,  1.38it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.55it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.52it/s]
+Generating reference tokens...
+Opening device (2x4)...
+2026-02-12 01:07:52.153 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 01:07:52.183 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-12 01:07:52.193 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 01:07:52.265 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 01:07:52.324 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 01:07:52.386 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x208 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 01:07:52.396 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 01:07:52.406 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x41 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 01:07:52.415 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 01:07:52.429 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x208 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 01:07:52.442 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x300 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 01:07:52.456 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x42 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 01:07:52.469 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 1, 2, 3] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
+2026-02-12 01:07:52.469 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-12 01:07:52.469 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-12 01:07:52.477 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-12 01:07:52.478 | info     |             UMD | Mapped hugepage 0x340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 01:07:52.479 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 01:07:52.480 | info     |             UMD | Mapped hugepage 0x440000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 01:07:52.480 | info     |             UMD | Mapped hugepage 0x400000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 01:07:52.481 | info     |             UMD | Mapped hugepage 0x4240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 01:07:52.482 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 01:07:52.483 | info     |             UMD | Mapped hugepage 0x4340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 01:07:52.484 | info     |             UMD | Mapped hugepage 0x4300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 01:07:52.541 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto (metal_context.cpp:822)
+2026-02-12 01:07:52.542 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-12 01:07:52.547 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-12 01:07:52.547 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-12 01:07:52.552 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 01:07:52.555 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 01:07:52.555 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 01:07:52.555 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 01:07:52.555 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 01:07:52.556 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 01:07:52.556 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 01:07:52.556 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 01:07:52.872 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
+2026-02-12 01:07:52.872 | info     |           Metal | Dispatch on FabricConfig::FABRIC_2D with 1 Command Queues
+ (device_manager.cpp:328)
+2026-02-12 01:07:52.888 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
+2026-02-12 01:07:53.058 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
+2026-02-12 01:07:53.058 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
+2026-02-12 01:07:53.059 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
+2026-02-12 01:07:53.060 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
+2026-02-12 01:07:53.062 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
+2026-02-12 01:07:53.065 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
+2026-02-12 01:07:53.072 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
+2026-02-12 01:07:53.078 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
+2026-02-12 01:07:53.078 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_2D (device_manager.cpp:409)
+2026-02-12 01:07:53.155 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
+2026-02-12 01:07:53.155 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
+2026-02-12 01:07:53.156 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
+2026-02-12 01:07:53.157 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
+Loading ttnn model...
+  Loading embeddings...
+  Computing RoPE cache...
+  Loading 36 layers...
+Running teacher-forcing eval (100 tokens)...
+Top-1 accuracy: 98.00% (0.9800)
+Top-5 accuracy: 100.00% (1.0000)
+2026-02-12 01:10:09.120 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-12 01:10:09.120 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/arcee-ai/AFM-4.5B/t3000/optimized/model.py
+++ b/models/arcee-ai/AFM-4.5B/t3000/optimized/model.py
@@ -1,0 +1,875 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Optimized Arcee AFM-4.5B implementation in ttnn for T3000.
+
+Key optimizations versus functional:
+- Fused QKV projection in attention (single matmul for Q/K/V)
+- Prefill-last-logits fast path for TTFT measurement in demo/eval
+- Decode trace path with preallocated input/position/RoPE buffers
+- Decode attention intermediates moved to L1 where safe
+
+Architecture remains the same as HuggingFace AFM-4.5B:
+- RMSNorm
+- GQA attention with Yarn RoPE scaling
+- MLP with relu2 activation
+"""
+
+import math
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import ttnn
+from transformers import GenerationConfig
+from transformers.generation.utils import GenerationMixin
+from transformers.modeling_outputs import CausalLMOutputWithPast
+from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+
+
+TILE_SIZE = 32
+MESH_SHAPE = (2, 4)
+MESH_TOPOLOGY = ttnn.Topology.Linear
+MESH_NUM_LINKS = 1
+PAGED_BLOCK_SIZE = 64
+WEIGHT_DTYPE = ttnn.bfloat8_b
+WEIGHT_LAYOUT = ttnn.TILE_LAYOUT
+USE_DECODE_TRACE = True
+
+
+def pad_to_tile(x: int) -> int:
+    """Pad to tile boundary (32)."""
+    return ((x + TILE_SIZE - 1) // TILE_SIZE) * TILE_SIZE
+
+
+def mesh_shape_to_axis(mesh_shape: tuple[int, int]) -> Optional[int]:
+    """Return the mesh axis used for 1D tensor parallel or None for 2D."""
+    if mesh_shape[0] == 1 and mesh_shape[1] > 1:
+        return 1
+    if mesh_shape[1] == 1 and mesh_shape[0] > 1:
+        return 0
+    if mesh_shape[0] > 1 and mesh_shape[1] > 1:
+        return None
+    raise ValueError(f"Expected mesh shape with at least one dimension > 1, got {mesh_shape}")
+
+
+def num_mesh_devices(mesh_shape: tuple[int, int]) -> int:
+    return mesh_shape[0] * mesh_shape[1]
+
+
+@dataclass
+class ModelConfig:
+    """Model configuration extracted from HuggingFace."""
+
+    vocab_size: int
+    hidden_size: int
+    intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    rms_norm_eps: float
+    rope_theta: float
+    rope_scaling: Optional[dict]
+    max_position_embeddings: int
+    hidden_act: str
+
+    @classmethod
+    def from_hf(cls, hf_config) -> "ModelConfig":
+        num_kv_heads = getattr(hf_config, "num_key_value_heads", hf_config.num_attention_heads)
+        head_dim = getattr(hf_config, "head_dim", None)
+        if head_dim is None:
+            head_dim = hf_config.hidden_size // hf_config.num_attention_heads
+        return cls(
+            hf_config.vocab_size,
+            hf_config.hidden_size,
+            hf_config.intermediate_size,
+            hf_config.num_hidden_layers,
+            hf_config.num_attention_heads,
+            num_kv_heads,
+            head_dim,
+            hf_config.rms_norm_eps,
+            hf_config.rope_theta,
+            getattr(hf_config, "rope_scaling", None),
+            hf_config.max_position_embeddings,
+            hf_config.hidden_act,
+        )
+
+
+@dataclass
+class ParallelConfig:
+    mesh_device: ttnn.MeshDevice
+    mesh_shape: tuple[int, int]
+    num_devices: int
+    mesh_axis: Optional[int]
+    num_links: int
+    topology: ttnn.Topology
+    replicate_mapper: object
+    shard_width_mapper: object
+    shard_height_mapper: object
+    shard_kv_mapper: object
+    vocab_composer: object
+
+
+def validate_parallel_config(config: ModelConfig, num_devices: int) -> None:
+    if num_devices != 8:
+        raise ValueError("T3000 model expects an 8-device mesh")
+    if config.hidden_size % num_devices != 0:
+        raise ValueError("hidden_size must divide evenly across devices")
+    if config.intermediate_size % num_devices != 0:
+        raise ValueError("intermediate_size must divide evenly across devices")
+
+
+def padded_head_counts(config: ModelConfig, num_devices: int) -> tuple[int, int]:
+    if config.num_attention_heads % config.num_key_value_heads != 0:
+        raise ValueError("num_attention_heads must be a multiple of num_key_value_heads")
+    head_ratio = config.num_attention_heads // config.num_key_value_heads
+    padded_kv = ((config.num_key_value_heads + num_devices - 1) // num_devices) * num_devices
+    padded_heads = head_ratio * padded_kv
+    return padded_heads, padded_kv
+
+
+def all_reduce_tensor(x: ttnn.Tensor, parallel: ParallelConfig) -> ttnn.Tensor:
+    if parallel.num_devices == 1:
+        return x
+    if parallel.mesh_axis is None:
+        return ttnn.all_reduce(
+            x,
+            num_links=parallel.num_links,
+            topology=parallel.topology,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+    return ttnn.all_reduce(
+        x,
+        cluster_axis=parallel.mesh_axis,
+        num_links=parallel.num_links,
+        topology=parallel.topology,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+def compute_rope_cache(config: ModelConfig, max_seq_len: int) -> tuple[torch.Tensor, torch.Tensor]:
+    """Precompute RoPE cos/sin cache using HF rope utils (supports Yarn)."""
+    rope_type = "default"
+    if config.rope_scaling:
+        rope_type = config.rope_scaling.get("rope_type", config.rope_scaling.get("type", "default"))
+    rope_init_fn = ROPE_INIT_FUNCTIONS[rope_type]
+    inv_freq, attention_scaling = rope_init_fn(config, device=torch.device("cpu"), seq_len=max_seq_len)
+
+    t = torch.arange(max_seq_len, dtype=inv_freq.dtype)
+    freqs = torch.outer(t, inv_freq)
+    emb = torch.cat((freqs, freqs), dim=-1)
+    cos = emb.cos() * attention_scaling
+    sin = emb.sin() * attention_scaling
+
+    cos = cos.unsqueeze(0).unsqueeze(0).to(torch.bfloat16)
+    sin = sin.unsqueeze(0).unsqueeze(0).to(torch.bfloat16)
+    return cos, sin
+
+
+class RMSNorm:
+    """RMSNorm layer."""
+
+    def __init__(self, weight: torch.Tensor, eps: float, parallel: ParallelConfig):
+        self.eps = eps
+        self.weight = ttnn.as_tensor(
+            weight.unsqueeze(0).unsqueeze(0).unsqueeze(0).to(torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=parallel.replicate_mapper,
+        )
+
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        return ttnn.rms_norm(x, epsilon=self.eps, weight=self.weight)
+
+
+class Attention:
+    """
+    Multi-head attention with GQA support, 1D tensor parallel.
+
+    QKV projections are column-parallel. Output projection is row-parallel with
+    an all-reduce to replicate the result.
+    """
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        layer_idx: int,
+        state_dict: dict,
+        cos_cache: ttnn.Tensor,
+        sin_cache: ttnn.Tensor,
+        page_table: ttnn.Tensor,
+        parallel: ParallelConfig,
+        max_seq_len: int,
+        padded_num_heads: int,
+        padded_num_kv_heads: int,
+    ):
+        self.parallel = parallel
+        self.n_heads = padded_num_heads
+        self.n_kv_heads = padded_num_kv_heads
+        self.n_heads_real = config.num_attention_heads
+        self.n_kv_heads_real = config.num_key_value_heads
+        self.n_local_heads = self.n_heads // parallel.num_devices
+        self.n_local_kv_heads = self.n_kv_heads // parallel.num_devices
+        self.head_dim = config.head_dim
+        self.hidden_size = config.hidden_size
+        self.scale = 1.0 / math.sqrt(self.head_dim)
+
+        self.cos_cache = cos_cache
+        self.sin_cache = sin_cache
+        self.page_table = page_table
+
+        p = f"model.layers.{layer_idx}.self_attn."
+        q_weight = self._pad_out_features(state_dict[f"{p}q_proj.weight"], self.n_heads * self.head_dim)
+        k_weight = self._pad_out_features(state_dict[f"{p}k_proj.weight"], self.n_kv_heads * self.head_dim)
+        v_weight = self._pad_out_features(state_dict[f"{p}v_proj.weight"], self.n_kv_heads * self.head_dim)
+        o_weight = self._pad_in_features(state_dict[f"{p}o_proj.weight"], self.n_heads * self.head_dim)
+
+        self.qkv_proj = self._load_qkv_weight(q_weight, k_weight, v_weight, parallel.shard_width_mapper)
+        self.o_proj = self._load_weight(o_weight, parallel.shard_height_mapper)
+
+        max_num_blocks = math.ceil(max_seq_len / PAGED_BLOCK_SIZE)
+        cache_shape = (max_num_blocks, self.n_kv_heads, PAGED_BLOCK_SIZE, self.head_dim)
+        self.k_cache = ttnn.as_tensor(
+            torch.zeros(cache_shape, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=parallel.shard_kv_mapper,
+        )
+        self.v_cache = ttnn.as_tensor(
+            torch.zeros(cache_shape, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=parallel.shard_kv_mapper,
+        )
+
+    def _load_weight(self, w: torch.Tensor, mesh_mapper) -> ttnn.Tensor:
+        """Load weight transposed for ttnn.linear: [out, in] -> [1, 1, in, out]."""
+        return ttnn.as_tensor(
+            w.T.unsqueeze(0).unsqueeze(0).to(torch.bfloat16).contiguous(),
+            dtype=WEIGHT_DTYPE,
+            layout=WEIGHT_LAYOUT,
+            device=self.parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=mesh_mapper,
+        )
+
+    def _pad_out_features(self, w: torch.Tensor, padded_out: int) -> torch.Tensor:
+        if w.shape[0] > padded_out:
+            raise ValueError("padded_out must be >= weight out features")
+        if w.shape[0] == padded_out:
+            return w
+        pad_rows = padded_out - w.shape[0]
+        return torch.nn.functional.pad(w, (0, 0, 0, pad_rows))
+
+    def _pad_in_features(self, w: torch.Tensor, padded_in: int) -> torch.Tensor:
+        if w.shape[1] > padded_in:
+            raise ValueError("padded_in must be >= weight in features")
+        if w.shape[1] == padded_in:
+            return w
+        pad_cols = padded_in - w.shape[1]
+        return torch.nn.functional.pad(w, (0, pad_cols))
+
+    def _load_qkv_weight(self, q_weight: torch.Tensor, k_weight: torch.Tensor, v_weight: torch.Tensor, mesh_mapper) -> ttnn.Tensor:
+        q_chunks = torch.chunk(q_weight, self.parallel.num_devices, dim=0)
+        k_chunks = torch.chunk(k_weight, self.parallel.num_devices, dim=0)
+        v_chunks = torch.chunk(v_weight, self.parallel.num_devices, dim=0)
+        qkv_weight = torch.cat(
+            [torch.cat((q_chunks[i], k_chunks[i], v_chunks[i]), dim=0) for i in range(self.parallel.num_devices)],
+            dim=0,
+        )
+        return self._load_weight(qkv_weight, mesh_mapper)
+
+    def __call__(
+        self,
+        x: ttnn.Tensor,
+        start_pos: int,
+        seq_len: int,
+        cur_pos_tensor: Optional[ttnn.Tensor] = None,
+        decode_cos: Optional[ttnn.Tensor] = None,
+        decode_sin: Optional[ttnn.Tensor] = None,
+        trace_decode: bool = False,
+    ) -> ttnn.Tensor:
+        """Forward pass for prefill (seq_len > 1) or decode (seq_len == 1)."""
+        is_prefill = seq_len > 1
+        padded_seq = pad_to_tile(seq_len)
+
+        if is_prefill:
+            qkv = ttnn.linear(x, self.qkv_proj)
+        else:
+            qkv = ttnn.linear(
+                x,
+                self.qkv_proj,
+                memory_config=ttnn.L1_MEMORY_CONFIG,
+            )
+
+        num_heads = self.n_local_heads
+        num_kv_heads = self.n_local_kv_heads
+
+        if is_prefill:
+            q, k, v = ttnn.experimental.nlp_create_qkv_heads(
+                qkv,
+                num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
+                transpose_k_heads=False,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            ttnn.deallocate(qkv)
+
+            cos = self.cos_cache[:, :, :padded_seq, :]
+            sin = self.sin_cache[:, :, :padded_seq, :]
+            q = ttnn.experimental.rotary_embedding(q, cos, sin)
+            k = ttnn.experimental.rotary_embedding(k, cos, sin)
+
+            ttnn.experimental.paged_fill_cache(self.k_cache, k, self.page_table, batch_idx=0)
+            ttnn.experimental.paged_fill_cache(self.v_cache, v, self.page_table, batch_idx=0)
+
+            attn_out = ttnn.transformer.scaled_dot_product_attention(
+                q, k, v, is_causal=True, scale=self.scale
+            )
+            attn_out = ttnn.experimental.nlp_concat_heads(attn_out, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        else:
+            if cur_pos_tensor is None:
+                raise ValueError("cur_pos_tensor is required for decode")
+
+            q, k, v = ttnn.experimental.nlp_create_qkv_heads_decode(
+                qkv,
+                num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
+                memory_config=ttnn.L1_MEMORY_CONFIG,
+            )
+            if not trace_decode:
+                ttnn.deallocate(qkv)
+
+            q = ttnn.reshape(q, (1, 1, q.shape[1] * num_heads, self.head_dim))
+            if decode_cos is None or decode_sin is None:
+                q = ttnn.experimental.rotary_embedding(q, self.cos_cache, self.sin_cache, start_pos)
+            else:
+                q = ttnn.experimental.rotary_embedding(q, decode_cos, decode_sin)
+            q = ttnn.reshape(q, (1, q.shape[2] // num_heads, num_heads, self.head_dim))
+
+            k = ttnn.reshape(k, (1, 1, k.shape[1] * num_kv_heads, self.head_dim))
+            if decode_cos is None or decode_sin is None:
+                k = ttnn.experimental.rotary_embedding(k, self.cos_cache, self.sin_cache, start_pos)
+            else:
+                k = ttnn.experimental.rotary_embedding(k, decode_cos, decode_sin)
+            k = ttnn.reshape(k, (1, k.shape[2] // num_kv_heads, num_kv_heads, self.head_dim))
+
+            ttnn.experimental.paged_update_cache(
+                self.k_cache, k, update_idxs_tensor=cur_pos_tensor, page_table=self.page_table
+            )
+            ttnn.experimental.paged_update_cache(
+                self.v_cache, v, update_idxs_tensor=cur_pos_tensor, page_table=self.page_table
+            )
+
+            attn_out = ttnn.transformer.paged_scaled_dot_product_attention_decode(
+                q,
+                self.k_cache,
+                self.v_cache,
+                page_table_tensor=self.page_table,
+                cur_pos_tensor=cur_pos_tensor,
+                scale=self.scale,
+                memory_config=ttnn.L1_MEMORY_CONFIG,
+            )
+            attn_out = ttnn.transpose(attn_out, 1, 2)
+            attn_out = ttnn.experimental.nlp_concat_heads(attn_out, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+        expected_width = num_heads * self.head_dim
+        if attn_out.shape[-1] != expected_width:
+            attn_out = ttnn.slice(
+                attn_out,
+                (0, 0, 0, 0),
+                (attn_out.shape[0], attn_out.shape[1], attn_out.shape[2], expected_width),
+            )
+
+        out = ttnn.linear(attn_out, self.o_proj)
+        return all_reduce_tensor(out, self.parallel)
+
+
+class MLP:
+    """Arcee MLP with relu2 activation, 1D tensor parallel."""
+
+    def __init__(self, layer_idx: int, hidden_act: str, state_dict: dict, parallel: ParallelConfig):
+        self.hidden_act = hidden_act
+        self.parallel = parallel
+        p = f"model.layers.{layer_idx}.mlp."
+        self.up_proj = self._load_weight(state_dict[f"{p}up_proj.weight"], parallel.shard_width_mapper)
+        self.down_proj = self._load_weight(state_dict[f"{p}down_proj.weight"], parallel.shard_height_mapper)
+
+    def _load_weight(self, w: torch.Tensor, mesh_mapper) -> ttnn.Tensor:
+        return ttnn.as_tensor(
+            w.T.unsqueeze(0).unsqueeze(0).to(torch.bfloat16).contiguous(),
+            dtype=WEIGHT_DTYPE,
+            layout=WEIGHT_LAYOUT,
+            device=self.parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=mesh_mapper,
+        )
+
+    def _act(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        if self.hidden_act != "relu2":
+            raise ValueError(f"Unsupported activation: {self.hidden_act}")
+        relu = ttnn.relu(x)
+        return ttnn.mul(relu, relu)
+
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        up = ttnn.linear(x, self.up_proj)
+        out = ttnn.linear(self._act(up), self.down_proj)
+        return all_reduce_tensor(out, self.parallel)
+
+
+class DecoderLayer:
+    """Single transformer layer."""
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        layer_idx: int,
+        state_dict: dict,
+        cos_cache: ttnn.Tensor,
+        sin_cache: ttnn.Tensor,
+        page_table: ttnn.Tensor,
+        parallel: ParallelConfig,
+        max_seq_len: int,
+        padded_num_heads: int,
+        padded_num_kv_heads: int,
+    ):
+        p = f"model.layers.{layer_idx}."
+        self.attn_norm = RMSNorm(state_dict[f"{p}input_layernorm.weight"], config.rms_norm_eps, parallel)
+        self.ffn_norm = RMSNorm(state_dict[f"{p}post_attention_layernorm.weight"], config.rms_norm_eps, parallel)
+        self.attn = Attention(
+            config,
+            layer_idx,
+            state_dict,
+            cos_cache,
+            sin_cache,
+            page_table,
+            parallel,
+            max_seq_len,
+            padded_num_heads,
+            padded_num_kv_heads,
+        )
+        self.mlp = MLP(layer_idx, config.hidden_act, state_dict, parallel)
+
+    def __call__(
+        self,
+        x: ttnn.Tensor,
+        start_pos: int,
+        seq_len: int,
+        cur_pos_tensor: Optional[ttnn.Tensor] = None,
+        decode_cos: Optional[ttnn.Tensor] = None,
+        decode_sin: Optional[ttnn.Tensor] = None,
+        trace_decode: bool = False,
+    ) -> ttnn.Tensor:
+        x = ttnn.add(
+            x,
+            self.attn(
+                self.attn_norm(x),
+                start_pos,
+                seq_len,
+                cur_pos_tensor=cur_pos_tensor,
+                decode_cos=decode_cos,
+                decode_sin=decode_sin,
+                trace_decode=trace_decode,
+            ),
+        )
+        x = ttnn.add(x, self.mlp(self.ffn_norm(x)))
+        return x
+
+
+class TtnnArceeForCausalLM(torch.nn.Module, GenerationMixin):
+    """
+    Arcee model with 100% ttnn execution and 1D tensor parallel on T3000.
+    HuggingFace `generate()`-compatible via `GenerationMixin`.
+    """
+
+    def __init__(self, hf_model, tt_device, max_seq_len: Optional[int] = None):
+        super().__init__()
+
+        self.tt_device = tt_device
+        self.hf_config = hf_model.config
+        self.tt_config = ModelConfig.from_hf(hf_model.config)
+        if max_seq_len is None:
+            max_seq_len = self.tt_config.max_position_embeddings
+        self.max_seq_len = max_seq_len
+        self._pos = 0
+        self.vocab_size = self.tt_config.vocab_size
+
+        if self.tt_config.hidden_act != "relu2":
+            raise ValueError(f"hidden_act {self.tt_config.hidden_act} is not supported in this bringup")
+
+        self.config = self.hf_config
+        self.generation_config = GenerationConfig.from_model_config(self.config)
+        if self.generation_config.pad_token_id is None:
+            self.generation_config.pad_token_id = self.generation_config.eos_token_id
+        self._supports_cache_class = False
+        self.main_input_name = "input_ids"
+        self.register_buffer("_torch_dummy", torch.empty(0, dtype=torch.float32), persistent=False)
+
+        mesh_shape = tuple(tt_device.shape)
+        num_devices = num_mesh_devices(mesh_shape)
+        validate_parallel_config(self.tt_config, num_devices)
+
+        padded_num_heads, padded_num_kv_heads = padded_head_counts(self.tt_config, num_devices)
+        self.padded_num_heads = padded_num_heads
+        self.padded_num_kv_heads = padded_num_kv_heads
+
+        mesh_axis = mesh_shape_to_axis(mesh_shape)
+
+        self.parallel = ParallelConfig(
+            mesh_device=tt_device,
+            mesh_shape=mesh_shape,
+            num_devices=num_devices,
+            mesh_axis=mesh_axis,
+            num_links=MESH_NUM_LINKS,
+            topology=MESH_TOPOLOGY,
+            replicate_mapper=ttnn.ReplicateTensorToMesh(tt_device),
+            shard_width_mapper=ttnn.ShardTensorToMesh(tt_device, dim=3),
+            shard_height_mapper=ttnn.ShardTensorToMesh(tt_device, dim=2),
+            shard_kv_mapper=ttnn.ShardTensorToMesh(tt_device, dim=1),
+            vocab_composer=ttnn.ConcatMeshToTensor(tt_device, dim=3),
+        )
+        self.tt_device = tt_device
+        padded_vocab_size = ((self.vocab_size + self.parallel.num_devices - 1) // self.parallel.num_devices) * self.parallel.num_devices
+        self.padded_vocab_size = padded_vocab_size
+
+        state_dict = hf_model.state_dict()
+
+        print("  Loading embeddings...")
+        self.embed = ttnn.as_tensor(
+            state_dict["model.embed_tokens.weight"].unsqueeze(0).unsqueeze(0).to(torch.bfloat16),
+            dtype=WEIGHT_DTYPE,
+            layout=WEIGHT_LAYOUT,
+            device=self.tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+
+        print("  Computing RoPE cache...")
+        cos, sin = compute_rope_cache(self.tt_config, self.max_seq_len)
+        self.cos_cache_host = cos
+        self.sin_cache_host = sin
+        self.cos_cache = ttnn.as_tensor(
+            cos,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=self.tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.sin_cache = ttnn.as_tensor(
+            sin,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=self.tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+
+        max_num_blocks = math.ceil(self.max_seq_len / PAGED_BLOCK_SIZE)
+        page_table = torch.arange(max_num_blocks, dtype=torch.int32).repeat(TILE_SIZE, 1)
+        self.page_table = ttnn.as_tensor(
+            page_table,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=self.tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.decode_token_buffer = ttnn.from_torch(
+            torch.zeros((1, 1, 1, TILE_SIZE), dtype=torch.int32),
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=self.tt_device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.decode_rope_seq = (self.padded_num_heads // self.parallel.num_devices) * TILE_SIZE
+        self.decode_pos_buffer = ttnn.from_torch(
+            torch.zeros((TILE_SIZE,), dtype=torch.int32),
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=self.tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.decode_cos_buffer = ttnn.from_torch(
+            torch.zeros((1, 1, self.decode_rope_seq, self.tt_config.head_dim), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=self.tt_device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.decode_sin_buffer = ttnn.from_torch(
+            torch.zeros((1, 1, self.decode_rope_seq, self.tt_config.head_dim), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=self.tt_device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.use_decode_trace = USE_DECODE_TRACE
+        self.decode_trace_id = None
+        self.decode_trace_logits = None
+
+        print(f"  Loading {self.tt_config.num_hidden_layers} layers...")
+        self.layers = [
+            DecoderLayer(
+                self.tt_config,
+                i,
+                state_dict,
+                self.cos_cache,
+                self.sin_cache,
+                self.page_table,
+                self.parallel,
+                self.max_seq_len,
+                self.padded_num_heads,
+                self.padded_num_kv_heads,
+            )
+            for i in range(self.tt_config.num_hidden_layers)
+        ]
+
+        self.norm = RMSNorm(state_dict["model.norm.weight"], self.tt_config.rms_norm_eps, self.parallel)
+        lm_head_weight = state_dict.get("lm_head.weight", state_dict["model.embed_tokens.weight"])
+        if self.padded_vocab_size != self.vocab_size:
+            pad_rows = self.padded_vocab_size - self.vocab_size
+            lm_head_weight = torch.nn.functional.pad(lm_head_weight, (0, 0, 0, pad_rows))
+        self.lm_head = ttnn.as_tensor(
+            lm_head_weight.T.unsqueeze(0).unsqueeze(0).to(torch.bfloat16).contiguous(),
+            dtype=WEIGHT_DTYPE,
+            layout=WEIGHT_LAYOUT,
+            device=self.tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.shard_width_mapper,
+        )
+
+        self._tt_past_key_values = object()
+
+    @property
+    def device(self) -> torch.device:
+        return self._torch_dummy.device
+
+    def _release_decode_trace(self) -> None:
+        if self.decode_trace_id is None:
+            return
+        ttnn.release_trace(self.tt_device, self.decode_trace_id)
+        self.decode_trace_id = None
+        self.decode_trace_logits = None
+
+    def reset(self):
+        """Reset position counter for new sequence."""
+        self._pos = 0
+        self._release_decode_trace()
+
+    def prepare_inputs_for_generation(self, input_ids, past_key_values=None, **kwargs):
+        if past_key_values is not None:
+            input_ids = input_ids[:, -1:]
+        return {"input_ids": input_ids, "past_key_values": past_key_values, "use_cache": True}
+
+    def _reorder_cache(self, past_key_values, beam_idx):
+        return past_key_values
+
+    def _logits_to_torch(self, logits: ttnn.Tensor) -> torch.Tensor:
+        if self.parallel.num_devices > 1:
+            return ttnn.to_torch(logits, mesh_composer=self.parallel.vocab_composer)
+        return ttnn.to_torch(logits)
+
+    def _forward_prefill(self, input_ids: torch.Tensor, start_pos: int, seq_len: int) -> ttnn.Tensor:
+        tokens = ttnn.from_torch(
+            input_ids.reshape(1, 1, 1, -1),
+            dtype=ttnn.uint32,
+            device=self.tt_device,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        h = ttnn.embedding(tokens, self.embed, layout=ttnn.TILE_LAYOUT)
+        for layer in self.layers:
+            h = layer(h, start_pos, seq_len)
+        h = self.norm(h)
+        return ttnn.linear(h, self.lm_head)
+
+    def _forward_prefill_last_logits(self, input_ids: torch.Tensor, start_pos: int, seq_len: int) -> ttnn.Tensor:
+        tokens = ttnn.from_torch(
+            input_ids.reshape(1, 1, 1, -1),
+            dtype=ttnn.uint32,
+            device=self.tt_device,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        h = ttnn.embedding(tokens, self.embed, layout=ttnn.TILE_LAYOUT)
+        for layer in self.layers:
+            h = layer(h, start_pos, seq_len)
+        h = self.norm(h)
+        last_token_idx = seq_len - 1
+        h_last = ttnn.slice(
+            h,
+            (0, 0, last_token_idx, 0),
+            (h.shape[0], h.shape[1], last_token_idx + 1, h.shape[-1]),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        ttnn.deallocate(h)
+        return ttnn.linear(h_last, self.lm_head)
+
+    def _update_decode_token_buffer(self, input_ids: torch.Tensor) -> None:
+        token_ids = torch.zeros((TILE_SIZE,), dtype=torch.int32)
+        token_ids[: input_ids.numel()] = input_ids.view(-1).to(torch.int32)
+        token_ids = token_ids.reshape(1, 1, 1, -1)
+        host_tokens = ttnn.from_torch(
+            token_ids,
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        ttnn.copy_host_to_device_tensor(host_tokens, self.decode_token_buffer)
+
+    def _update_decode_pos_buffer(self, start_pos: int) -> None:
+        pos = torch.full((TILE_SIZE,), -1, dtype=torch.int32)
+        pos[0] = start_pos
+        host_pos = ttnn.from_torch(
+            pos,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        ttnn.copy_host_to_device_tensor(host_pos, self.decode_pos_buffer)
+
+    def _update_decode_rope_buffers(self, start_pos: int) -> None:
+        cos_token = self.cos_cache_host[:, :, start_pos : start_pos + 1, :]
+        sin_token = self.sin_cache_host[:, :, start_pos : start_pos + 1, :]
+        cos_slice = cos_token.repeat(1, 1, self.decode_rope_seq, 1)
+        sin_slice = sin_token.repeat(1, 1, self.decode_rope_seq, 1)
+        host_cos = ttnn.from_torch(
+            cos_slice,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+        )
+        host_sin = ttnn.from_torch(
+            sin_slice,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+        )
+        ttnn.copy_host_to_device_tensor(host_cos, self.decode_cos_buffer)
+        ttnn.copy_host_to_device_tensor(host_sin, self.decode_sin_buffer)
+
+    def _forward_decode_device(self, start_pos: int, trace_decode: bool) -> ttnn.Tensor:
+        h = ttnn.embedding(self.decode_token_buffer, self.embed, layout=ttnn.TILE_LAYOUT)
+        for layer in self.layers:
+            h = layer(
+                h,
+                start_pos,
+                1,
+                cur_pos_tensor=self.decode_pos_buffer,
+                decode_cos=self.decode_cos_buffer,
+                decode_sin=self.decode_sin_buffer,
+                trace_decode=trace_decode,
+            )
+        h = self.norm(h)
+        h = ttnn.slice(
+            h,
+            (0, 0, 0, 0),
+            (h.shape[0], h.shape[1], 1, h.shape[-1]),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        return ttnn.linear(h, self.lm_head)
+
+    def _forward_decode(self, input_ids: torch.Tensor, start_pos: int) -> ttnn.Tensor:
+        self._update_decode_token_buffer(input_ids)
+        self._update_decode_pos_buffer(start_pos)
+        self._update_decode_rope_buffers(start_pos)
+
+        if self.use_decode_trace:
+            if self.decode_trace_id is None:
+                warmup_logits = self._forward_decode_device(start_pos, False)
+                ttnn.deallocate(warmup_logits)
+                self.decode_trace_id = ttnn.begin_trace_capture(self.tt_device)
+                self.decode_trace_logits = self._forward_decode_device(start_pos, True)
+                ttnn.end_trace_capture(self.tt_device, self.decode_trace_id)
+            else:
+                ttnn.execute_trace(self.tt_device, self.decode_trace_id, blocking=False)
+            return self.decode_trace_logits
+        return self._forward_decode_device(start_pos, False)
+
+    def _forward_device_logits(self, input_ids: torch.Tensor, past_key_values, use_cache: bool):
+        batch, seq_len = input_ids.shape
+        if batch != 1:
+            raise ValueError("Only batch=1 supported")
+
+        if past_key_values is None:
+            self.reset()
+        elif seq_len != 1:
+            raise ValueError("Only 1-token decode supported when using cache")
+
+        start_pos = self._pos
+        if start_pos + seq_len > self.max_seq_len:
+            raise ValueError(
+                f"sequence length {start_pos + seq_len} exceeds max_seq_len {self.max_seq_len}"
+            )
+
+        if seq_len == 1:
+            logits = self._forward_decode(input_ids, start_pos)
+            padded_seq = 1
+        else:
+            padded_seq = pad_to_tile(seq_len)
+            if seq_len < padded_seq:
+                input_ids = torch.nn.functional.pad(input_ids, (0, padded_seq - seq_len), value=0)
+            logits = self._forward_prefill(input_ids, start_pos, seq_len)
+
+        self._pos = start_pos + seq_len
+        past = self._tt_past_key_values if use_cache else None
+        return logits, seq_len, padded_seq, past
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        past_key_values=None,
+        use_cache: bool = True,
+        cache_position: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> CausalLMOutputWithPast:
+        """Forward pass compatible with HuggingFace generate()."""
+        batch = input_ids.shape[0]
+        logits_device, seq_len, padded_seq, past = self._forward_device_logits(input_ids, past_key_values, use_cache)
+        logits = self._logits_to_torch(logits_device)
+        logits = logits.reshape(batch, padded_seq, -1)[:, :seq_len, : self.vocab_size]
+
+        if seq_len > 1 or not self.use_decode_trace:
+            ttnn.deallocate(logits_device)
+
+        return CausalLMOutputWithPast(
+            logits=logits.float(),
+            past_key_values=past,
+        )
+
+    def prefill_logits_last_device(self, input_ids: torch.Tensor, use_cache: bool = True) -> tuple[torch.Tensor, object]:
+        batch, seq_len = input_ids.shape
+        if batch != 1:
+            raise ValueError("Only batch=1 supported")
+
+        self.reset()
+        start_pos = self._pos
+        if start_pos + seq_len > self.max_seq_len:
+            raise ValueError(
+                f"sequence length {start_pos + seq_len} exceeds max_seq_len {self.max_seq_len}"
+            )
+
+        padded_seq = pad_to_tile(seq_len)
+        if seq_len < padded_seq:
+            input_ids = torch.nn.functional.pad(input_ids, (0, padded_seq - seq_len), value=0)
+
+        logits_device = self._forward_prefill_last_logits(input_ids, start_pos, seq_len)
+        self._pos = start_pos + seq_len
+        logits = self._logits_to_torch(logits_device).reshape(batch, 1, -1)[:, 0, : self.vocab_size].float()
+        ttnn.deallocate(logits_device)
+
+        past = self._tt_past_key_values if use_cache else None
+        return logits, past
+
+
+def build_model(hf_model, tt_device, max_seq_len: Optional[int] = None) -> TtnnArceeForCausalLM:
+    """Build the ttnn model from a HuggingFace reference model."""
+    return TtnnArceeForCausalLM(hf_model, tt_device, max_seq_len)


### PR DESCRIPTION
## Summary
- optimize `models/arcee-ai/AFM-4.5B/t3000/optimized` for T3000
- fuse attention Q/K/V projection into a single matmul while preserving padded-head TP layout
- keep decode traced execution and prefill-last-logits fast path
- refresh `MODELS.md`, `MODEL_BRINGUP.md`, `demo.log`, and `eval.log` with current results

## Results (t3000 optimized)
- Top-1: 98%
- Top-5: 100%
- TTFT: 69ms
- t/s/u: 29.0
- Seq len: 65536

## Validation
- `python -m py_compile models/arcee-ai/AFM-4.5B/t3000/optimized/model.py`
- `python demo.py models/arcee-ai/AFM-4.5B/t3000/optimized/model.py --seed 0`
- `python eval.py models/arcee-ai/AFM-4.5B/t3000/optimized/model.py --model arcee-ai/AFM-4.5B --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 65536`

Fixes #132
