### PR TITLE
models/microsoft/Phi-3-mini-128k-instruct/t3000/optimized

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -41,6 +41,7 @@ Note: Keep the table columns padded with spaces and right-justify numeric cells 
 | microsoft/Phi-3-mini-128k-instruct  |   n150   | functional |   92% |   99% |   80ms |  13.7 |   12288 |
 | microsoft/Phi-3-mini-128k-instruct  |   n300   | functional |   90% |  100% |  193ms |   6.7 |   12288 |
 | microsoft/Phi-3-mini-128k-instruct  |  t3000   | functional |   90% |  100% |  184ms |   6.8 |   12288 |
+| microsoft/Phi-3-mini-128k-instruct  |  t3000   | optimized  |   92% |   99% |  105ms |  23.6 |   12288 |
 | tiiuae/Falcon3-7B-Instruct          |   n150   | functional |   97% |  100% |  144ms |  13.4 |   32768 |
 | tiiuae/Falcon3-7B-Instruct          |   n300   | functional |   97% |  100% |  661ms |   5.6 |   32768 |
 | tiiuae/Falcon3-7B-Instruct          |  t3000   | functional |   97% |  100% |  199ms |   7.3 |   32768 |

--- a/models/microsoft/Phi-3-mini-128k-instruct/t3000/optimized/MODEL_BRINGUP.md
+++ b/models/microsoft/Phi-3-mini-128k-instruct/t3000/optimized/MODEL_BRINGUP.md
@@ -1,0 +1,64 @@
+# MODEL_BRINGUP.md - Phi-3 Mini 128k Instruct (t3000 optimized)
+
+## Overview
+This is the optimized TTNN bringup of `microsoft/Phi-3-mini-128k-instruct` for `t3000`.
+
+- Model code: `models/microsoft/Phi-3-mini-128k-instruct/t3000/optimized/model.py`
+- Demo log: `models/microsoft/Phi-3-mini-128k-instruct/t3000/optimized/demo.log`
+- Eval log: `models/microsoft/Phi-3-mini-128k-instruct/t3000/optimized/eval.log`
+- Machine-readable metrics: `models/microsoft/Phi-3-mini-128k-instruct/t3000/optimized/metrics.json`
+- Decode path uses traced execution (`ttnn.begin_trace_capture` + `ttnn.execute_trace`).
+
+## Baseline vs final
+| Metric | Functional baseline (`MODELS.md`) | Final optimized |
+| --- | ---: | ---: |
+| Top-1 | 90% | 92% |
+| Top-5 | 100% | 99% |
+| TTFT | 184 ms | 105 ms |
+| t/s/u | 6.8 | 23.6 |
+| Seq len | 12288 | 12288 |
+
+## Kept optimization decisions
+1. Decode trace with preallocated decode buffers.
+- Preallocates token ids, position tensor, and per-token RoPE cos/sin buffers.
+- Uses decode-only preallocated pad zeros for RoPE head-dim padding (avoids `ttnn.zeros` inside trace capture).
+
+2. Prefill last-token logits fast path (`prefill_logits_last_device`).
+- Avoids materializing full prefill logits when only the final prompt token is needed (demo/eval TTFT).
+
+3. Fused QKV projection (single matmul) with TP-safe shard ordering.
+- Builds a fused weight with per-shard `[q_i, k_i, v_i]` ordering so width-sharding matches `nlp_create_qkv_heads[_decode]`.
+
+4. Paged KV cache (block_size=64).
+- Cache layout: `[max_num_blocks, n_kv_heads, block_size, head_dim]`.
+
+## Rejected optimization attempts
+- None yet.
+
+## Commands used
+```bash
+TT_VISIBLE_DEVICES=0,1,2,3 \
+TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto \
+TT_METAL_CACHE=/tmp/tt-metal-cache \
+PYTHONUNBUFFERED=1 \
+python -u demo.py models/microsoft/Phi-3-mini-128k-instruct/t3000/optimized/model.py \
+  --prompt "Write a short, vivid paragraph about a sunrise over the ocean." \
+  --max-new-tokens 120 \
+  --max_seq_len 12288 \
+  --seed 0
+
+TT_VISIBLE_DEVICES=0,1,2,3 \
+TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto \
+TT_METAL_CACHE=/tmp/tt-metal-cache \
+PYTHONUNBUFFERED=1 \
+python -u eval.py models/microsoft/Phi-3-mini-128k-instruct/t3000/optimized/model.py \
+  --model microsoft/Phi-3-mini-128k-instruct \
+  --prompt_file prompts/bringup_eval_long.txt \
+  --max_new_tokens 100 \
+  --max_seq_len 12288 \
+  --seed 0
+```
+
+## Environment note
+On this host, `tt-smi` in `/home/moconnor/bin/` is broken (`bad interpreter`).
+Use `/home/moconnor/.local/bin/tt-smi` for reset/list.

--- a/models/microsoft/Phi-3-mini-128k-instruct/t3000/optimized/demo.log
+++ b/models/microsoft/Phi-3-mini-128k-instruct/t3000/optimized/demo.log
@@ -1,0 +1,84 @@
+COMMAND: TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto TT_VISIBLE_DEVICES=0,1,2,3 TT_METAL_CACHE=/tmp/tt-metal-cache PYTHONUNBUFFERED=1 python -u demo.py models/microsoft/Phi-3-mini-128k-instruct/t3000/optimized/model.py --prompt "Write a short, vivid paragraph about a sunrise over the ocean." --max-new-tokens 120 --max_seq_len 12288 --seed 0
+2026-02-12 11:22:55.336 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
+Loading tokenizer: microsoft/Phi-3-mini-128k-instruct
+Opening TT device...
+2026-02-12 11:22:55.855 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 11:22:55.885 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-12 11:22:55.895 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 11:22:55.967 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 11:22:56.029 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 11:22:56.085 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x208 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 11:22:56.095 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 11:22:56.105 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x41 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 11:22:56.115 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 11:22:56.129 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x208 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 11:22:56.142 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x300 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 11:22:56.155 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x42 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 11:22:56.169 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 1, 2, 3] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
+2026-02-12 11:22:56.169 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-12 11:22:56.169 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-12 11:22:56.178 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-12 11:22:56.179 | info     |             UMD | Mapped hugepage 0x340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 11:22:56.180 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 11:22:56.181 | info     |             UMD | Mapped hugepage 0x440000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 11:22:56.182 | info     |             UMD | Mapped hugepage 0x400000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 11:22:56.183 | info     |             UMD | Mapped hugepage 0x4240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 11:22:56.183 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 11:22:56.184 | info     |             UMD | Mapped hugepage 0x4340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 11:22:56.185 | info     |             UMD | Mapped hugepage 0x4300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 11:22:56.237 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto (metal_context.cpp:822)
+2026-02-12 11:22:56.238 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-12 11:22:56.242 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-12 11:22:56.242 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-12 11:22:56.246 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 11:22:56.249 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 11:22:56.249 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 11:22:56.249 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 11:22:56.250 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 11:22:56.250 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 11:22:56.250 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 11:22:56.250 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 11:22:56.563 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
+2026-02-12 11:22:56.563 | info     |           Metal | Dispatch on FabricConfig::FABRIC_2D with 1 Command Queues
+ (device_manager.cpp:328)
+2026-02-12 11:22:56.586 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
+2026-02-12 11:22:56.734 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
+2026-02-12 11:22:56.762 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
+2026-02-12 11:22:56.763 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
+2026-02-12 11:22:56.763 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
+2026-02-12 11:22:56.766 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
+2026-02-12 11:22:56.769 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
+2026-02-12 11:22:56.775 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
+2026-02-12 11:22:56.781 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
+2026-02-12 11:22:56.781 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_2D (device_manager.cpp:409)
+2026-02-12 11:22:56.864 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
+2026-02-12 11:22:56.865 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
+2026-02-12 11:22:56.866 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
+2026-02-12 11:22:56.866 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
+Loading HuggingFace reference model on CPU: microsoft/Phi-3-mini-128k-instruct
+Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:00<00:00,  1.17it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.66it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.56it/s]
+Building TT model...
+  Loading embeddings...
+  Computing RoPE cache...
+  Loading 32 layers...
+Running one warmup prefill+decode pass (kernel compile warmup)...
+TT demo (t3000)
+Model: microsoft/Phi-3-mini-128k-instruct
+Mesh shape: 2x4
+Prompt tokens: 16 | Generated tokens: 120
+TTFT: 105 ms | Decode: 23.6 t/s/u (118 tokens)
+
+Prompt:
+Write a short, vivid paragraph about a sunrise over the ocean.
+
+Output:
+Use present tense and at least three descriptive adjectives to enhance your imagery.
+
+
+Solution 1:
+
+The horizon glows as the newborn sun peeks over the tranquil ocean, splashing the sky with a palette of pastel hues. Gentle waves caress the serene shoreline, each one a whisper of the ocean's eternal song. A tapestry of pink, orange, and gold blankets the sky, gradually revealing the crisp, glittering sea beneath. The
+YT_METRICS={"mode": "tt_demo", "model": "microsoft/Phi-3-mini-128k-instruct", "system": "t3000", "mesh_shape": [2, 4], "prompt_tokens": 16, "generated_tokens": 120, "ttft_ms": 104.77044712752104, "decode_tps_u": 23.604999364790086, "decode_tokens": 118, "max_seq_len": 12288}
+2026-02-12 11:23:58.949 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-12 11:23:58.949 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/microsoft/Phi-3-mini-128k-instruct/t3000/optimized/eval.log
+++ b/models/microsoft/Phi-3-mini-128k-instruct/t3000/optimized/eval.log
@@ -1,0 +1,72 @@
+COMMAND: TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto TT_VISIBLE_DEVICES=0,1,2,3 TT_METAL_CACHE=/tmp/tt-metal-cache PYTHONUNBUFFERED=1 python -u eval.py models/microsoft/Phi-3-mini-128k-instruct/t3000/optimized/model.py --model microsoft/Phi-3-mini-128k-instruct --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 12288 --seed 0
+2026-02-12 11:24:22.016 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
+Loading model module: /localdev/moconnor/ttnn_models/models/microsoft/Phi-3-mini-128k-instruct/t3000/optimized/model.py
+Loading HuggingFace tokenizer...
+Loading HuggingFace reference model on CPU...
+Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:00<00:00,  1.41it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  2.01it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.89it/s]
+Generating reference tokens...
+Opening device (2x4)...
+2026-02-12 11:25:05.981 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 11:25:06.012 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-12 11:25:06.023 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 11:25:06.100 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 11:25:06.160 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 11:25:06.217 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x208 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 11:25:06.227 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 11:25:06.236 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x41 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 11:25:06.246 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 11:25:06.259 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x208 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 11:25:06.273 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x300 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 11:25:06.286 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x42 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 11:25:06.300 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 1, 2, 3] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
+2026-02-12 11:25:06.300 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-12 11:25:06.300 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-12 11:25:06.309 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-12 11:25:06.310 | info     |             UMD | Mapped hugepage 0x340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 11:25:06.311 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 11:25:06.312 | info     |             UMD | Mapped hugepage 0x440000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 11:25:06.312 | info     |             UMD | Mapped hugepage 0x400000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 11:25:06.313 | info     |             UMD | Mapped hugepage 0x4240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 11:25:06.314 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 11:25:06.315 | info     |             UMD | Mapped hugepage 0x4340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 11:25:06.315 | info     |             UMD | Mapped hugepage 0x4300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 11:25:06.372 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto (metal_context.cpp:822)
+2026-02-12 11:25:06.373 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-12 11:25:06.378 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-12 11:25:06.378 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-12 11:25:06.383 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 11:25:06.385 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 11:25:06.385 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 11:25:06.386 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 11:25:06.386 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 11:25:06.386 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 11:25:06.386 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 11:25:06.387 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 11:25:06.699 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
+2026-02-12 11:25:06.699 | info     |           Metal | Dispatch on FabricConfig::FABRIC_2D with 1 Command Queues
+ (device_manager.cpp:328)
+2026-02-12 11:25:06.710 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
+2026-02-12 11:25:06.846 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
+2026-02-12 11:25:06.876 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
+2026-02-12 11:25:06.876 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
+2026-02-12 11:25:06.877 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
+2026-02-12 11:25:06.880 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
+2026-02-12 11:25:06.883 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
+2026-02-12 11:25:06.889 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
+2026-02-12 11:25:06.895 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
+2026-02-12 11:25:06.895 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_2D (device_manager.cpp:409)
+2026-02-12 11:25:06.973 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
+2026-02-12 11:25:06.973 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
+2026-02-12 11:25:06.975 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
+2026-02-12 11:25:06.975 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
+Loading ttnn model...
+  Loading embeddings...
+  Computing RoPE cache...
+  Loading 32 layers...
+Running teacher-forcing eval (100 tokens)...
+Top-1 accuracy: 92.00% (0.9200)
+Top-5 accuracy: 99.00% (0.9900)
+YT_METRICS={"mode": "tt_eval", "model": "microsoft/Phi-3-mini-128k-instruct", "top1": 0.92, "top5": 0.99, "top1_pct": 92.0, "top5_pct": 99.0, "total_tokens": 100, "max_new_tokens": 100, "max_seq_len": 12288}
+2026-02-12 11:26:47.461 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-12 11:26:47.461 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/microsoft/Phi-3-mini-128k-instruct/t3000/optimized/metrics.json
+++ b/models/microsoft/Phi-3-mini-128k-instruct/t3000/optimized/metrics.json
@@ -1,0 +1,26 @@
+{
+  "model": "microsoft/Phi-3-mini-128k-instruct",
+  "hardware": "t3000",
+  "variant": "optimized",
+  "functional_baseline": {
+    "top1_pct": 90.0,
+    "top5_pct": 100.0,
+    "ttft_ms": 184.0,
+    "decode_tps_u": 6.8,
+    "seq_len": 12288
+  },
+  "optimized_final": {
+    "top1_pct": 92.0,
+    "top5_pct": 99.0,
+    "ttft_ms": 104.77044712752104,
+    "decode_tps_u": 23.604999364790086,
+    "seq_len": 12288
+  },
+  "acceptance": {
+    "top1_top5_pass": true,
+    "decode_trace_enabled": true,
+    "ttft_improved": true,
+    "decode_tps_improved": true,
+    "seq_len_non_regressed": true
+  }
+}

--- a/models/microsoft/Phi-3-mini-128k-instruct/t3000/optimized/model.py
+++ b/models/microsoft/Phi-3-mini-128k-instruct/t3000/optimized/model.py
@@ -1,0 +1,1167 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Phi-3 Mini 128k Instruct optimized TTNN model for T3000.
+
+Optimizations versus the functional bringup:
+- Prefill last-token logits fast path (`prefill_logits_last_device`) to lower TTFT.
+- Decode trace with preallocated token/pos/RoPE buffers.
+- Fused QKV projection (single matmul) with TP-safe shard ordering.
+
+Use `demo.py` and `eval.py` at repo root for timing and teacher-forcing accuracy checks.
+"""
+
+import math
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import ttnn
+from transformers import GenerationConfig
+from transformers.generation.utils import GenerationMixin
+from transformers.modeling_outputs import CausalLMOutputWithPast
+
+
+TILE_SIZE = 32
+HEAD_DIM_TILE = 64
+PAGED_BLOCK_SIZE = 64
+WEIGHT_DTYPE = ttnn.bfloat16
+WEIGHT_LAYOUT = ttnn.TILE_LAYOUT
+MESH_SHAPE = (2, 4)
+MESH_TOPOLOGY = ttnn.Topology.Linear
+MESH_NUM_LINKS = 1
+USE_DECODE_TRACE = True
+DECODE_MEMORY_CONFIG = ttnn.DRAM_MEMORY_CONFIG
+
+
+def pad_to_tile(x: int) -> int:
+    """Pad to tile boundary (32)."""
+    return ((x + TILE_SIZE - 1) // TILE_SIZE) * TILE_SIZE
+
+
+def pad_head_dim(x: int) -> int:
+    """Pad head dimension to the rotary tile requirement (64)."""
+    return ((x + HEAD_DIM_TILE - 1) // HEAD_DIM_TILE) * HEAD_DIM_TILE
+
+
+def mesh_shape_to_axis(mesh_shape: tuple[int, int]) -> Optional[int]:
+    """Return the mesh axis used for 1D tensor parallel or None for 2D."""
+    if mesh_shape[0] == 1 and mesh_shape[1] > 1:
+        return 1
+    if mesh_shape[1] == 1 and mesh_shape[0] > 1:
+        return 0
+    if mesh_shape[0] > 1 and mesh_shape[1] > 1:
+        return None
+    raise ValueError(f"Expected mesh shape with at least one dimension > 1, got {mesh_shape}")
+
+
+def num_mesh_devices(mesh_shape: tuple[int, int]) -> int:
+    return mesh_shape[0] * mesh_shape[1]
+
+
+@dataclass
+class ModelConfig:
+    """Model configuration extracted from HuggingFace."""
+
+    vocab_size: int
+    hidden_size: int
+    intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    rms_norm_eps: float
+    rope_theta: float
+    rope_scaling: Optional[dict]
+    hidden_act: str
+    tie_word_embeddings: bool
+    max_position_embeddings: int
+    original_max_position_embeddings: int
+    partial_rotary_factor: float
+
+    @classmethod
+    def from_hf(cls, hf_config) -> "ModelConfig":
+        num_kv_heads = getattr(hf_config, "num_key_value_heads", hf_config.num_attention_heads)
+        head_dim = getattr(hf_config, "head_dim", None)
+        if head_dim is None:
+            head_dim = hf_config.hidden_size // hf_config.num_attention_heads
+        original_max = getattr(hf_config, "original_max_position_embeddings", hf_config.max_position_embeddings)
+        partial_rotary = getattr(hf_config, "partial_rotary_factor", 1.0)
+        return cls(
+            hf_config.vocab_size,
+            hf_config.hidden_size,
+            hf_config.intermediate_size,
+            hf_config.num_hidden_layers,
+            hf_config.num_attention_heads,
+            num_kv_heads,
+            head_dim,
+            hf_config.rms_norm_eps,
+            hf_config.rope_theta,
+            getattr(hf_config, "rope_scaling", None),
+            hf_config.hidden_act,
+            hf_config.tie_word_embeddings,
+            hf_config.max_position_embeddings,
+            original_max,
+            partial_rotary,
+        )
+
+
+@dataclass
+class PagedAttentionConfig:
+    """Paged KV cache configuration."""
+
+    block_size: int
+    max_num_blocks: int
+
+
+@dataclass
+class ParallelConfig:
+    mesh_device: ttnn.MeshDevice
+    mesh_shape: tuple[int, int]
+    num_devices: int
+    mesh_axis: Optional[int]
+    num_links: int
+    topology: ttnn.Topology
+    replicate_mapper: object
+    shard_width_mapper: object
+    shard_height_mapper: object
+    shard_kv_mapper: object
+    vocab_composer: object
+
+
+def validate_parallel_config(config: ModelConfig, num_devices: int) -> None:
+    if num_devices != 8:
+        raise ValueError("T3000 model expects an 8-device mesh")
+    if config.num_attention_heads % num_devices != 0:
+        raise ValueError("num_attention_heads must divide evenly across devices")
+    if config.num_key_value_heads % num_devices != 0:
+        raise ValueError("num_key_value_heads must divide evenly across devices")
+    if config.hidden_size % num_devices != 0:
+        raise ValueError("hidden_size must divide evenly across devices")
+    if config.intermediate_size % num_devices != 0:
+        raise ValueError("intermediate_size must divide evenly across devices")
+
+
+def all_reduce_tensor(x: ttnn.Tensor, parallel: ParallelConfig) -> ttnn.Tensor:
+    if parallel.num_devices == 1:
+        return x
+    if parallel.mesh_axis is None:
+        return ttnn.all_reduce(
+            x,
+            num_links=parallel.num_links,
+            topology=parallel.topology,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+    return ttnn.all_reduce(
+        x,
+        cluster_axis=parallel.mesh_axis,
+        num_links=parallel.num_links,
+        topology=parallel.topology,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+def compute_attention_scaling(config: ModelConfig) -> float:
+    factor = config.max_position_embeddings / config.original_max_position_embeddings
+    if factor <= 1.0:
+        return 1.0
+    return math.sqrt(1 + math.log(factor) / math.log(config.original_max_position_embeddings))
+
+
+def compute_rope_cache(
+    config: ModelConfig,
+    max_seq_len: int,
+    use_long: Optional[bool] = None,
+) -> tuple:
+    """
+    Precompute RoPE cos/sin cache in HuggingFace format.
+    Returns cos, sin tensors of shape [1, 1, max_seq_len, head_dim].
+    """
+    if config.partial_rotary_factor != 1.0:
+        raise ValueError("partial_rotary_factor != 1.0 is not supported in this bringup")
+
+    head_dim = config.head_dim
+    padded_head_dim = pad_head_dim(head_dim)
+    attention_scaling = 1.0
+
+    if config.rope_scaling:
+        rope_type = config.rope_scaling.get("rope_type", config.rope_scaling.get("type"))
+        if rope_type != "longrope":
+            raise ValueError(f"rope_scaling {rope_type} is not supported in this bringup")
+
+        long_factor = config.rope_scaling["long_factor"]
+        short_factor = config.rope_scaling["short_factor"]
+        if use_long is None:
+            use_long = max_seq_len > config.original_max_position_embeddings
+        ext_factors = torch.tensor(long_factor if use_long else short_factor, dtype=torch.float32)
+
+        inv_freq = 1.0 / (
+            ext_factors * (config.rope_theta ** (torch.arange(0, head_dim, 2).float() / head_dim))
+        )
+        attention_scaling = config.rope_scaling.get("attention_factor")
+        if attention_scaling is None:
+            attention_scaling = compute_attention_scaling(config)
+    else:
+        inv_freq = 1.0 / (config.rope_theta ** (torch.arange(0, head_dim, 2).float() / head_dim))
+
+    t = torch.arange(max_seq_len, dtype=inv_freq.dtype)
+    freqs = torch.outer(t, inv_freq)
+    emb = torch.cat((freqs, freqs), dim=-1)
+    cos = emb.cos()
+    sin = emb.sin()
+    if attention_scaling != 1.0:
+        cos = cos * attention_scaling
+        sin = sin * attention_scaling
+    if padded_head_dim != head_dim:
+        half = head_dim // 2
+        half_padded = padded_head_dim // 2
+        pad = half_padded - half
+        cos_left = torch.cat([cos[:, :half], torch.ones((max_seq_len, pad), dtype=cos.dtype)], dim=-1)
+        cos_right = torch.cat([cos[:, half:], torch.ones((max_seq_len, pad), dtype=cos.dtype)], dim=-1)
+        sin_left = torch.cat([sin[:, :half], torch.zeros((max_seq_len, pad), dtype=sin.dtype)], dim=-1)
+        sin_right = torch.cat([sin[:, half:], torch.zeros((max_seq_len, pad), dtype=sin.dtype)], dim=-1)
+        cos = torch.cat([cos_left, cos_right], dim=-1)
+        sin = torch.cat([sin_left, sin_right], dim=-1)
+    cos = cos.unsqueeze(0).unsqueeze(0).to(torch.bfloat16)
+    sin = sin.unsqueeze(0).unsqueeze(0).to(torch.bfloat16)
+    return cos, sin
+
+
+def resolve_max_seq_len(hf_config, max_seq_len: Optional[int]) -> int:
+    """Resolve max sequence length from HF config when not provided."""
+    config_max = getattr(hf_config, "max_position_embeddings", None)
+    if config_max is None:
+        config_max = getattr(hf_config, "max_seq_len", None)
+    if max_seq_len is None:
+        if config_max is None:
+            raise ValueError("max_seq_len is required when config has no max_position_embeddings")
+        return config_max
+    if config_max is not None and max_seq_len > config_max:
+        raise ValueError(f"max_seq_len {max_seq_len} exceeds config max {config_max}")
+    return max_seq_len
+
+
+class RMSNorm:
+    """RMSNorm layer."""
+
+    def __init__(self, weight: torch.Tensor, eps: float, parallel: ParallelConfig):
+        self.eps = eps
+        self.weight = ttnn.as_tensor(
+            weight.unsqueeze(0).unsqueeze(0).unsqueeze(0).to(torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=parallel.replicate_mapper,
+        )
+
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        return ttnn.rms_norm(x, epsilon=self.eps, weight=self.weight)
+
+
+class Attention:
+    """Multi-head attention with a fused QKV projection, 1D tensor parallel."""
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        layer_idx: int,
+        state_dict: dict,
+        cos_cache_short: ttnn.Tensor,
+        sin_cache_short: ttnn.Tensor,
+        cos_cache_long: ttnn.Tensor,
+        sin_cache_long: ttnn.Tensor,
+        parallel: ParallelConfig,
+        paged_attention_config: PagedAttentionConfig,
+        page_table: ttnn.Tensor,
+    ):
+        self.parallel = parallel
+        self.n_heads = config.num_attention_heads
+        self.n_kv_heads = config.num_key_value_heads
+        self.n_local_heads = self.n_heads // parallel.num_devices
+        self.n_local_kv_heads = self.n_kv_heads // parallel.num_devices
+        self.original_max_position_embeddings = config.original_max_position_embeddings
+        self.head_dim = config.head_dim
+        self.head_dim_padded = pad_head_dim(self.head_dim)
+        self.head_dim_half = self.head_dim // 2
+        self.head_dim_half_padded = self.head_dim_padded // 2
+        self.scale = 1.0 / math.sqrt(self.head_dim)
+        self.paged_attention_config = paged_attention_config
+        self.page_table = page_table
+        device_grid = self.parallel.mesh_device.core_grid
+        grid_x = device_grid.x
+        grid_y = device_grid.y
+        if grid_x * grid_y > TILE_SIZE:
+            grid_y = max(1, TILE_SIZE // grid_x)
+        self.decode_heads_grid = ttnn.CoreGrid(x=grid_x, y=grid_y)
+        padded_heads = pad_to_tile(self.n_local_heads)
+        self.decode_heads_memcfg = ttnn.create_sharded_memory_config(
+            (padded_heads, self.head_dim),
+            self.decode_heads_grid,
+            ttnn.ShardStrategy.HEIGHT,
+            ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+        self.decode_q_pad_zeros = None
+        self.decode_k_pad_zeros = None
+        if self.head_dim_padded != self.head_dim:
+            pad = self.head_dim_half_padded - self.head_dim_half
+            pad_tile = pad_to_tile(pad)
+            self.decode_q_pad_zeros = ttnn.zeros(
+                (1, 1, TILE_SIZE * self.n_local_heads, pad_tile),
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=self.parallel.mesh_device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            self.decode_k_pad_zeros = ttnn.zeros(
+                (1, 1, TILE_SIZE * self.n_local_kv_heads, pad_tile),
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=self.parallel.mesh_device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+
+        self.cos_cache_short = cos_cache_short
+        self.sin_cache_short = sin_cache_short
+        self.cos_cache_long = cos_cache_long
+        self.sin_cache_long = sin_cache_long
+
+        p = f"model.layers.{layer_idx}.self_attn."
+        qkv_weight = state_dict[f"{p}qkv_proj.weight"]
+        q_end = self.n_heads * self.head_dim
+        k_end = q_end + self.n_kv_heads * self.head_dim
+        v_end = k_end + self.n_kv_heads * self.head_dim
+        self.qkv_proj = self._load_qkv_weight(
+            qkv_weight[:q_end, :],
+            qkv_weight[q_end:k_end, :],
+            qkv_weight[k_end:v_end, :],
+            parallel.shard_width_mapper,
+        )
+        self.o_proj = self._load_weight(state_dict[f"{p}o_proj.weight"], parallel.shard_height_mapper)
+
+        cache_shape = (
+            self.paged_attention_config.max_num_blocks,
+            self.n_kv_heads,
+            self.paged_attention_config.block_size,
+            self.head_dim,
+        )
+        self.k_cache = ttnn.as_tensor(
+            torch.zeros(cache_shape, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=parallel.shard_kv_mapper,
+        )
+        self.v_cache = ttnn.as_tensor(
+            torch.zeros(cache_shape, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=parallel.shard_kv_mapper,
+        )
+
+    def _load_weight(self, w: torch.Tensor, mesh_mapper) -> ttnn.Tensor:
+        return ttnn.as_tensor(
+            w.T.unsqueeze(0).unsqueeze(0).to(torch.bfloat16).contiguous(),
+            dtype=WEIGHT_DTYPE,
+            layout=WEIGHT_LAYOUT,
+            device=self.parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=mesh_mapper,
+        )
+
+    def _load_qkv_weight(
+        self, q_weight: torch.Tensor, k_weight: torch.Tensor, v_weight: torch.Tensor, mesh_mapper
+    ) -> ttnn.Tensor:
+        q_chunks = torch.chunk(q_weight, self.parallel.num_devices, dim=0)
+        k_chunks = torch.chunk(k_weight, self.parallel.num_devices, dim=0)
+        v_chunks = torch.chunk(v_weight, self.parallel.num_devices, dim=0)
+        qkv_weight = torch.cat(
+            [torch.cat((q_chunks[i], k_chunks[i], v_chunks[i]), dim=0) for i in range(self.parallel.num_devices)],
+            dim=0,
+        )
+        return self._load_weight(qkv_weight, mesh_mapper)
+
+    def _pad_head_dim(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        if self.head_dim_padded == self.head_dim:
+            return x
+        pad = self.head_dim_half_padded - self.head_dim_half
+        pad_tile = pad_to_tile(pad)
+        zeros = ttnn.zeros(
+            (x.shape[0], x.shape[1], x.shape[2], pad_tile),
+            dtype=x.dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=self.parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        zeros = ttnn.slice(
+            zeros,
+            (0, 0, 0, 0),
+            (zeros.shape[0], zeros.shape[1], zeros.shape[2], pad),
+        )
+        left = ttnn.slice(
+            x,
+            (0, 0, 0, 0),
+            (x.shape[0], x.shape[1], x.shape[2], self.head_dim_half),
+        )
+        right = ttnn.slice(
+            x,
+            (0, 0, 0, self.head_dim_half),
+            (x.shape[0], x.shape[1], x.shape[2], self.head_dim),
+        )
+        left = ttnn.concat([left, zeros], dim=-1, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        right = ttnn.concat([right, zeros], dim=-1, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        return ttnn.concat([left, right], dim=-1, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    def _pad_head_dim_decode(self, x: ttnn.Tensor, zeros_padded: ttnn.Tensor) -> ttnn.Tensor:
+        if self.head_dim_padded == self.head_dim:
+            return x
+        pad = self.head_dim_half_padded - self.head_dim_half
+        zeros = ttnn.slice(
+            zeros_padded,
+            (0, 0, 0, 0),
+            (zeros_padded.shape[0], zeros_padded.shape[1], zeros_padded.shape[2], pad),
+        )
+        left = ttnn.slice(
+            x,
+            (0, 0, 0, 0),
+            (x.shape[0], x.shape[1], x.shape[2], self.head_dim_half),
+        )
+        right = ttnn.slice(
+            x,
+            (0, 0, 0, self.head_dim_half),
+            (x.shape[0], x.shape[1], x.shape[2], self.head_dim),
+        )
+        left = ttnn.concat([left, zeros], dim=-1, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        right = ttnn.concat([right, zeros], dim=-1, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        return ttnn.concat([left, right], dim=-1, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    def _slice_head_dim(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        if self.head_dim_padded == self.head_dim:
+            return x
+        left = ttnn.slice(
+            x,
+            (0, 0, 0, 0),
+            (x.shape[0], x.shape[1], x.shape[2], self.head_dim_half_padded),
+        )
+        right = ttnn.slice(
+            x,
+            (0, 0, 0, self.head_dim_half_padded),
+            (x.shape[0], x.shape[1], x.shape[2], self.head_dim_padded),
+        )
+        left = ttnn.slice(
+            left,
+            (0, 0, 0, 0),
+            (left.shape[0], left.shape[1], left.shape[2], self.head_dim_half),
+        )
+        right = ttnn.slice(
+            right,
+            (0, 0, 0, 0),
+            (right.shape[0], right.shape[1], right.shape[2], self.head_dim_half),
+        )
+        return ttnn.concat([left, right], dim=-1, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    def __call__(
+        self,
+        x: ttnn.Tensor,
+        start_pos: int,
+        seq_len: int,
+        cur_pos_tensor: Optional[ttnn.Tensor] = None,
+        decode_cos_q: Optional[ttnn.Tensor] = None,
+        decode_sin_q: Optional[ttnn.Tensor] = None,
+        decode_cos_k: Optional[ttnn.Tensor] = None,
+        decode_sin_k: Optional[ttnn.Tensor] = None,
+        trace_decode: bool = False,
+    ) -> ttnn.Tensor:
+        is_prefill = seq_len > 1
+        padded_seq = pad_to_tile(seq_len)
+        if is_prefill:
+            qkv = ttnn.linear(x, self.qkv_proj)
+        else:
+            qkv = ttnn.linear(x, self.qkv_proj, memory_config=DECODE_MEMORY_CONFIG)
+
+        num_heads = self.n_local_heads
+        num_kv_heads = self.n_local_kv_heads
+
+        if is_prefill:
+            use_long = seq_len > self.original_max_position_embeddings
+            cos_cache = self.cos_cache_long if use_long else self.cos_cache_short
+            sin_cache = self.sin_cache_long if use_long else self.sin_cache_short
+
+            q, k, v = ttnn.experimental.nlp_create_qkv_heads(
+                qkv,
+                num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
+                transpose_k_heads=False,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            ttnn.deallocate(qkv)
+
+            q_mem = ttnn.get_memory_config(q)
+            k_mem = ttnn.get_memory_config(k)
+            q = ttnn.to_memory_config(q, ttnn.DRAM_MEMORY_CONFIG)
+            k = ttnn.to_memory_config(k, ttnn.DRAM_MEMORY_CONFIG)
+
+            cos = cos_cache[:, :, :padded_seq, :]
+            sin = sin_cache[:, :, :padded_seq, :]
+            q = self._slice_head_dim(ttnn.experimental.rotary_embedding(self._pad_head_dim(q), cos, sin))
+            k = self._slice_head_dim(ttnn.experimental.rotary_embedding(self._pad_head_dim(k), cos, sin))
+
+            q = ttnn.to_memory_config(q, q_mem)
+            k = ttnn.to_memory_config(k, k_mem)
+
+            ttnn.experimental.paged_fill_cache(self.k_cache, k, self.page_table, batch_idx=0)
+            ttnn.experimental.paged_fill_cache(self.v_cache, v, self.page_table, batch_idx=0)
+
+            attn_out = ttnn.transformer.scaled_dot_product_attention(
+                q, k, v, is_causal=True, scale=self.scale
+            )
+            attn_out = ttnn.experimental.nlp_concat_heads(attn_out, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        else:
+            if cur_pos_tensor is None:
+                raise ValueError("cur_pos_tensor is required for decode")
+
+            q, k, v = ttnn.experimental.nlp_create_qkv_heads_decode(
+                qkv,
+                num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
+                memory_config=DECODE_MEMORY_CONFIG,
+            )
+            if not trace_decode:
+                ttnn.deallocate(qkv)
+
+            q_mem = ttnn.get_memory_config(q)
+            k_mem = ttnn.get_memory_config(k)
+            q = ttnn.to_memory_config(q, ttnn.DRAM_MEMORY_CONFIG)
+            k = ttnn.to_memory_config(k, ttnn.DRAM_MEMORY_CONFIG)
+
+            q_batch = q.shape[1]
+            q_heads = q.shape[2]
+            q_bh = q_batch * q_heads
+            q_bh_padded = pad_to_tile(q_bh)
+            q = ttnn.reshape(q, (1, 1, q_bh, self.head_dim), (1, 1, q_bh_padded, self.head_dim))
+            if decode_cos_q is None or decode_sin_q is None:
+                use_long = start_pos >= self.original_max_position_embeddings
+                cos_cache = self.cos_cache_long if use_long else self.cos_cache_short
+                sin_cache = self.sin_cache_long if use_long else self.sin_cache_short
+                q = self._slice_head_dim(
+                    ttnn.experimental.rotary_embedding(
+                        self._pad_head_dim_decode(q, self.decode_q_pad_zeros),
+                        cos_cache,
+                        sin_cache,
+                        start_pos,
+                    )
+                )
+            else:
+                q = self._slice_head_dim(
+                    ttnn.experimental.rotary_embedding(
+                        self._pad_head_dim_decode(q, self.decode_q_pad_zeros),
+                        decode_cos_q,
+                        decode_sin_q,
+                    )
+                )
+            q = ttnn.reshape(q, (1, q_batch, q_heads, self.head_dim), (1, q_batch, q_heads, self.head_dim))
+
+            k_batch = k.shape[1]
+            k_heads = k.shape[2]
+            k_bh = k_batch * k_heads
+            k_bh_padded = pad_to_tile(k_bh)
+            k = ttnn.reshape(k, (1, 1, k_bh, self.head_dim), (1, 1, k_bh_padded, self.head_dim))
+            if decode_cos_k is None or decode_sin_k is None:
+                use_long = start_pos >= self.original_max_position_embeddings
+                cos_cache = self.cos_cache_long if use_long else self.cos_cache_short
+                sin_cache = self.sin_cache_long if use_long else self.sin_cache_short
+                k = self._slice_head_dim(
+                    ttnn.experimental.rotary_embedding(
+                        self._pad_head_dim_decode(k, self.decode_k_pad_zeros),
+                        cos_cache,
+                        sin_cache,
+                        start_pos,
+                    )
+                )
+            else:
+                k = self._slice_head_dim(
+                    ttnn.experimental.rotary_embedding(
+                        self._pad_head_dim_decode(k, self.decode_k_pad_zeros),
+                        decode_cos_k,
+                        decode_sin_k,
+                    )
+                )
+            k = ttnn.reshape(k, (1, k_batch, k_heads, self.head_dim), (1, k_batch, k_heads, self.head_dim))
+
+            q = ttnn.to_memory_config(q, q_mem)
+            k = ttnn.to_memory_config(k, k_mem)
+
+            ttnn.experimental.paged_update_cache(
+                self.k_cache,
+                k,
+                update_idxs_tensor=cur_pos_tensor,
+                page_table=self.page_table,
+            )
+            ttnn.experimental.paged_update_cache(
+                self.v_cache,
+                v,
+                update_idxs_tensor=cur_pos_tensor,
+                page_table=self.page_table,
+            )
+
+            attn_out = ttnn.transformer.paged_scaled_dot_product_attention_decode(
+                q,
+                self.k_cache,
+                self.v_cache,
+                page_table_tensor=self.page_table,
+                cur_pos_tensor=cur_pos_tensor,
+                scale=self.scale,
+            )
+            attn_out = ttnn.to_memory_config(attn_out, self.decode_heads_memcfg)
+            attn_out = ttnn.experimental.nlp_concat_heads_decode(
+                attn_out,
+                num_heads=num_heads,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+
+        expected_width = num_heads * self.head_dim
+        if attn_out.shape[-1] != expected_width:
+            attn_out = ttnn.slice(
+                attn_out,
+                (0, 0, 0, 0),
+                (attn_out.shape[0], attn_out.shape[1], attn_out.shape[2], expected_width),
+            )
+
+        out = ttnn.linear(attn_out, self.o_proj)
+        return all_reduce_tensor(out, self.parallel)
+
+
+class MLP:
+    """Gated MLP using a split gate/up projection, 1D tensor parallel."""
+
+    def __init__(self, layer_idx: int, state_dict: dict, parallel: ParallelConfig):
+        p = f"model.layers.{layer_idx}.mlp."
+        self.parallel = parallel
+        gate_up_weight = state_dict[f"{p}gate_up_proj.weight"]
+        split = gate_up_weight.shape[0] // 2
+        self.gate_proj = self._load_weight(gate_up_weight[:split, :], parallel.shard_width_mapper)
+        self.up_proj = self._load_weight(gate_up_weight[split:, :], parallel.shard_width_mapper)
+        self.down_proj = self._load_weight(state_dict[f"{p}down_proj.weight"], parallel.shard_height_mapper)
+
+    def _load_weight(self, w: torch.Tensor, mesh_mapper) -> ttnn.Tensor:
+        return ttnn.as_tensor(
+            w.T.unsqueeze(0).unsqueeze(0).to(torch.bfloat16).contiguous(),
+            dtype=WEIGHT_DTYPE,
+            layout=WEIGHT_LAYOUT,
+            device=self.parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=mesh_mapper,
+        )
+
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        gate = ttnn.silu(ttnn.linear(x, self.gate_proj))
+        up = ttnn.linear(x, self.up_proj)
+        out = ttnn.linear(ttnn.mul(gate, up), self.down_proj)
+        return all_reduce_tensor(out, self.parallel)
+
+
+class DecoderLayer:
+    """Single transformer layer."""
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        layer_idx: int,
+        state_dict: dict,
+        cos_cache_short: ttnn.Tensor,
+        sin_cache_short: ttnn.Tensor,
+        cos_cache_long: ttnn.Tensor,
+        sin_cache_long: ttnn.Tensor,
+        parallel: ParallelConfig,
+        paged_attention_config: PagedAttentionConfig,
+        page_table: ttnn.Tensor,
+    ):
+        p = f"model.layers.{layer_idx}."
+        self.attn_norm = RMSNorm(state_dict[f"{p}input_layernorm.weight"], config.rms_norm_eps, parallel)
+        self.ffn_norm = RMSNorm(state_dict[f"{p}post_attention_layernorm.weight"], config.rms_norm_eps, parallel)
+        self.attn = Attention(
+            config,
+            layer_idx,
+            state_dict,
+            cos_cache_short,
+            sin_cache_short,
+            cos_cache_long,
+            sin_cache_long,
+            parallel,
+            paged_attention_config,
+            page_table,
+        )
+        self.mlp = MLP(layer_idx, state_dict, parallel)
+
+    def __call__(
+        self,
+        x: ttnn.Tensor,
+        start_pos: int,
+        seq_len: int,
+        cur_pos_tensor: Optional[ttnn.Tensor] = None,
+        decode_cos_q: Optional[ttnn.Tensor] = None,
+        decode_sin_q: Optional[ttnn.Tensor] = None,
+        decode_cos_k: Optional[ttnn.Tensor] = None,
+        decode_sin_k: Optional[ttnn.Tensor] = None,
+        trace_decode: bool = False,
+    ) -> ttnn.Tensor:
+        x = ttnn.add(
+            x,
+            self.attn(
+                self.attn_norm(x),
+                start_pos,
+                seq_len,
+                cur_pos_tensor=cur_pos_tensor,
+                decode_cos_q=decode_cos_q,
+                decode_sin_q=decode_sin_q,
+                decode_cos_k=decode_cos_k,
+                decode_sin_k=decode_sin_k,
+                trace_decode=trace_decode,
+            ),
+        )
+        x = ttnn.add(x, self.mlp(self.ffn_norm(x)))
+        return x
+
+
+class TtnnPhi3ForCausalLM(torch.nn.Module, GenerationMixin):
+    """
+    Phi-3 model with 100% ttnn execution and 1D tensor parallel on T3000.
+    HuggingFace `generate()`-compatible via `GenerationMixin`.
+    """
+
+    def __init__(self, hf_model, tt_device, max_seq_len: Optional[int] = None):
+        super().__init__()
+
+        self.tt_device = tt_device
+        self.hf_config = hf_model.config
+        self.tt_config = ModelConfig.from_hf(hf_model.config)
+        self.max_seq_len = resolve_max_seq_len(self.hf_config, max_seq_len)
+        self._pos = 0
+        self.paged_attention_config = PagedAttentionConfig(
+            PAGED_BLOCK_SIZE,
+            math.ceil(self.max_seq_len / PAGED_BLOCK_SIZE),
+        )
+
+        if self.tt_config.hidden_act != "silu":
+            raise ValueError(f"hidden_act {self.tt_config.hidden_act} is not supported in this bringup")
+
+        self.config = self.hf_config
+        self.generation_config = GenerationConfig.from_model_config(self.config)
+        if self.generation_config.pad_token_id is None:
+            self.generation_config.pad_token_id = self.generation_config.eos_token_id
+        self._supports_cache_class = False
+        self.main_input_name = "input_ids"
+        self.register_buffer("_torch_dummy", torch.empty(0, dtype=torch.float32), persistent=False)
+
+        mesh_shape = tuple(tt_device.shape)
+        num_devices = num_mesh_devices(mesh_shape)
+        mesh_axis = mesh_shape_to_axis(mesh_shape)
+        validate_parallel_config(self.tt_config, num_devices)
+
+        self.parallel = ParallelConfig(
+            mesh_device=tt_device,
+            mesh_shape=mesh_shape,
+            num_devices=num_devices,
+            mesh_axis=mesh_axis,
+            num_links=MESH_NUM_LINKS,
+            topology=MESH_TOPOLOGY,
+            replicate_mapper=ttnn.ReplicateTensorToMesh(tt_device),
+            shard_width_mapper=ttnn.ShardTensorToMesh(tt_device, dim=3),
+            shard_height_mapper=ttnn.ShardTensorToMesh(tt_device, dim=2),
+            shard_kv_mapper=ttnn.ShardTensorToMesh(tt_device, dim=1),
+            vocab_composer=ttnn.ConcatMeshToTensor(tt_device, dim=3),
+        )
+
+        state_dict = hf_model.state_dict()
+
+        print("  Loading embeddings...")
+        self.embed = ttnn.as_tensor(
+            state_dict["model.embed_tokens.weight"].unsqueeze(0).unsqueeze(0).to(torch.bfloat16),
+            dtype=WEIGHT_DTYPE,
+            layout=WEIGHT_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+
+        print("  Computing RoPE cache...")
+        cos_short, sin_short = compute_rope_cache(self.tt_config, self.max_seq_len, use_long=False)
+        cos_long, sin_long = compute_rope_cache(self.tt_config, self.max_seq_len, use_long=True)
+        self.cos_cache_short_host = cos_short
+        self.sin_cache_short_host = sin_short
+        self.cos_cache_long_host = cos_long
+        self.sin_cache_long_host = sin_long
+        self.cos_cache_short = ttnn.as_tensor(
+            cos_short,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.sin_cache_short = ttnn.as_tensor(
+            sin_short,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.cos_cache_long = ttnn.as_tensor(
+            cos_long,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.sin_cache_long = ttnn.as_tensor(
+            sin_long,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+
+        page_table = torch.arange(self.paged_attention_config.max_num_blocks, dtype=torch.int32)
+        page_table = page_table.repeat(TILE_SIZE, 1)
+        self.page_table = ttnn.as_tensor(
+            page_table,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+
+        head_dim_padded = pad_head_dim(self.tt_config.head_dim)
+        self.decode_token_buffer = ttnn.from_torch(
+            torch.zeros((1, 1, 1, TILE_SIZE), dtype=torch.int32),
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.decode_pos_buffer = ttnn.from_torch(
+            torch.zeros((TILE_SIZE,), dtype=torch.int32),
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.decode_q_rope_seq = (self.tt_config.num_attention_heads // self.parallel.num_devices) * TILE_SIZE
+        self.decode_k_rope_seq = (self.tt_config.num_key_value_heads // self.parallel.num_devices) * TILE_SIZE
+        self.decode_cos_q_buffer = ttnn.from_torch(
+            torch.zeros((1, 1, self.decode_q_rope_seq, head_dim_padded), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.decode_sin_q_buffer = ttnn.from_torch(
+            torch.zeros((1, 1, self.decode_q_rope_seq, head_dim_padded), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.decode_cos_k_buffer = ttnn.from_torch(
+            torch.zeros((1, 1, self.decode_k_rope_seq, head_dim_padded), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.decode_sin_k_buffer = ttnn.from_torch(
+            torch.zeros((1, 1, self.decode_k_rope_seq, head_dim_padded), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.use_decode_trace = USE_DECODE_TRACE
+        self.decode_trace_id = None
+        self.decode_trace_logits = None
+
+        print(f"  Loading {self.tt_config.num_hidden_layers} layers...")
+        self.layers = [
+            DecoderLayer(
+                self.tt_config,
+                i,
+                state_dict,
+                self.cos_cache_short,
+                self.sin_cache_short,
+                self.cos_cache_long,
+                self.sin_cache_long,
+                self.parallel,
+                self.paged_attention_config,
+                self.page_table,
+            )
+            for i in range(self.tt_config.num_hidden_layers)
+        ]
+
+        self.norm = RMSNorm(state_dict["model.norm.weight"], self.tt_config.rms_norm_eps, self.parallel)
+        lm_head_weight = state_dict.get("lm_head.weight", state_dict["model.embed_tokens.weight"])
+        self.lm_head = ttnn.as_tensor(
+            lm_head_weight.T.unsqueeze(0).unsqueeze(0).to(torch.bfloat16).contiguous(),
+            dtype=WEIGHT_DTYPE,
+            layout=WEIGHT_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.shard_width_mapper,
+        )
+
+        self._tt_past_key_values = object()
+
+    @property
+    def device(self) -> torch.device:
+        return self._torch_dummy.device
+
+    def _release_decode_trace(self) -> None:
+        if self.decode_trace_id is None:
+            return
+        ttnn.release_trace(self.tt_device, self.decode_trace_id)
+        self.decode_trace_id = None
+        self.decode_trace_logits = None
+
+    def reset(self):
+        """Reset position counter for new sequence."""
+        self._pos = 0
+        self._release_decode_trace()
+
+    def prepare_inputs_for_generation(self, input_ids, past_key_values=None, **kwargs):
+        if past_key_values is not None:
+            input_ids = input_ids[:, -1:]
+        return {"input_ids": input_ids, "past_key_values": past_key_values, "use_cache": True}
+
+    def _reorder_cache(self, past_key_values, beam_idx):
+        return past_key_values
+
+    def _logits_to_torch(self, logits: ttnn.Tensor) -> torch.Tensor:
+        if self.parallel.num_devices > 1:
+            return ttnn.to_torch(logits, mesh_composer=self.parallel.vocab_composer)
+        return ttnn.to_torch(logits)
+
+    def _forward_prefill(self, input_ids: torch.Tensor, start_pos: int, seq_len: int) -> ttnn.Tensor:
+        tokens = ttnn.from_torch(
+            input_ids.reshape(1, 1, 1, -1),
+            dtype=ttnn.uint32,
+            device=self.tt_device,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        h = ttnn.embedding(tokens, self.embed, layout=ttnn.TILE_LAYOUT)
+        for layer in self.layers:
+            h = layer(h, start_pos, seq_len)
+        h = self.norm(h)
+        return ttnn.linear(h, self.lm_head)
+
+    def _forward_prefill_last_logits(self, input_ids: torch.Tensor, start_pos: int, seq_len: int) -> ttnn.Tensor:
+        tokens = ttnn.from_torch(
+            input_ids.reshape(1, 1, 1, -1),
+            dtype=ttnn.uint32,
+            device=self.tt_device,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        h = ttnn.embedding(tokens, self.embed, layout=ttnn.TILE_LAYOUT)
+        for layer in self.layers:
+            h = layer(h, start_pos, seq_len)
+        h = self.norm(h)
+        last_token_idx = seq_len - 1
+        h_last = ttnn.slice(
+            h,
+            (0, 0, last_token_idx, 0),
+            (h.shape[0], h.shape[1], last_token_idx + 1, h.shape[-1]),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        ttnn.deallocate(h)
+        return ttnn.linear(h_last, self.lm_head)
+
+    def _update_decode_token_buffer(self, input_ids: torch.Tensor) -> None:
+        token_ids = torch.zeros((TILE_SIZE,), dtype=torch.int32)
+        token_ids[: input_ids.numel()] = input_ids.view(-1).to(torch.int32)
+        token_ids = token_ids.reshape(1, 1, 1, -1)
+        host_tokens = ttnn.from_torch(
+            token_ids,
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        ttnn.copy_host_to_device_tensor(host_tokens, self.decode_token_buffer)
+
+    def _update_decode_pos_buffer(self, start_pos: int) -> None:
+        pos = torch.full((TILE_SIZE,), -1, dtype=torch.int32)
+        pos[0] = start_pos
+        host_pos = ttnn.from_torch(
+            pos,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        ttnn.copy_host_to_device_tensor(host_pos, self.decode_pos_buffer)
+
+    def _update_decode_rope_buffers(self, start_pos: int) -> None:
+        use_long = start_pos >= self.tt_config.original_max_position_embeddings
+        cos_cache = self.cos_cache_long_host if use_long else self.cos_cache_short_host
+        sin_cache = self.sin_cache_long_host if use_long else self.sin_cache_short_host
+        cos_token = cos_cache[:, :, start_pos : start_pos + 1, :]
+        sin_token = sin_cache[:, :, start_pos : start_pos + 1, :]
+        cos_q = cos_token.repeat(1, 1, self.decode_q_rope_seq, 1)
+        sin_q = sin_token.repeat(1, 1, self.decode_q_rope_seq, 1)
+        cos_k = cos_token.repeat(1, 1, self.decode_k_rope_seq, 1)
+        sin_k = sin_token.repeat(1, 1, self.decode_k_rope_seq, 1)
+        host_cos_q = ttnn.from_torch(
+            cos_q,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+        )
+        host_sin_q = ttnn.from_torch(
+            sin_q,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+        )
+        host_cos_k = ttnn.from_torch(
+            cos_k,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+        )
+        host_sin_k = ttnn.from_torch(
+            sin_k,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+        )
+        ttnn.copy_host_to_device_tensor(host_cos_q, self.decode_cos_q_buffer)
+        ttnn.copy_host_to_device_tensor(host_sin_q, self.decode_sin_q_buffer)
+        ttnn.copy_host_to_device_tensor(host_cos_k, self.decode_cos_k_buffer)
+        ttnn.copy_host_to_device_tensor(host_sin_k, self.decode_sin_k_buffer)
+
+    def _forward_decode_device(self, start_pos: int, trace_decode: bool) -> ttnn.Tensor:
+        h = ttnn.embedding(self.decode_token_buffer, self.embed, layout=ttnn.TILE_LAYOUT)
+        for layer in self.layers:
+            h = layer(
+                h,
+                start_pos,
+                1,
+                cur_pos_tensor=self.decode_pos_buffer,
+                decode_cos_q=self.decode_cos_q_buffer,
+                decode_sin_q=self.decode_sin_q_buffer,
+                decode_cos_k=self.decode_cos_k_buffer,
+                decode_sin_k=self.decode_sin_k_buffer,
+                trace_decode=trace_decode,
+            )
+        h = self.norm(h)
+        h = ttnn.slice(
+            h,
+            (0, 0, 0, 0),
+            (h.shape[0], h.shape[1], 1, h.shape[-1]),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        return ttnn.linear(h, self.lm_head)
+
+    def _forward_decode(self, input_ids: torch.Tensor, start_pos: int) -> ttnn.Tensor:
+        self._update_decode_token_buffer(input_ids)
+        self._update_decode_pos_buffer(start_pos)
+        self._update_decode_rope_buffers(start_pos)
+
+        if self.use_decode_trace:
+            if self.decode_trace_id is None:
+                warmup_logits = self._forward_decode_device(start_pos, False)
+                ttnn.deallocate(warmup_logits)
+                self.decode_trace_id = ttnn.begin_trace_capture(self.tt_device)
+                self.decode_trace_logits = self._forward_decode_device(start_pos, True)
+                ttnn.end_trace_capture(self.tt_device, self.decode_trace_id)
+            else:
+                ttnn.execute_trace(self.tt_device, self.decode_trace_id, blocking=False)
+            return self.decode_trace_logits
+        return self._forward_decode_device(start_pos, False)
+
+    def _forward_device_logits(self, input_ids: torch.Tensor, past_key_values, use_cache: bool):
+        batch, seq_len = input_ids.shape
+        if batch != 1:
+            raise ValueError("Only batch=1 supported")
+
+        if past_key_values is None:
+            self.reset()
+        elif seq_len != 1:
+            raise ValueError("Only 1-token decode supported when using cache")
+
+        start_pos = self._pos
+        if start_pos + seq_len > self.max_seq_len:
+            raise ValueError(
+                f"sequence length {start_pos + seq_len} exceeds max_seq_len {self.max_seq_len}; "
+                "increase --max-seq-len if memory allows"
+            )
+
+        if seq_len == 1:
+            logits = self._forward_decode(input_ids, start_pos)
+            padded_seq = 1
+        else:
+            padded_seq = pad_to_tile(seq_len)
+            if seq_len < padded_seq:
+                input_ids = torch.nn.functional.pad(input_ids, (0, padded_seq - seq_len), value=0)
+            logits = self._forward_prefill(input_ids, start_pos, seq_len)
+
+        self._pos = start_pos + seq_len
+        past = self._tt_past_key_values if use_cache else None
+        return logits, seq_len, padded_seq, past
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        past_key_values=None,
+        use_cache: bool = True,
+        cache_position: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> CausalLMOutputWithPast:
+        batch = input_ids.shape[0]
+        logits_device, seq_len, padded_seq, past = self._forward_device_logits(input_ids, past_key_values, use_cache)
+        logits = self._logits_to_torch(logits_device).reshape(batch, padded_seq, -1)[:, :seq_len, :]
+
+        if seq_len > 1 or not self.use_decode_trace:
+            ttnn.deallocate(logits_device)
+
+        return CausalLMOutputWithPast(
+            logits=logits.float(),
+            past_key_values=past,
+        )
+
+    def prefill_logits_last_device(self, input_ids: torch.Tensor, use_cache: bool = True) -> tuple[torch.Tensor, object]:
+        batch, seq_len = input_ids.shape
+        if batch != 1:
+            raise ValueError("Only batch=1 supported")
+
+        self.reset()
+        start_pos = self._pos
+        if start_pos + seq_len > self.max_seq_len:
+            raise ValueError(
+                f"sequence length {start_pos + seq_len} exceeds max_seq_len {self.max_seq_len}; "
+                "increase --max-seq-len if memory allows"
+            )
+
+        padded_seq = pad_to_tile(seq_len)
+        if seq_len < padded_seq:
+            input_ids = torch.nn.functional.pad(input_ids, (0, padded_seq - seq_len), value=0)
+
+        logits_device = self._forward_prefill_last_logits(input_ids, start_pos, seq_len)
+        self._pos = start_pos + seq_len
+
+        logits = self._logits_to_torch(logits_device).reshape(batch, 1, -1)[:, 0, :].float()
+        ttnn.deallocate(logits_device)
+
+        past = self._tt_past_key_values if use_cache else None
+        return logits, past
+
+
+def build_model(hf_model, tt_device, max_seq_len: Optional[int] = None) -> TtnnPhi3ForCausalLM:
+    """Build the ttnn model from a HuggingFace reference model."""
+    return TtnnPhi3ForCausalLM(hf_model, tt_device, max_seq_len)


### PR DESCRIPTION
Target: optimize `models/microsoft/Phi-3-mini-128k-instruct/t3000/optimized` using `tasks/optimize_model.yaml`.

Summary:
- Added `t3000/optimized` variant for `microsoft/Phi-3-mini-128k-instruct`.
- Decode uses traced execution with preallocated token/pos/RoPE buffers.
- Added `prefill_logits_last_device()` fast path for TTFT.
- Fused QKV projection with TP-safe shard ordering.

Results (t3000):
- Demo: TTFT 105 ms, decode 23.6 t/s/u, seq len 12288
- Long eval: Top-1 92%, Top-5 99%

Artifacts:
- `models/microsoft/Phi-3-mini-128k-instruct/t3000/optimized/demo.log`
- `models/microsoft/Phi-3-mini-128k-instruct/t3000/optimized/eval.log`
- `models/microsoft/Phi-3-mini-128k-instruct/t3000/optimized/metrics.json`

Fixes #152
