### PR TITLE
models/Qwen/Qwen3-0.6B/t3000/optimized

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -34,6 +34,7 @@ Note: Keep the table columns padded with spaces and right-justify numeric cells 
 | Qwen/Qwen3-0.6B                     |   n150   | functional |   99% |  100% |   52ms |  28.0 |   40960 |
 | Qwen/Qwen3-0.6B                     |   n300   | functional |   99% |  100% |  943ms |   2.0 |   40960 |
 | Qwen/Qwen3-0.6B                     |  t3000   | functional |   98% |  100% |  229ms |   6.2 |   40960 |
+| Qwen/Qwen3-0.6B                     |  t3000   | optimized  |   98% |  100% |   59ms |  61.9 |   40960 |
 | google/gemma-3-4b-it                |   n150   | functional |   92% |  100% |   98ms |  13.9 |   40960 |
 | google/gemma-3-4b-it                |   n300   | functional |   94% |  100% |  535ms |   3.2 |   40960 |
 | google/gemma-3-4b-it                |  t3000   | functional |   92% |  100% |  330ms |   4.7 |   40960 |

--- a/models/Qwen/Qwen3-0.6B/t3000/optimized/MODEL_BRINGUP.md
+++ b/models/Qwen/Qwen3-0.6B/t3000/optimized/MODEL_BRINGUP.md
@@ -1,0 +1,63 @@
+# MODEL_BRINGUP.md - Qwen3 0.6B (t3000 optimized)
+
+## Overview
+This is the optimized TTNN bringup of `Qwen/Qwen3-0.6B` for `t3000`.
+
+- Model code: `models/Qwen/Qwen3-0.6B/t3000/optimized/model.py`
+- Demo log: `models/Qwen/Qwen3-0.6B/t3000/optimized/demo.log`
+- Eval log: `models/Qwen/Qwen3-0.6B/t3000/optimized/eval.log`
+- Machine-readable metrics: `models/Qwen/Qwen3-0.6B/t3000/optimized/metrics.json`
+- Decode path uses traced execution (`ttnn.begin_trace_capture` + `ttnn.execute_trace`).
+
+## Baseline vs final
+| Metric | Functional baseline (`MODELS.md`) | Final optimized |
+| --- | ---: | ---: |
+| Top-1 | 98% | 98% |
+| Top-5 | 100% | 100% |
+| TTFT | 229 ms | 59 ms |
+| t/s/u | 6.2 | 61.9 |
+| Seq len | 40960 | 40960 |
+
+## Kept optimization decisions
+1. Decode trace with preallocated decode buffers.
+- Preallocates token ids, position tensor, and RoPE cos/sin buffers.
+- Captures a stable decode graph and replays it with `ttnn.execute_trace`.
+
+2. Prefill last-token logits fast path (`prefill_logits_last_device`).
+- Avoids materializing full prefill logits when only the final prompt token is needed.
+
+3. Paged KV cache (block_size=64).
+- Cache layout: `[max_num_blocks, n_kv_heads, block_size, head_dim]`.
+- Uses identity page table and paged update/fill ops.
+
+4. Fused QKV projection.
+- Replaces 3 matmuls (`q_proj`, `k_proj`, `v_proj`) + concat with one `qkv_proj` matmul.
+- Builds fused weight with TP-safe shard ordering: per-shard `[q_i, k_i, v_i]`.
+
+## Rejected optimization attempts
+- None yet.
+
+## Commands used
+```bash
+TT_VISIBLE_DEVICES=0,1,2,3 \
+TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto \
+TT_METAL_CACHE=/tmp/tt-metal-cache \
+PYTHONUNBUFFERED=1 \
+python -u demo.py models/Qwen/Qwen3-0.6B/t3000/optimized/model.py \
+  --seed 0 \
+  --max_seq_len 40960
+
+TT_VISIBLE_DEVICES=0,1,2,3 \
+TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto \
+TT_METAL_CACHE=/tmp/tt-metal-cache \
+PYTHONUNBUFFERED=1 \
+python -u eval.py models/Qwen/Qwen3-0.6B/t3000/optimized/model.py \
+  --model Qwen/Qwen3-0.6B \
+  --prompt_file prompts/bringup_eval_long.txt \
+  --max_new_tokens 100 \
+  --max_seq_len 40960
+```
+
+## Environment note
+On this host, `tt-smi` in `/home/moconnor/bin/` is broken (`bad interpreter`).
+Use `/proj_sw/user_dev/moconnor/tt-metal/python_env/bin/python3 -m tt_smi` for reset/list.

--- a/models/Qwen/Qwen3-0.6B/t3000/optimized/demo.log
+++ b/models/Qwen/Qwen3-0.6B/t3000/optimized/demo.log
@@ -1,0 +1,78 @@
+TT_VISIBLE_DEVICES=0,1,2,3 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto TT_METAL_CACHE=/tmp/tt-metal-cache PYTHONUNBUFFERED=1 python -u demo.py models/Qwen/Qwen3-0.6B/t3000/optimized/model.py --seed 0 --max_seq_len 40960
+2026-02-12 07:58:37.394 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
+Loading tokenizer: Qwen/Qwen3-0.6B
+Opening TT device...
+2026-02-12 07:58:38.069 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 07:58:38.100 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-12 07:58:38.109 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 07:58:38.182 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 07:58:38.246 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 07:58:38.297 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x208 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 07:58:38.307 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 07:58:38.318 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x41 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 07:58:38.328 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 07:58:38.341 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x208 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 07:58:38.355 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x300 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 07:58:38.368 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x42 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 07:58:38.381 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 1, 2, 3] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
+2026-02-12 07:58:38.381 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-12 07:58:38.381 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-12 07:58:38.390 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-12 07:58:38.391 | info     |             UMD | Mapped hugepage 0x340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 07:58:38.391 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 07:58:38.392 | info     |             UMD | Mapped hugepage 0x440000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 07:58:38.393 | info     |             UMD | Mapped hugepage 0x400000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 07:58:38.394 | info     |             UMD | Mapped hugepage 0x4240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 07:58:38.395 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 07:58:38.396 | info     |             UMD | Mapped hugepage 0x4340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 07:58:38.396 | info     |             UMD | Mapped hugepage 0x4300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 07:58:38.454 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto (metal_context.cpp:822)
+2026-02-12 07:58:38.455 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-12 07:58:38.460 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-12 07:58:38.460 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-12 07:58:38.465 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 07:58:38.468 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 07:58:38.468 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 07:58:38.468 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 07:58:38.468 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 07:58:38.469 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 07:58:38.469 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 07:58:38.469 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 07:58:38.788 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
+2026-02-12 07:58:38.788 | info     |           Metal | Dispatch on FabricConfig::FABRIC_2D with 1 Command Queues
+ (device_manager.cpp:328)
+2026-02-12 07:58:38.806 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
+2026-02-12 07:58:38.948 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
+2026-02-12 07:58:38.978 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
+2026-02-12 07:58:38.979 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
+2026-02-12 07:58:38.979 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
+2026-02-12 07:58:38.982 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
+2026-02-12 07:58:38.986 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
+2026-02-12 07:58:38.992 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
+2026-02-12 07:58:38.998 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
+2026-02-12 07:58:38.998 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_2D (device_manager.cpp:409)
+2026-02-12 07:58:39.076 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
+2026-02-12 07:58:39.077 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
+2026-02-12 07:58:39.077 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
+2026-02-12 07:58:39.079 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
+Loading HuggingFace reference model on CPU: Qwen/Qwen3-0.6B
+Building TT model...
+  Loading embeddings...
+  Computing RoPE cache...
+  Loading 28 layers...
+Running one warmup prefill+decode pass (kernel compile warmup)...
+TT demo (t3000)
+Model: Qwen/Qwen3-0.6B
+Mesh shape: 2x4
+Prompt tokens: 56 | Generated tokens: 128
+TTFT: 59 ms | Decode: 61.9 t/s/u (126 tokens)
+
+Prompt:
+Journal entry, 1957: Tonight a tiny sphere called Sputnik 1 crossed the sky, beeping like a metronome for a new era. The neighbors gathered on the roof, listening and arguing about what comes next. I wrote in my notebook that
+
+Output:
+ I could not understand what was happening. The answer, of course, was that the United Nations had launched a new world order, a new era of progress. I was a teenager, the young man of my youth, and I could not agree with it or be swayed by it, for what the United Nations did was not what I believed in. What I believed in was my own, the American dream, the dream of the young man of my youth, the dream that every young man could achieve in his own way, in his own time. In my younger days, I would have known that the dream would not come to him
+YT_METRICS={"mode": "tt_demo", "model": "Qwen/Qwen3-0.6B", "system": "t3000", "mesh_shape": [2, 4], "prompt_tokens": 56, "generated_tokens": 128, "ttft_ms": 59.24348719418049, "decode_tps_u": 61.91652416665636, "decode_tokens": 126, "max_seq_len": 40960}
+2026-02-12 08:00:10.844 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-12 08:00:10.844 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/Qwen/Qwen3-0.6B/t3000/optimized/eval.log
+++ b/models/Qwen/Qwen3-0.6B/t3000/optimized/eval.log
@@ -1,0 +1,72 @@
+TT_VISIBLE_DEVICES=0,1,2,3 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto TT_METAL_CACHE=/tmp/tt-metal-cache PYTHONUNBUFFERED=1 python -u eval.py models/Qwen/Qwen3-0.6B/t3000/optimized/model.py --model Qwen/Qwen3-0.6B --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 40960
+2026-02-12 08:00:39.654 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
+Loading model module: /localdev/moconnor/ttnn_models/models/Qwen/Qwen3-0.6B/t3000/optimized/model.py
+Loading HuggingFace tokenizer...
+Loading HuggingFace reference model on CPU...
+Generating reference tokens...
+The following generation flags are not valid and may be ignored: ['temperature', 'top_p', 'top_k']. Set `TRANSFORMERS_VERBOSITY=info` for more details.
+Opening device (2x4)...
+2026-02-12 08:01:12.776 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 08:01:12.807 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-12 08:01:12.818 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 08:01:12.896 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 08:01:12.958 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 08:01:13.004 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x208 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 08:01:13.014 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 08:01:13.024 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x41 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 08:01:13.034 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 08:01:13.048 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x208 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 08:01:13.061 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x300 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 08:01:13.076 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x42 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 08:01:13.089 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 1, 2, 3] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
+2026-02-12 08:01:13.089 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-12 08:01:13.089 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-12 08:01:13.098 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-12 08:01:13.099 | info     |             UMD | Mapped hugepage 0x340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 08:01:13.099 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 08:01:13.100 | info     |             UMD | Mapped hugepage 0x440000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 08:01:13.101 | info     |             UMD | Mapped hugepage 0x400000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 08:01:13.102 | info     |             UMD | Mapped hugepage 0x4240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 08:01:13.103 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 08:01:13.103 | info     |             UMD | Mapped hugepage 0x4340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 08:01:13.104 | info     |             UMD | Mapped hugepage 0x4300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 08:01:13.154 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto (metal_context.cpp:822)
+2026-02-12 08:01:13.155 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-12 08:01:13.160 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-12 08:01:13.160 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-12 08:01:13.165 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 08:01:13.167 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 08:01:13.168 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 08:01:13.168 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 08:01:13.168 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 08:01:13.168 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 08:01:13.169 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 08:01:13.169 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 08:01:13.482 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
+2026-02-12 08:01:13.482 | info     |           Metal | Dispatch on FabricConfig::FABRIC_2D with 1 Command Queues
+ (device_manager.cpp:328)
+2026-02-12 08:01:13.503 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
+2026-02-12 08:01:13.652 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
+2026-02-12 08:01:13.655 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
+2026-02-12 08:01:13.656 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
+2026-02-12 08:01:13.657 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
+2026-02-12 08:01:13.660 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
+2026-02-12 08:01:13.663 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
+2026-02-12 08:01:13.670 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
+2026-02-12 08:01:13.676 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
+2026-02-12 08:01:13.676 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_2D (device_manager.cpp:409)
+2026-02-12 08:01:13.758 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
+2026-02-12 08:01:13.759 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
+2026-02-12 08:01:13.759 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
+2026-02-12 08:01:13.761 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
+Loading ttnn model...
+  Loading embeddings...
+  Computing RoPE cache...
+  Loading 28 layers...
+Running teacher-forcing eval (100 tokens)...
+Top-1 accuracy: 98.00% (0.9800)
+Top-5 accuracy: 100.00% (1.0000)
+YT_METRICS={"mode": "tt_eval", "model": "Qwen/Qwen3-0.6B", "top1": 0.98, "top5": 1.0, "top1_pct": 98.0, "top5_pct": 100.0, "total_tokens": 100, "max_new_tokens": 100, "max_seq_len": 40960}
+2026-02-12 08:02:22.085 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-12 08:02:22.085 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/Qwen/Qwen3-0.6B/t3000/optimized/metrics.json
+++ b/models/Qwen/Qwen3-0.6B/t3000/optimized/metrics.json
@@ -1,0 +1,26 @@
+{
+  "model": "Qwen/Qwen3-0.6B",
+  "hardware": "t3000",
+  "variant": "optimized",
+  "functional_baseline": {
+    "top1_pct": 98.0,
+    "top5_pct": 100.0,
+    "ttft_ms": 229.0,
+    "decode_tps_u": 6.2,
+    "seq_len": 40960
+  },
+  "optimized_final": {
+    "top1_pct": 98.0,
+    "top5_pct": 100.0,
+    "ttft_ms": 59.24348719418049,
+    "decode_tps_u": 61.91652416665636,
+    "seq_len": 40960
+  },
+  "acceptance": {
+    "top1_top5_pass": true,
+    "decode_trace_enabled": true,
+    "ttft_improved": true,
+    "decode_tps_improved": true,
+    "seq_len_non_regressed": true
+  }
+}

--- a/models/Qwen/Qwen3-0.6B/t3000/optimized/model.py
+++ b/models/Qwen/Qwen3-0.6B/t3000/optimized/model.py
@@ -1,0 +1,920 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Qwen3 0.6B optimized TTNN model for T3000.
+
+Optimizations versus the functional bringup:
+- Paged KV cache (block_size=64) for long max_seq_len.
+- Fused QKV projection (single matmul) with TP-safe shard ordering.
+- Decode trace with preallocated token/pos/RoPE buffers.
+- Prefill last-token logits fast path (`prefill_logits_last_device`) to lower TTFT.
+
+Use `eval.py` at repo root for teacher-forcing accuracy checks against the
+HuggingFace reference.
+"""
+
+import math
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import ttnn
+from transformers import GenerationConfig
+from transformers.generation.utils import GenerationMixin
+from transformers.modeling_outputs import CausalLMOutputWithPast
+
+
+TILE_SIZE = 32
+PAGED_BLOCK_SIZE = 64
+
+MESH_SHAPE = (2, 4)
+MESH_TOPOLOGY = ttnn.Topology.Linear
+MESH_NUM_LINKS = 1
+
+USE_DECODE_TRACE = True
+DECODE_MEMORY_CONFIG = ttnn.DRAM_MEMORY_CONFIG
+
+ATTN_WEIGHT_DTYPE = ttnn.bfloat16
+MLP_WEIGHT_DTYPE = ttnn.bfloat8_b
+LM_HEAD_WEIGHT_DTYPE = ttnn.bfloat16
+WEIGHT_LAYOUT = ttnn.TILE_LAYOUT
+
+
+def pad_to_tile(x: int) -> int:
+    """Pad to tile boundary (32)."""
+    return ((x + TILE_SIZE - 1) // TILE_SIZE) * TILE_SIZE
+
+
+def mesh_shape_to_axis(mesh_shape: tuple[int, int]) -> Optional[int]:
+    """Return the mesh axis used for 1D tensor parallel or None for 2D."""
+    if mesh_shape[0] == 1 and mesh_shape[1] > 1:
+        return 1
+    if mesh_shape[1] == 1 and mesh_shape[0] > 1:
+        return 0
+    if mesh_shape[0] > 1 and mesh_shape[1] > 1:
+        return None
+    raise ValueError(f"Expected mesh shape with at least one dimension > 1, got {mesh_shape}")
+
+
+def num_mesh_devices(mesh_shape: tuple[int, int]) -> int:
+    return mesh_shape[0] * mesh_shape[1]
+
+
+@dataclass
+class ModelConfig:
+    """Model configuration extracted from HuggingFace."""
+
+    vocab_size: int
+    hidden_size: int
+    intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    rms_norm_eps: float
+    rope_theta: float
+    rope_scaling: Optional[dict]
+    attention_bias: bool
+    hidden_act: str
+    tie_word_embeddings: bool
+
+    @classmethod
+    def from_hf(cls, hf_config) -> "ModelConfig":
+        num_kv_heads = getattr(hf_config, "num_key_value_heads", hf_config.num_attention_heads)
+        head_dim = getattr(hf_config, "head_dim", None)
+        if head_dim is None:
+            head_dim = hf_config.hidden_size // hf_config.num_attention_heads
+        return cls(
+            vocab_size=hf_config.vocab_size,
+            hidden_size=hf_config.hidden_size,
+            intermediate_size=hf_config.intermediate_size,
+            num_hidden_layers=hf_config.num_hidden_layers,
+            num_attention_heads=hf_config.num_attention_heads,
+            num_key_value_heads=num_kv_heads,
+            head_dim=head_dim,
+            rms_norm_eps=hf_config.rms_norm_eps,
+            rope_theta=hf_config.rope_theta,
+            rope_scaling=hf_config.rope_scaling,
+            attention_bias=hf_config.attention_bias,
+            hidden_act=hf_config.hidden_act,
+            tie_word_embeddings=hf_config.tie_word_embeddings,
+        )
+
+
+@dataclass
+class ParallelConfig:
+    mesh_device: ttnn.MeshDevice
+    mesh_shape: tuple[int, int]
+    num_devices: int
+    mesh_axis: Optional[int]
+    num_links: int
+    topology: ttnn.Topology
+    replicate_mapper: object
+    shard_width_mapper: object
+    shard_height_mapper: object
+    shard_kv_mapper: object
+    vocab_composer: object
+
+
+@dataclass
+class PagedAttentionConfig:
+    block_size: int
+    max_num_blocks: int
+
+
+def validate_parallel_config(config: ModelConfig, num_devices: int) -> None:
+    if num_devices != 8:
+        raise ValueError("T3000 model expects an 8-device mesh")
+    if config.num_attention_heads % num_devices != 0:
+        raise ValueError("num_attention_heads must divide evenly across devices")
+    if config.num_key_value_heads % num_devices != 0:
+        raise ValueError("num_key_value_heads must divide evenly across devices")
+    if config.hidden_size % num_devices != 0:
+        raise ValueError("hidden_size must divide evenly across devices")
+    if config.intermediate_size % num_devices != 0:
+        raise ValueError("intermediate_size must divide evenly across devices")
+
+
+def all_reduce_tensor(x: ttnn.Tensor, parallel: ParallelConfig) -> ttnn.Tensor:
+    if parallel.num_devices == 1:
+        return x
+    if parallel.mesh_axis is None:
+        return ttnn.all_reduce(
+            x,
+            num_links=parallel.num_links,
+            topology=parallel.topology,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+    return ttnn.all_reduce(
+        x,
+        cluster_axis=parallel.mesh_axis,
+        num_links=parallel.num_links,
+        topology=parallel.topology,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+def compute_rope_cache(config: ModelConfig, max_seq_len: int) -> tuple[torch.Tensor, torch.Tensor]:
+    """Precompute RoPE cos/sin cache in HuggingFace format.
+
+    Returns cos, sin tensors of shape [1, 1, max_seq_len, head_dim].
+    """
+    if config.rope_scaling:
+        rope_type = config.rope_scaling.get("rope_type", config.rope_scaling.get("type"))
+        if rope_type != "default":
+            raise ValueError(f"rope_scaling {rope_type} is not supported in this bringup")
+
+    head_dim = config.head_dim
+    inv_freq = 1.0 / (config.rope_theta ** (torch.arange(0, head_dim, 2).float() / head_dim))
+    t = torch.arange(max_seq_len, dtype=inv_freq.dtype)
+    freqs = torch.outer(t, inv_freq)
+    emb = torch.cat((freqs, freqs), dim=-1)
+    cos = emb.cos().unsqueeze(0).unsqueeze(0).to(torch.bfloat16)
+    sin = emb.sin().unsqueeze(0).unsqueeze(0).to(torch.bfloat16)
+    return cos, sin
+
+
+class RMSNorm:
+    """RMSNorm layer."""
+
+    def __init__(self, weight: torch.Tensor, eps: float, parallel: ParallelConfig):
+        self.eps = eps
+        self.weight = ttnn.as_tensor(
+            weight.unsqueeze(0).unsqueeze(0).unsqueeze(0).to(torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=parallel.replicate_mapper,
+        )
+
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        return ttnn.rms_norm(x, epsilon=self.eps, weight=self.weight)
+
+
+class Attention:
+    """Multi-head attention with GQA support, 1D tensor parallel.
+
+    Includes Q/K RMSNorm on the head dimension, matching Qwen3.
+
+    QKV projections are column-parallel. Output projection is row-parallel with
+    an all-reduce to replicate the result.
+    """
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        layer_idx: int,
+        state_dict: dict,
+        cos_cache: ttnn.Tensor,
+        sin_cache: ttnn.Tensor,
+        parallel: ParallelConfig,
+        paged_attention_config: PagedAttentionConfig,
+        page_table: ttnn.Tensor,
+    ):
+        self.layer_idx = layer_idx
+        self.parallel = parallel
+        self.n_heads = config.num_attention_heads
+        self.n_kv_heads = config.num_key_value_heads
+        self.n_local_heads = self.n_heads // parallel.num_devices
+        self.n_local_kv_heads = self.n_kv_heads // parallel.num_devices
+        self.head_dim = config.head_dim
+        self.scale = 1.0 / math.sqrt(self.head_dim)
+        self.paged_attention_config = paged_attention_config
+        self.page_table = page_table
+
+        if config.attention_bias:
+            raise ValueError("attention_bias=True is not supported in this bringup")
+
+        self.cos_cache = cos_cache
+        self.sin_cache = sin_cache
+
+        p = f"model.layers.{layer_idx}.self_attn."
+        self.qkv_proj = self._load_qkv_weight(
+            state_dict[f"{p}q_proj.weight"],
+            state_dict[f"{p}k_proj.weight"],
+            state_dict[f"{p}v_proj.weight"],
+            parallel.shard_width_mapper,
+        )
+        self.o_proj = self._load_weight(state_dict[f"{p}o_proj.weight"], parallel.shard_height_mapper, ATTN_WEIGHT_DTYPE)
+        self.q_norm = RMSNorm(state_dict[f"{p}q_norm.weight"], config.rms_norm_eps, parallel)
+        self.k_norm = RMSNorm(state_dict[f"{p}k_norm.weight"], config.rms_norm_eps, parallel)
+
+        cache_shape = (
+            self.paged_attention_config.max_num_blocks,
+            self.n_kv_heads,
+            self.paged_attention_config.block_size,
+            self.head_dim,
+        )
+        self.k_cache = ttnn.as_tensor(
+            torch.zeros(cache_shape, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=parallel.shard_kv_mapper,
+        )
+        self.v_cache = ttnn.as_tensor(
+            torch.zeros(cache_shape, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=parallel.shard_kv_mapper,
+        )
+
+    def _load_weight(self, w: torch.Tensor, mesh_mapper, dtype) -> ttnn.Tensor:
+        """Load weight transposed for ttnn.linear: [out, in] -> [1, 1, in, out]."""
+        return ttnn.as_tensor(
+            w.T.unsqueeze(0).unsqueeze(0).to(torch.bfloat16).contiguous(),
+            dtype=dtype,
+            layout=WEIGHT_LAYOUT,
+            device=self.parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=mesh_mapper,
+        )
+
+    def _load_qkv_weight(self, q_weight: torch.Tensor, k_weight: torch.Tensor, v_weight: torch.Tensor, mesh_mapper) -> ttnn.Tensor:
+        q_chunks = torch.chunk(q_weight, self.parallel.num_devices, dim=0)
+        k_chunks = torch.chunk(k_weight, self.parallel.num_devices, dim=0)
+        v_chunks = torch.chunk(v_weight, self.parallel.num_devices, dim=0)
+        qkv_weight = torch.cat(
+            [torch.cat((q_chunks[i], k_chunks[i], v_chunks[i]), dim=0) for i in range(self.parallel.num_devices)],
+            dim=0,
+        )
+        return self._load_weight(qkv_weight, mesh_mapper, ATTN_WEIGHT_DTYPE)
+
+    def __call__(
+        self,
+        x: ttnn.Tensor,
+        start_pos: int,
+        seq_len: int,
+        cur_pos_tensor: Optional[ttnn.Tensor] = None,
+        decode_cos_q: Optional[ttnn.Tensor] = None,
+        decode_sin_q: Optional[ttnn.Tensor] = None,
+        decode_cos_k: Optional[ttnn.Tensor] = None,
+        decode_sin_k: Optional[ttnn.Tensor] = None,
+        trace_decode: bool = False,
+    ) -> ttnn.Tensor:
+        is_prefill = seq_len > 1
+        padded_seq = x.shape[2]
+
+        if is_prefill:
+            qkv = ttnn.linear(x, self.qkv_proj)
+        else:
+            qkv = ttnn.linear(x, self.qkv_proj, memory_config=DECODE_MEMORY_CONFIG)
+
+        num_heads = self.n_local_heads
+        num_kv_heads = self.n_local_kv_heads
+
+        if is_prefill:
+            q, k, v = ttnn.experimental.nlp_create_qkv_heads(
+                qkv,
+                num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
+                transpose_k_heads=False,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            ttnn.deallocate(qkv)
+
+            q_mem = ttnn.get_memory_config(q)
+            k_mem = ttnn.get_memory_config(k)
+            q = ttnn.to_memory_config(q, ttnn.DRAM_MEMORY_CONFIG)
+            k = ttnn.to_memory_config(k, ttnn.DRAM_MEMORY_CONFIG)
+            q = self.q_norm(q)
+            k = self.k_norm(k)
+            q = ttnn.to_memory_config(q, q_mem)
+            k = ttnn.to_memory_config(k, k_mem)
+
+            cos = self.cos_cache[:, :, :padded_seq, :]
+            sin = self.sin_cache[:, :, :padded_seq, :]
+            q = ttnn.experimental.rotary_embedding(q, cos, sin)
+            k = ttnn.experimental.rotary_embedding(k, cos, sin)
+
+            ttnn.experimental.paged_fill_cache(self.k_cache, k, self.page_table, batch_idx=0)
+            ttnn.experimental.paged_fill_cache(self.v_cache, v, self.page_table, batch_idx=0)
+
+            attn_out = ttnn.transformer.scaled_dot_product_attention(q, k, v, is_causal=True, scale=self.scale)
+            attn_out = ttnn.experimental.nlp_concat_heads(attn_out, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        else:
+            if cur_pos_tensor is None:
+                raise ValueError("cur_pos_tensor is required for decode")
+
+            q, k, v = ttnn.experimental.nlp_create_qkv_heads_decode(
+                qkv,
+                num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
+                memory_config=DECODE_MEMORY_CONFIG,
+            )
+            if not trace_decode:
+                ttnn.deallocate(qkv)
+
+            q_mem = ttnn.get_memory_config(q)
+            k_mem = ttnn.get_memory_config(k)
+            q = ttnn.to_memory_config(q, ttnn.DRAM_MEMORY_CONFIG)
+            k = ttnn.to_memory_config(k, ttnn.DRAM_MEMORY_CONFIG)
+            q = self.q_norm(q)
+            k = self.k_norm(k)
+            q = ttnn.to_memory_config(q, q_mem)
+            k = ttnn.to_memory_config(k, k_mem)
+
+            q = ttnn.reshape(q, (1, 1, q.shape[1] * num_heads, self.head_dim))
+            if decode_cos_q is None or decode_sin_q is None:
+                q = ttnn.experimental.rotary_embedding(q, self.cos_cache, self.sin_cache, start_pos)
+            else:
+                q = ttnn.experimental.rotary_embedding(q, decode_cos_q, decode_sin_q)
+            q = ttnn.reshape(q, (1, q.shape[2] // num_heads, num_heads, self.head_dim))
+
+            k = ttnn.reshape(k, (1, 1, k.shape[1] * num_kv_heads, self.head_dim))
+            if decode_cos_k is None or decode_sin_k is None:
+                k = ttnn.experimental.rotary_embedding(k, self.cos_cache, self.sin_cache, start_pos)
+            else:
+                k = ttnn.experimental.rotary_embedding(k, decode_cos_k, decode_sin_k)
+            k = ttnn.reshape(k, (1, k.shape[2] // num_kv_heads, num_kv_heads, self.head_dim))
+
+            ttnn.experimental.paged_update_cache(
+                self.k_cache,
+                k,
+                update_idxs_tensor=cur_pos_tensor,
+                page_table=self.page_table,
+            )
+            ttnn.experimental.paged_update_cache(
+                self.v_cache,
+                v,
+                update_idxs_tensor=cur_pos_tensor,
+                page_table=self.page_table,
+            )
+
+            attn_out = ttnn.transformer.paged_scaled_dot_product_attention_decode(
+                q,
+                self.k_cache,
+                self.v_cache,
+                page_table_tensor=self.page_table,
+                cur_pos_tensor=cur_pos_tensor,
+                scale=self.scale,
+                memory_config=DECODE_MEMORY_CONFIG,
+            )
+            attn_out = ttnn.transpose(attn_out, 1, 2)
+            attn_out = ttnn.experimental.nlp_concat_heads(attn_out, memory_config=DECODE_MEMORY_CONFIG)
+
+        expected_width = num_heads * self.head_dim
+        if attn_out.shape[-1] != expected_width:
+            attn_out = ttnn.slice(
+                attn_out,
+                (0, 0, 0, 0),
+                (attn_out.shape[0], attn_out.shape[1], attn_out.shape[2], expected_width),
+            )
+
+        out = ttnn.linear(attn_out, self.o_proj)
+        return all_reduce_tensor(out, self.parallel)
+
+
+class MLP:
+    """SwiGLU MLP with 1D tensor parallel."""
+
+    def __init__(self, layer_idx: int, state_dict: dict, parallel: ParallelConfig):
+        p = f"model.layers.{layer_idx}.mlp."
+        self.parallel = parallel
+        self.gate_proj = self._load_weight(state_dict[f"{p}gate_proj.weight"], parallel.shard_width_mapper)
+        self.up_proj = self._load_weight(state_dict[f"{p}up_proj.weight"], parallel.shard_width_mapper)
+        self.down_proj = self._load_weight(state_dict[f"{p}down_proj.weight"], parallel.shard_height_mapper)
+
+    def _load_weight(self, w: torch.Tensor, mesh_mapper) -> ttnn.Tensor:
+        return ttnn.as_tensor(
+            w.T.unsqueeze(0).unsqueeze(0).to(torch.bfloat16).contiguous(),
+            dtype=MLP_WEIGHT_DTYPE,
+            layout=WEIGHT_LAYOUT,
+            device=self.parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=mesh_mapper,
+        )
+
+    def __call__(self, x: ttnn.Tensor, seq_len: int) -> ttnn.Tensor:
+        is_prefill = seq_len > 1
+        if is_prefill:
+            gate = ttnn.silu(ttnn.linear(x, self.gate_proj))
+            up = ttnn.linear(x, self.up_proj)
+            out = ttnn.linear(ttnn.mul(gate, up), self.down_proj)
+            return all_reduce_tensor(out, self.parallel)
+
+        gate = ttnn.linear(x, self.gate_proj, memory_config=DECODE_MEMORY_CONFIG)
+        up = ttnn.linear(x, self.up_proj, memory_config=DECODE_MEMORY_CONFIG)
+        w2_in = ttnn.mul(
+            gate,
+            up,
+            input_tensor_a_activations=[ttnn.UnaryOpType.SILU],
+            memory_config=DECODE_MEMORY_CONFIG,
+        )
+        out = ttnn.linear(w2_in, self.down_proj)
+        return all_reduce_tensor(out, self.parallel)
+
+
+class DecoderLayer:
+    """Single transformer layer."""
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        layer_idx: int,
+        state_dict: dict,
+        cos_cache: ttnn.Tensor,
+        sin_cache: ttnn.Tensor,
+        parallel: ParallelConfig,
+        paged_attention_config: PagedAttentionConfig,
+        page_table: ttnn.Tensor,
+    ):
+        p = f"model.layers.{layer_idx}."
+        self.attn_norm = RMSNorm(state_dict[f"{p}input_layernorm.weight"], config.rms_norm_eps, parallel)
+        self.ffn_norm = RMSNorm(state_dict[f"{p}post_attention_layernorm.weight"], config.rms_norm_eps, parallel)
+        self.attn = Attention(
+            config,
+            layer_idx,
+            state_dict,
+            cos_cache,
+            sin_cache,
+            parallel,
+            paged_attention_config,
+            page_table,
+        )
+        self.mlp = MLP(layer_idx, state_dict, parallel)
+
+    def __call__(
+        self,
+        x: ttnn.Tensor,
+        start_pos: int,
+        seq_len: int,
+        cur_pos_tensor: Optional[ttnn.Tensor] = None,
+        decode_cos_q: Optional[ttnn.Tensor] = None,
+        decode_sin_q: Optional[ttnn.Tensor] = None,
+        decode_cos_k: Optional[ttnn.Tensor] = None,
+        decode_sin_k: Optional[ttnn.Tensor] = None,
+        trace_decode: bool = False,
+    ) -> ttnn.Tensor:
+        x = ttnn.add(
+            x,
+            self.attn(
+                self.attn_norm(x),
+                start_pos,
+                seq_len,
+                cur_pos_tensor,
+                decode_cos_q,
+                decode_sin_q,
+                decode_cos_k,
+                decode_sin_k,
+                trace_decode,
+            ),
+        )
+        x = ttnn.add(x, self.mlp(self.ffn_norm(x), seq_len))
+        return x
+
+
+class TtnnQwen3ForCausalLM(torch.nn.Module, GenerationMixin):
+    """Qwen3 model with 100% ttnn execution and 1D tensor parallel on T3000."""
+
+    def __init__(self, hf_model, tt_device, max_seq_len: int = 2048):
+        super().__init__()
+
+        self.tt_device = tt_device
+        self.hf_config = hf_model.config
+        self.tt_config = ModelConfig.from_hf(hf_model.config)
+
+        hf_max_seq_len = getattr(self.hf_config, "max_position_embeddings", None)
+        if hf_max_seq_len is not None and max_seq_len > hf_max_seq_len:
+            raise ValueError(f"max_seq_len {max_seq_len} exceeds HF max_position_embeddings {hf_max_seq_len}")
+        self.max_seq_len = max_seq_len
+        self._pos = 0
+
+        if self.tt_config.hidden_act != "silu":
+            raise ValueError(f"hidden_act {self.tt_config.hidden_act} is not supported in this bringup")
+        if getattr(self.hf_config, "use_sliding_window", False):
+            raise ValueError("sliding_window attention is not supported in this bringup")
+
+        self.config = self.hf_config
+        self.generation_config = GenerationConfig.from_model_config(self.config)
+        if self.generation_config.pad_token_id is None:
+            self.generation_config.pad_token_id = self.generation_config.eos_token_id
+        self._supports_cache_class = False
+        self.main_input_name = "input_ids"
+        self.register_buffer("_torch_dummy", torch.empty(0, dtype=torch.float32), persistent=False)
+
+        mesh_shape = tuple(tt_device.shape)
+        num_devices = num_mesh_devices(mesh_shape)
+        mesh_axis = mesh_shape_to_axis(mesh_shape)
+        validate_parallel_config(self.tt_config, num_devices)
+
+        self.parallel = ParallelConfig(
+            mesh_device=tt_device,
+            mesh_shape=mesh_shape,
+            num_devices=num_devices,
+            mesh_axis=mesh_axis,
+            num_links=MESH_NUM_LINKS,
+            topology=MESH_TOPOLOGY,
+            replicate_mapper=ttnn.ReplicateTensorToMesh(tt_device),
+            shard_width_mapper=ttnn.ShardTensorToMesh(tt_device, dim=3),
+            shard_height_mapper=ttnn.ShardTensorToMesh(tt_device, dim=2),
+            shard_kv_mapper=ttnn.ShardTensorToMesh(tt_device, dim=1),
+            vocab_composer=ttnn.ConcatMeshToTensor(tt_device, dim=3),
+        )
+
+        state_dict = hf_model.state_dict()
+
+        print("  Loading embeddings...")
+        self.embed = ttnn.as_tensor(
+            state_dict["model.embed_tokens.weight"].unsqueeze(0).unsqueeze(0).to(torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+
+        print("  Computing RoPE cache...")
+        cos, sin = compute_rope_cache(self.tt_config, self.max_seq_len)
+        self.cos_cache_host = cos
+        self.sin_cache_host = sin
+        self.cos_cache = ttnn.as_tensor(
+            cos,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.sin_cache = ttnn.as_tensor(
+            sin,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+
+        max_num_blocks = math.ceil(self.max_seq_len / PAGED_BLOCK_SIZE)
+        self.paged_attention_config = PagedAttentionConfig(PAGED_BLOCK_SIZE, max_num_blocks)
+        page_table = torch.arange(max_num_blocks, dtype=torch.int32).repeat(TILE_SIZE, 1)
+        self.page_table = ttnn.as_tensor(
+            page_table,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+
+        self.decode_token_buffer = ttnn.from_torch(
+            torch.zeros((1, 1, 1, TILE_SIZE), dtype=torch.int32),
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.decode_q_rope_seq = (self.tt_config.num_attention_heads // self.parallel.num_devices) * TILE_SIZE
+        self.decode_k_rope_seq = (self.tt_config.num_key_value_heads // self.parallel.num_devices) * TILE_SIZE
+        self.decode_pos_buffer = ttnn.from_torch(
+            torch.zeros((TILE_SIZE,), dtype=torch.int32),
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.decode_cos_q_buffer = ttnn.from_torch(
+            torch.zeros((1, 1, self.decode_q_rope_seq, self.tt_config.head_dim), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.decode_sin_q_buffer = ttnn.from_torch(
+            torch.zeros((1, 1, self.decode_q_rope_seq, self.tt_config.head_dim), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.decode_cos_k_buffer = ttnn.from_torch(
+            torch.zeros((1, 1, self.decode_k_rope_seq, self.tt_config.head_dim), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.decode_sin_k_buffer = ttnn.from_torch(
+            torch.zeros((1, 1, self.decode_k_rope_seq, self.tt_config.head_dim), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+
+        self.use_decode_trace = USE_DECODE_TRACE
+        self.decode_trace_id = None
+        self.decode_trace_logits = None
+
+        print(f"  Loading {self.tt_config.num_hidden_layers} layers...")
+        self.layers = [
+            DecoderLayer(
+                self.tt_config,
+                i,
+                state_dict,
+                self.cos_cache,
+                self.sin_cache,
+                self.parallel,
+                self.paged_attention_config,
+                self.page_table,
+            )
+            for i in range(self.tt_config.num_hidden_layers)
+        ]
+
+        self.norm = RMSNorm(state_dict["model.norm.weight"], self.tt_config.rms_norm_eps, self.parallel)
+        lm_head_weight = state_dict.get("lm_head.weight", state_dict["model.embed_tokens.weight"])
+        self.lm_head = ttnn.as_tensor(
+            lm_head_weight.T.unsqueeze(0).unsqueeze(0).to(torch.bfloat16).contiguous(),
+            dtype=LM_HEAD_WEIGHT_DTYPE,
+            layout=WEIGHT_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.shard_width_mapper,
+        )
+
+        self._tt_past_key_values = object()
+
+    @property
+    def device(self) -> torch.device:
+        return self._torch_dummy.device
+
+    def _release_decode_trace(self) -> None:
+        if self.decode_trace_id is None:
+            return
+        ttnn.release_trace(self.tt_device, self.decode_trace_id)
+        self.decode_trace_id = None
+        self.decode_trace_logits = None
+
+    def reset(self):
+        """Reset position counter for new sequence."""
+        self._pos = 0
+        self._release_decode_trace()
+
+    def prepare_inputs_for_generation(self, input_ids, past_key_values=None, **kwargs):
+        if past_key_values is not None:
+            input_ids = input_ids[:, -1:]
+        return {"input_ids": input_ids, "past_key_values": past_key_values, "use_cache": True}
+
+    def _reorder_cache(self, past_key_values, beam_idx):
+        return past_key_values
+
+    def _logits_to_torch(self, logits: ttnn.Tensor) -> torch.Tensor:
+        if self.parallel.num_devices > 1:
+            return ttnn.to_torch(logits, mesh_composer=self.parallel.vocab_composer)
+        return ttnn.to_torch(logits)
+
+    def _forward_prefill(self, input_ids: torch.Tensor, start_pos: int, seq_len: int) -> ttnn.Tensor:
+        tokens = ttnn.from_torch(
+            input_ids.reshape(1, 1, 1, -1),
+            dtype=ttnn.uint32,
+            device=self.tt_device,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        h = ttnn.embedding(tokens, self.embed, layout=ttnn.TILE_LAYOUT)
+        for layer in self.layers:
+            h = layer(h, start_pos, seq_len)
+        h = self.norm(h)
+        return ttnn.linear(h, self.lm_head)
+
+    def _forward_prefill_last_logits(self, input_ids: torch.Tensor, start_pos: int, seq_len: int) -> ttnn.Tensor:
+        tokens = ttnn.from_torch(
+            input_ids.reshape(1, 1, 1, -1),
+            dtype=ttnn.uint32,
+            device=self.tt_device,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        h = ttnn.embedding(tokens, self.embed, layout=ttnn.TILE_LAYOUT)
+        for layer in self.layers:
+            h = layer(h, start_pos, seq_len)
+        h = self.norm(h)
+        last_token_idx = seq_len - 1
+        h_last = ttnn.slice(
+            h,
+            (0, 0, last_token_idx, 0),
+            (h.shape[0], h.shape[1], last_token_idx + 1, h.shape[-1]),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        ttnn.deallocate(h)
+        return ttnn.linear(h_last, self.lm_head)
+
+    def _update_decode_token_buffer(self, input_ids: torch.Tensor) -> None:
+        token_ids = torch.zeros((TILE_SIZE,), dtype=torch.int32)
+        token_ids[: input_ids.numel()] = input_ids.view(-1).to(torch.int32)
+        token_ids = token_ids.reshape(1, 1, 1, -1)
+        host_tokens = ttnn.from_torch(
+            token_ids,
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        ttnn.copy_host_to_device_tensor(host_tokens, self.decode_token_buffer)
+
+    def _update_decode_pos_buffer(self, start_pos: int) -> None:
+        pos = torch.full((TILE_SIZE,), -1, dtype=torch.int32)
+        pos[0] = start_pos
+        host_pos = ttnn.from_torch(
+            pos,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        ttnn.copy_host_to_device_tensor(host_pos, self.decode_pos_buffer)
+
+    def _update_decode_rope_buffers(self, start_pos: int) -> None:
+        cos_token = self.cos_cache_host[:, :, start_pos : start_pos + 1, :]
+        sin_token = self.sin_cache_host[:, :, start_pos : start_pos + 1, :]
+        cos_q = cos_token.repeat(1, 1, self.decode_q_rope_seq, 1)
+        sin_q = sin_token.repeat(1, 1, self.decode_q_rope_seq, 1)
+        cos_k = cos_token.repeat(1, 1, self.decode_k_rope_seq, 1)
+        sin_k = sin_token.repeat(1, 1, self.decode_k_rope_seq, 1)
+        host_cos_q = ttnn.from_torch(
+            cos_q,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+        )
+        host_sin_q = ttnn.from_torch(
+            sin_q,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+        )
+        host_cos_k = ttnn.from_torch(
+            cos_k,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+        )
+        host_sin_k = ttnn.from_torch(
+            sin_k,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+        )
+        ttnn.copy_host_to_device_tensor(host_cos_q, self.decode_cos_q_buffer)
+        ttnn.copy_host_to_device_tensor(host_sin_q, self.decode_sin_q_buffer)
+        ttnn.copy_host_to_device_tensor(host_cos_k, self.decode_cos_k_buffer)
+        ttnn.copy_host_to_device_tensor(host_sin_k, self.decode_sin_k_buffer)
+
+    def _forward_decode_device(self, start_pos: int, trace_decode: bool) -> ttnn.Tensor:
+        h = ttnn.embedding(self.decode_token_buffer, self.embed, layout=ttnn.TILE_LAYOUT)
+        for layer in self.layers:
+            h = layer(
+                h,
+                start_pos,
+                1,
+                self.decode_pos_buffer,
+                self.decode_cos_q_buffer,
+                self.decode_sin_q_buffer,
+                self.decode_cos_k_buffer,
+                self.decode_sin_k_buffer,
+                trace_decode,
+            )
+        h = self.norm(h)
+        h = ttnn.slice(
+            h,
+            (0, 0, 0, 0),
+            (h.shape[0], h.shape[1], 1, h.shape[-1]),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        return ttnn.linear(h, self.lm_head)
+
+    def _forward_decode(self, input_ids: torch.Tensor, start_pos: int) -> ttnn.Tensor:
+        self._update_decode_token_buffer(input_ids)
+        self._update_decode_pos_buffer(start_pos)
+        self._update_decode_rope_buffers(start_pos)
+
+        if self.use_decode_trace:
+            if self.decode_trace_id is None:
+                warmup_logits = self._forward_decode_device(start_pos, False)
+                ttnn.deallocate(warmup_logits)
+                self.decode_trace_id = ttnn.begin_trace_capture(self.tt_device)
+                self.decode_trace_logits = self._forward_decode_device(start_pos, True)
+                ttnn.end_trace_capture(self.tt_device, self.decode_trace_id)
+            else:
+                ttnn.execute_trace(self.tt_device, self.decode_trace_id, blocking=False)
+            return self.decode_trace_logits
+        return self._forward_decode_device(start_pos, False)
+
+    def _forward_device_logits(self, input_ids: torch.Tensor, past_key_values, use_cache: bool):
+        batch, seq_len = input_ids.shape
+        if batch != 1:
+            raise ValueError("Only batch=1 supported")
+
+        if past_key_values is None:
+            self.reset()
+        elif seq_len != 1:
+            raise ValueError("Only 1-token decode supported when using cache")
+
+        start_pos = self._pos
+        if start_pos + seq_len > self.max_seq_len:
+            raise ValueError(f"sequence length {start_pos + seq_len} exceeds max_seq_len {self.max_seq_len}")
+
+        if seq_len == 1:
+            logits_device = self._forward_decode(input_ids, start_pos)
+            padded_seq = 1
+        else:
+            padded_seq = pad_to_tile(seq_len)
+            if seq_len < padded_seq:
+                input_ids = torch.nn.functional.pad(input_ids, (0, padded_seq - seq_len), value=0)
+            logits_device = self._forward_prefill(input_ids, start_pos, seq_len)
+
+        self._pos = start_pos + seq_len
+        past = self._tt_past_key_values if use_cache else None
+        return logits_device, seq_len, padded_seq, past
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        past_key_values=None,
+        use_cache: bool = True,
+        cache_position: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> CausalLMOutputWithPast:
+        batch = input_ids.shape[0]
+        logits_device, seq_len, padded_seq, past = self._forward_device_logits(input_ids, past_key_values, use_cache)
+
+        logits = self._logits_to_torch(logits_device)
+        logits = logits.reshape(batch, padded_seq, -1)[:, :seq_len, :]
+
+        if seq_len > 1 or not self.use_decode_trace:
+            ttnn.deallocate(logits_device)
+
+        return CausalLMOutputWithPast(
+            logits=logits.float(),
+            past_key_values=past,
+        )
+
+    def prefill_logits_last_device(self, input_ids: torch.Tensor, use_cache: bool = True) -> tuple[torch.Tensor, object]:
+        batch, seq_len = input_ids.shape
+        if batch != 1:
+            raise ValueError("Only batch=1 supported")
+
+        self.reset()
+        start_pos = self._pos
+        if start_pos + seq_len > self.max_seq_len:
+            raise ValueError(f"sequence length {start_pos + seq_len} exceeds max_seq_len {self.max_seq_len}")
+
+        padded_seq = pad_to_tile(seq_len)
+        if seq_len < padded_seq:
+            input_ids = torch.nn.functional.pad(input_ids, (0, padded_seq - seq_len), value=0)
+
+        logits_device = self._forward_prefill_last_logits(input_ids, start_pos, seq_len)
+        self._pos = start_pos + seq_len
+
+        logits = self._logits_to_torch(logits_device)
+        logits = logits.reshape(batch, 1, -1)[:, 0, :].float()
+        ttnn.deallocate(logits_device)
+
+        past = self._tt_past_key_values if use_cache else None
+        return logits, past
+
+
+def build_model(hf_model, tt_device, max_seq_len: int = 2048) -> TtnnQwen3ForCausalLM:
+    """Build the ttnn model from a HuggingFace reference model."""
+    return TtnnQwen3ForCausalLM(hf_model, tt_device, max_seq_len)


### PR DESCRIPTION
This adds an optimized TTNN variant for `models/Qwen/Qwen3-0.6B/t3000/optimized` and updates `MODELS.md` with the new results.

Key changes:
- Decode uses traced execution with preallocated token/pos/RoPE buffers.
- Paged KV cache (block_size=64) + paged SDPA decode.
- Fused QKV projection to replace 3 matmuls + concat.
- `prefill_logits_last_device()` fast path to reduce TTFT.

Results (same hardware, seq len 40960):
- Quality (long eval): Top-1 98%, Top-5 100%
- TTFT: 229ms -> 59ms
- Decode throughput: 6.2 -> 61.9 t/s/u

Artifacts:
- `models/Qwen/Qwen3-0.6B/t3000/optimized/demo.log`
- `models/Qwen/Qwen3-0.6B/t3000/optimized/eval.log`
- `models/Qwen/Qwen3-0.6B/t3000/optimized/metrics.json`

Fixes #146
