### PR TITLE
models/meta-llama/Llama-3.2-1B/n150/optimized: refresh optimized metrics

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -25,7 +25,7 @@ Note: Keep the table columns padded with spaces and right-justify numeric cells 
 | humain-ai/ALLaM-7B-Instruct-preview |  t3000   | functional |   95% |  100% |  127ms |   9.1 |    4096 |
 | humain-ai/ALLaM-7B-Instruct-preview |  t3000   | optimized  |   97% |  100% |   61ms |  24.3 |    4096 |
 | meta-llama/Llama-3.2-1B             |   n150   | functional |   92% |  100% |   34ms |  39.5 |  131072 |
-| meta-llama/Llama-3.2-1B             |   n150   | optimized  |   90% |  100% |   21ms |  68.0 |    2048 |
+| meta-llama/Llama-3.2-1B             |   n150   | optimized  |   90% |  100% |   27ms |  63.0 |  131072 |
 | meta-llama/Llama-3.2-1B             |   n300   | functional |   90% |  100% |  610ms |   6.7 |  131072 |
 | meta-llama/Llama-3.2-1B             |  t3000   | functional |   92% |  100% |  267ms |   6.6 |  131072 |
 | meta-llama/Llama-3.2-1B             |  t3000   | optimized  |   94% |  100% |   36ms |  57.5 |  131072 |

--- a/models/meta-llama/Llama-3.2-1B/n150/optimized/MODEL_BRINGUP.md
+++ b/models/meta-llama/Llama-3.2-1B/n150/optimized/MODEL_BRINGUP.md
@@ -1,60 +1,64 @@
-# MODEL_BRINGUP.md — Llama 3.2 1B (n150 optimized)
+# MODEL_BRINGUP.md - Llama 3.2 1B (n150 optimized)
 
 ## Overview
 This is the optimized TTNN bringup of `meta-llama/Llama-3.2-1B` for `n150`.
-It is the maintained reference for this directory.
 
 - Model code: `models/meta-llama/Llama-3.2-1B/n150/optimized/model.py`
-- Eval harness: `eval.py`
-- Demo harness: `demo.py`
-- Optimization notes and decisions: `models/meta-llama/Llama-3.2-1B/n150/optimized/TODO.txt`
+- Demo log: `models/meta-llama/Llama-3.2-1B/n150/optimized/demo.log`
+- Eval log: `models/meta-llama/Llama-3.2-1B/n150/optimized/eval.log`
+- Machine-readable metrics: `models/meta-llama/Llama-3.2-1B/n150/optimized/metrics.json`
+- Decode path uses traced execution (`ttnn.begin_trace_capture` + `ttnn.execute_trace`)
 
 ## Model API contract
 - Exposes `build_model(hf_model, tt_device, max_seq_len)`.
-- Returns a `torch.nn.Module` + `GenerationMixin` model compatible with HF `generate()`.
-- Returns `CausalLMOutputWithPast(logits=..., past_key_values=...)`.
+- Returns a HuggingFace `generate()`-compatible model (`torch.nn.Module` + `GenerationMixin`).
+- Returns `CausalLMOutputWithPast(logits=..., past_key_values=...)` with on-device KV cache managed inside the TT model.
 
-## What this optimized path includes
-- Paged KV cache:
-  - K/V layout: `[max_num_blocks, n_kv_heads, block_size, head_dim]`
-  - `page_table`: `[32, max_num_blocks]` int32, row-major
-  - Prefill: `ttnn.experimental.paged_fill_cache`
-  - Decode: `ttnn.experimental.paged_update_cache` + `ttnn.transformer.paged_scaled_dot_product_attention_decode`
-- Fused QKV projection.
-- Decode trace path with allocation-safe decode logits trimming in traced region.
-- Decode-only DRAM-sharded matmuls for:
-  - MLP (`w1`, `w3`, `w2`)
-  - Attention output projection (`o_proj`)
-- Tuned LM head decode program config (`8x7` grid on n150) for better K blocking.
-- `prefill_logits_last_device()` fast path used by `eval.py` and `demo.py` when available.
+## Baseline vs final
+| Metric | Functional baseline (`MODELS.md`) | Starting optimized baseline (this pass) | Final optimized |
+| --- | ---: | ---: | ---: |
+| Top-1 | 92% | 90% | 90% |
+| Top-5 | 100% | 100% | 100% |
+| TTFT | 34 ms | 29 ms | 27 ms |
+| t/s/u | 39.5 | 63.1 | 63.0 |
+| Seq len | 131072 | 131072 | 131072 |
 
-## Correctness and runtime constraints
-- Keep `max_seq_len >= 2048` for the eval contract.
-- Decode uses tile-padded batch (`B=32`), and padded entries must use `cur_pos_tensor=-1`.
-- `decode_pos_buffer` must stay in DRAM (`paged_update_cache` requirement for `update_idxs_tensor`).
-- For GQA decode:
-  - SDPA decode output is interleaved.
-  - Reshard before `ttnn.experimental.nlp_concat_heads_decode`.
-- `ttnn.swiglu` is not used in decode MLP sharded path; decode MLP uses separate gate/up matmuls + `ttnn.mul(..., SILU)`.
+## Kept optimization decisions
+1. Paged KV cache for long-seq decode.
+- K/V layout: `[max_num_blocks, n_kv_heads, block_size, head_dim]`.
+- Prefill: `ttnn.experimental.paged_fill_cache`.
+- Decode: `ttnn.experimental.paged_update_cache` + `ttnn.transformer.paged_scaled_dot_product_attention_decode`.
 
-## Performance measurement notes
-- `demo.py` performs one prefill+decode warmup pass before timing to compile first-use kernels.
-- Decode throughput in recent runs is typically mid/high 60s t/s/u on this box; best recorded run is about 68 t/s/u.
+2. Decode trace with preallocated decode buffers.
+- Avoids per-token allocations in the decode loop.
 
-## Validation commands
+3. Decode-only DRAM-sharded matmuls for attention `o_proj` and MLP (w1/w3/w2).
+
+4. Prefill-last-logits fast paths.
+- `prefill_logits_last_device()` is used by `eval.py`/`demo.py` when host logits are needed.
+- `next_token_device()` uses a prefill-last-logits path so greedy TT demo does not materialize full prefill logits.
+
+## Constraints and gotchas
+- `eval.py` enforces `max_seq_len >= 2048`.
+- Decode uses a tile-padded batch (`B=32`); inactive lanes must use `cur_pos_tensor=-1`.
+- `decode_pos_buffer` must stay in DRAM (`paged_update_cache` requires DRAM `update_idxs_tensor`).
+- For GQA decode, SDPA output is interleaved and must be resharded before `ttnn.experimental.nlp_concat_heads_decode`.
+- Decode MLP sharded path avoids `ttnn.swiglu` and uses separate gate/up matmuls + `ttnn.mul(..., SILU)`.
+
+## Commands used
 ```bash
-python eval.py models/meta-llama/Llama-3.2-1B/n150/optimized/model.py --max_new_tokens 100 --prompt_file prompts/bringup_eval_long.txt --seed 0
-python demo.py models/meta-llama/Llama-3.2-1B/n150/optimized/model.py --seed 0
+python demo.py models/meta-llama/Llama-3.2-1B/n150/optimized/model.py \
+  --prompt-file prompts/bringup_eval_long.txt \
+  --max-new-tokens 100 \
+  --temperature 0 \
+  --seed 0 \
+  --max_seq_len 131072
+
+python eval.py models/meta-llama/Llama-3.2-1B/n150/optimized/model.py \
+  --prompt_file prompts/bringup_eval_long.txt \
+  --max_new_tokens 100 \
+  --seed 0 \
+  --max_seq_len 131072
 ```
 
-Expected current behavior:
-- `eval.py` 100-token teacher-forcing around Top-1 90%, Top-5 100%.
-- `demo.py` output coherent with decode throughput in the expected range above.
-
-## Deferred/rejected optimization directions
-- DRAM-sharded decode QKV: micro-op gain, negligible layer-level win for added complexity.
-- DRAM-sharded one-shot LM head: blocked by sharding/L1 static-CB constraints (would need chunking or another path).
-- SDPA decode LoFi / `packer_l1_acc=False` variants: slower on this setup.
-- Decode core grid below 32 cores: incompatible with decode sharding requirements.
-
-See `doc/ttnn.md` ("Optimizing models") for the generalized optimization workflow and reusable constraints.
+See `doc/ttnn.md` for the general optimization workflow and the paged-KV + decode-trace constraints we rely on here.

--- a/models/meta-llama/Llama-3.2-1B/n150/optimized/demo.log
+++ b/models/meta-llama/Llama-3.2-1B/n150/optimized/demo.log
@@ -1,64 +1,69 @@
-python demo.py models/meta-llama/Llama-3.2-1B/n150/optimized/model.py
+python demo.py models/meta-llama/Llama-3.2-1B/n150/optimized/model.py --prompt-file prompts/bringup_eval_long.txt --max-new-tokens 100 --temperature 0 --seed 0 --max_seq_len 131072
 /proj_sw/user_dev/moconnor/tt-metal/python_env/lib/python3.10/site-packages/transformers/utils/hub.py:111: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
   warnings.warn(
-2026-01-26 21:19:08.636 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+2026-02-12 13:34:28.329 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
-2026-01-26 21:19:09.366 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-01-26 21:19:09.367 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-01-26 21:19:09.370 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-01-26 21:19:09.389 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-01-26 21:19:09.389 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x10 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-01-26 21:19:09.471 | info     |             UMD | Opening local chip ids/PCIe ids: {0}/[7] and remote chip ids {} (cluster.cpp:186)
-2026-01-26 21:19:09.471 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-01-26 21:19:09.471 | info     |             UMD | KMD version: 2.4.0 (cluster.cpp:164)
-2026-01-26 21:19:09.473 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-01-26 21:19:09.476 | info     |             UMD | Mapped hugepage 0x4280000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-01-26 21:19:09.533 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.WORKER
-2026-01-26 21:19:09.533 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-01-26 21:19:09.533 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:863)
-2026-01-26 21:19:09.533 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:840)
-2026-01-26 21:19:09.533 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
-2026-01-26 21:19:09.533 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
-2026-01-26 21:19:52.682 | warning  |    BuildKernels | Compute kernel 'tilize/15226587635767794520/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:19:52.832 | warning  |    BuildKernels | Compute kernel 'layernorm/16575396072292877579/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:19:56.936 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/879325624015193869/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:20:03.246 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/5804696304524586410/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:20:07.355 | warning  |    BuildKernels | Compute kernel 'sdpa/9726990630651075361/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:20:12.284 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/5424550157315737887/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:20:17.065 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/16035928854143837900/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:20:22.058 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/5376491519864511775/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:20:26.787 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4595876156507707898/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:20:32.309 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/18121958218550865810/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:20:41.008 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/11544455884028682462/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:20:41.165 | warning  |    BuildKernels | Compute kernel 'update_cache/14870881097740960270/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:20:45.653 | warning  |    BuildKernels | Compute kernel 'sdpa_flash_decode/16585722589506561792/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:20:55.312 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4247234012368108197/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:21:04.353 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/12358738758558764553/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:21:22.068 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/3274274613297938579/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:21:27.190 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/17507116290200312911/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:21:36.164 | warning  |           Metal | Allocating device buffers is unsafe due to the existence of an active trace. These buffers may be corrupted once a trace is executed. (allocator.cpp:105)
-2026-01-26 21:21:36.199 | warning  |    BuildKernels | Compute kernel 'pack_untilize_wh/5246262845673806129/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:21:36.200 | warning  |    BuildKernels | Compute kernel 'pack_untilize_wh/9098729250554715758/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:21:36.203 | warning  |    BuildKernels | Compute kernel 'pack_untilize_wh/3389884531766802369/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
 Loading tokenizer: meta-llama/Llama-3.2-1B
 Opening TT device...
+2026-02-12 13:34:29.114 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 13:34:29.115 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-12 13:34:29.119 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 13:34:29.140 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 13:34:29.141 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x200 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 13:34:29.239 | info     |             UMD | Opening local chip ids/PCIe ids: {0}/[5] and remote chip ids {} (cluster.cpp:186)
+2026-02-12 13:34:29.239 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-12 13:34:29.239 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-12 13:34:29.241 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-12 13:34:29.242 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 13:34:29.347 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.WORKER
+2026-02-12 13:34:29.347 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-12 13:34:29.347 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:863)
+2026-02-12 13:34:29.347 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:840)
+2026-02-12 13:34:29.347 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
+2026-02-12 13:34:29.347 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
+2026-02-12 13:34:29.361 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 13:34:29.440 | warning  |           Metal | Unable to bind worker thread to CPU Core. May see performance degradation. Error Code: 22 (hardware_command_queue.cpp:65)
 Loading HuggingFace reference model on CPU: meta-llama/Llama-3.2-1B
 Building TT model...
   Loading embeddings...
   Computing RoPE cache...
   Loading 16 layers...
+Running one warmup prefill+decode pass (kernel compile warmup)...
+2026-02-12 13:35:45.116 | warning  |    BuildKernels | Compute kernel 'tilize/15226587635767794520/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:35:45.254 | warning  |    BuildKernels | Compute kernel 'layernorm/16575396072292877579/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:35:45.417 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/16441316398278494312/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:35:45.638 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/12842950227539693276/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:35:45.639 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/2900938726735679373/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:35:45.764 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/5804696304524586410/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:35:45.925 | warning  |    BuildKernels | Compute kernel 'sdpa/6905345576590187235/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:35:46.132 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4101541377063782974/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:35:46.377 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/6013385946793124051/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:35:46.640 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/10546507521909555400/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:35:46.775 | warning  |    BuildKernels | Compute kernel 'pack_untilize_wh/12783016731784767080/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:35:46.775 | warning  |    BuildKernels | Compute kernel 'pack_untilize_wh/7930053625946004808/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:35:46.776 | warning  |    BuildKernels | Compute kernel 'pack_untilize_wh/3639602974031525772/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:35:46.776 | warning  |    BuildKernels | Compute kernel 'pack_untilize_wh/9801006690367367760/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:35:46.973 | warning  |    BuildKernels | Compute kernel 'tilize_wh/4709288304851342762/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:35:47.077 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/3643904943648961295/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:35:47.395 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/18121958218550865810/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:35:47.582 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/11544455884028682462/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:35:47.702 | warning  |    BuildKernels | Compute kernel 'update_cache/9057611581672989182/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:35:47.820 | warning  |    BuildKernels | Compute kernel 'sdpa_flash_decode/9634701427854799071/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:35:48.115 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/7312482683771425452/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:35:48.367 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/8948541526623943240/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:35:48.532 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/1214715400350102490/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
 TT demo (n150)
 Model: meta-llama/Llama-3.2-1B
 Mesh shape: 1x1
-Prompt tokens: 55 | Generated tokens: 128
-TTFT: 26 ms | Decode: 58.0 t/s/u (127 tokens)
+Prompt tokens: 141 | Generated tokens: 100
+TTFT: 27 ms | Decode: 63.0 t/s/u (98 tokens)
 
 Prompt:
-Journal entry, 1957: Tonight a tiny sphere called Sputnik 1 crossed the sky, beeping like a metronome for a new era. The neighbors gathered on the roof, listening and arguing about what comes next. I wrote in my notebook that
+Write a concise internal update for the ttnn model bringup team. Yesterday we validated the Llama pipeline end to end and fixed a cache indexing bug. Today we want to run a longer teacher forcing eval with a realistic prompt. Summarize the goal in one sentence, then provide two sections: Risks and Plan. In Risks list three bullets: device contention, prompt length exceeding cache, and slow reference generation. In Plan list five bullets: prepare the prompt file, verify token count, run the HF reference, inspect output for coherence, then run the TT model and record top-1 and top-5. Close with a short reminder to keep logs and stop on unexpected behavior.
+
 
 Output:
- it reminded me of a baby. I wonder if we’ll be thinking about Sputnik’s mission in 50 years?
-I watched Sputnik 1 with my mother on TV while waiting for the dentist to leave. I remember a certain excitement at having the space program on TV and it reminded me of the time I was in space and watching the TV in Houston from the inside of a rocket. I wrote in my notebook that I didn’t even know then that I’d one day be in space and watching the TV in Houston from the inside of a rocket.
-Journal entry, 1966: It was the end of the Cold
-2026-01-26 21:21:48.579 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-01-26 21:21:48.579 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
+The goal of this update is to validate the Llama pipeline end to end and fix a cache indexing bug. We will run a longer teacher forcing eval with a realistic prompt. Summarize the goal in one sentence, then provide two sections: Risks and Plan. In Risks list three bullets: device contention, prompt length exceeding cache, and slow reference generation. In Plan list five bullets: prepare the prompt file, verify token count, run the HF reference, inspect output for coherence, then
+YT_METRICS={"mode": "tt_demo", "model": "meta-llama/Llama-3.2-1B", "system": "n150", "mesh_shape": [1, 1], "prompt_tokens": 141, "generated_tokens": 100, "ttft_ms": 27.17082799972559, "decode_tps_u": 63.03591640632349, "decode_tokens": 98, "max_seq_len": 131072}
+2026-02-12 13:35:51.894 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-12 13:35:51.894 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/meta-llama/Llama-3.2-1B/n150/optimized/eval.log
+++ b/models/meta-llama/Llama-3.2-1B/n150/optimized/eval.log
@@ -1,56 +1,62 @@
-python eval.py models/meta-llama/Llama-3.2-1B/n150/optimized/model.py --max_new_tokens 100 --prompt_file prompts/bringup_eval_long.txt
-2026-01-26 21:22:07.411 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+python eval.py models/meta-llama/Llama-3.2-1B/n150/optimized/model.py --max_new_tokens 100 --prompt_file prompts/bringup_eval_long.txt --seed 0 --max_seq_len 131072
+2026-02-12 13:31:47.625 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
 /proj_sw/user_dev/moconnor/tt-metal/python_env/lib/python3.10/site-packages/transformers/utils/hub.py:111: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
   warnings.warn(
-The following generation flags are not valid and may be ignored: ['temperature', 'top_p']. Set `TRANSFORMERS_VERBOSITY=info` for more details.
-2026-01-26 21:23:08.828 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-01-26 21:23:08.829 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-01-26 21:23:08.833 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-01-26 21:23:08.852 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-01-26 21:23:08.852 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x10 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-01-26 21:23:08.918 | info     |             UMD | Opening local chip ids/PCIe ids: {0}/[7] and remote chip ids {} (cluster.cpp:186)
-2026-01-26 21:23:08.918 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-01-26 21:23:08.918 | info     |             UMD | KMD version: 2.4.0 (cluster.cpp:164)
-2026-01-26 21:23:08.920 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-01-26 21:23:08.923 | info     |             UMD | Mapped hugepage 0x4280000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-01-26 21:23:08.976 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.WORKER
-2026-01-26 21:23:08.977 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-01-26 21:23:08.977 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:863)
-2026-01-26 21:23:08.977 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:840)
-2026-01-26 21:23:08.977 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
-2026-01-26 21:23:08.977 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
-2026-01-26 21:23:38.820 | warning  |    BuildKernels | Compute kernel 'tilize/15226587635767794520/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:23:38.995 | warning  |    BuildKernels | Compute kernel 'layernorm/16575396072292877579/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:23:39.204 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/16441316398278494312/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:23:44.195 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/2900938726735679373/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:23:44.196 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/12842950227539693276/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:23:44.344 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/5804696304524586410/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:23:44.521 | warning  |    BuildKernels | Compute kernel 'sdpa/6905345576590187235/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:23:49.489 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4101541377063782974/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:23:54.151 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/11274405974822183159/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:23:59.040 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/10546507521909555400/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:24:03.717 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/16385535429230802714/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:24:10.056 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/18121958218550865810/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:24:10.271 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/11544455884028682462/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:24:10.416 | warning  |    BuildKernels | Compute kernel 'update_cache/14870881097740960270/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:24:10.545 | warning  |    BuildKernels | Compute kernel 'sdpa_flash_decode/16585722589506561792/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:24:10.835 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4247234012368108197/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:24:11.066 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/12358738758558764553/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:24:11.481 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/3274274613297938579/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:24:11.615 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/17507116290200312911/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
-2026-01-26 21:24:11.786 | warning  |           Metal | Allocating device buffers is unsafe due to the existence of an active trace. These buffers may be corrupted once a trace is executed. (allocator.cpp:105)
 Loading model module: /localdev/moconnor/ttnn_models/models/meta-llama/Llama-3.2-1B/n150/optimized/model.py
 Loading HuggingFace tokenizer...
 Loading HuggingFace reference model on CPU...
 Generating reference tokens...
-Opening device...
+The following generation flags are not valid and may be ignored: ['temperature', 'top_p']. Set `TRANSFORMERS_VERBOSITY=info` for more details.
+Opening device (1x1)...
+2026-02-12 13:32:42.223 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 13:32:42.224 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-12 13:32:42.228 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 13:32:42.251 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 13:32:42.251 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x200 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 13:32:42.352 | info     |             UMD | Opening local chip ids/PCIe ids: {0}/[5] and remote chip ids {} (cluster.cpp:186)
+2026-02-12 13:32:42.352 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-12 13:32:42.352 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-12 13:32:42.355 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-12 13:32:42.356 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 13:32:42.463 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.WORKER
+2026-02-12 13:32:42.463 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-12 13:32:42.463 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:863)
+2026-02-12 13:32:42.463 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:840)
+2026-02-12 13:32:42.463 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
+2026-02-12 13:32:42.463 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
+2026-02-12 13:32:42.532 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-12 13:32:43.060 | warning  |           Metal | Unable to bind worker thread to CPU Core. May see performance degradation. Error Code: 22 (hardware_command_queue.cpp:65)
 Loading ttnn model...
   Loading embeddings...
   Computing RoPE cache...
   Loading 16 layers...
 Running teacher-forcing eval (100 tokens)...
-Top-1 accuracy: 79.00% (0.7900)
-Top-5 accuracy: 99.00% (0.9900)
-2026-01-26 21:24:15.063 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-01-26 21:24:15.063 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
+2026-02-12 13:33:44.610 | warning  |    BuildKernels | Compute kernel 'tilize/15226587635767794520/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:33:44.753 | warning  |    BuildKernels | Compute kernel 'layernorm/16575396072292877579/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:33:44.915 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/16441316398278494312/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:33:45.157 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/2900938726735679373/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:33:45.159 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/12842950227539693276/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:33:45.290 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/5804696304524586410/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:33:45.453 | warning  |    BuildKernels | Compute kernel 'sdpa/6905345576590187235/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:33:45.694 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4101541377063782974/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:33:45.938 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/6013385946793124051/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:33:46.205 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/10546507521909555400/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:33:46.336 | warning  |    BuildKernels | Compute kernel 'pack_untilize_wh/7930053625946004808/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:33:46.337 | warning  |    BuildKernels | Compute kernel 'pack_untilize_wh/3639602974031525772/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:33:46.337 | warning  |    BuildKernels | Compute kernel 'pack_untilize_wh/9801006690367367760/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:33:46.340 | warning  |    BuildKernels | Compute kernel 'pack_untilize_wh/12783016731784767080/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:33:46.541 | warning  |    BuildKernels | Compute kernel 'tilize_wh/4709288304851342762/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:33:46.653 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/3643904943648961295/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:33:46.892 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/18121958218550865810/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:33:47.094 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/11544455884028682462/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:33:47.220 | warning  |    BuildKernels | Compute kernel 'update_cache/9057611581672989182/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:33:47.336 | warning  |    BuildKernels | Compute kernel 'sdpa_flash_decode/9634701427854799071/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:33:47.630 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/7312482683771425452/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:33:47.881 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/8948541526623943240/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 13:33:48.049 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/1214715400350102490/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+Top-1 accuracy: 90.00% (0.9000)
+Top-5 accuracy: 100.00% (1.0000)
+YT_METRICS={"mode": "tt_eval", "model": "meta-llama/Llama-3.2-1B", "top1": 0.9, "top5": 1.0, "top1_pct": 90.0, "top5_pct": 100.0, "total_tokens": 100, "max_new_tokens": 100, "max_seq_len": 131072}
+2026-02-12 13:33:51.085 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-12 13:33:51.085 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/meta-llama/Llama-3.2-1B/n150/optimized/metrics.json
+++ b/models/meta-llama/Llama-3.2-1B/n150/optimized/metrics.json
@@ -1,0 +1,27 @@
+{
+  "model": "meta-llama/Llama-3.2-1B",
+  "hardware": "n150",
+  "variant": "optimized",
+  "functional_baseline": {
+    "top1_pct": 92.0,
+    "top5_pct": 100.0,
+    "ttft_ms": 34.0,
+    "decode_tps_u": 39.5,
+    "seq_len": 131072
+  },
+  "optimized_final": {
+    "top1_pct": 90.0,
+    "top5_pct": 100.0,
+    "ttft_ms": 27.17082799972559,
+    "decode_tps_u": 63.03591640632349,
+    "seq_len": 131072
+  },
+  "acceptance": {
+    "top1_top5_pass": true,
+    "decode_trace_enabled": true,
+    "ttft_improved": true,
+    "decode_tps_improved": true,
+    "seq_len_non_regressed": true
+  }
+}
+

--- a/models/meta-llama/Llama-3.2-1B/n150/optimized/model.py
+++ b/models/meta-llama/Llama-3.2-1B/n150/optimized/model.py
@@ -922,16 +922,37 @@ class TtnnLlamaForCausalLM(torch.nn.Module, GenerationMixin):
         )
 
     def next_token_device(self, input_ids: torch.Tensor, past_key_values=None, use_cache: bool = True) -> tuple[int, object]:
-        logits, seq_len, padded_seq, past = self._forward_device_logits(input_ids, past_key_values, use_cache)
-        token_idx = seq_len - 1
-        if seq_len == 1:
+        batch, seq_len = input_ids.shape
+        assert batch == 1, "Only batch=1 supported"
+
+        if past_key_values is None and seq_len > 1:
+            # Prefill: we only need the final prompt token logits to pick the next token.
+            # Avoid materializing the full [seq_len, vocab] logits tensor.
+            self.reset()
+            start_pos = self._pos
+            if start_pos + seq_len > self.cache_seq_len:
+                raise ValueError(
+                    f"sequence length {start_pos + seq_len} exceeds cache length {self.cache_seq_len}; "
+                    "increase max_seq_len"
+                )
+            padded_seq = pad_to_tile(seq_len)
+            if seq_len < padded_seq:
+                input_ids = torch.nn.functional.pad(input_ids, (0, padded_seq - seq_len), value=0)
+            logits = self._forward_prefill_last_logits(input_ids, start_pos, seq_len)
+            self._pos = start_pos + seq_len
+            past = self._tt_past_key_values if use_cache else None
             logits_token = logits
         else:
-            logits_token = ttnn.slice(
-                logits,
-                (0, 0, token_idx, 0),
-                (logits.shape[0], logits.shape[1], token_idx + 1, logits.shape[-1]),
-            )
+            logits, seq_len, padded_seq, past = self._forward_device_logits(input_ids, past_key_values, use_cache)
+            token_idx = seq_len - 1
+            if seq_len == 1:
+                logits_token = logits
+            else:
+                logits_token = ttnn.slice(
+                    logits,
+                    (0, 0, token_idx, 0),
+                    (logits.shape[0], logits.shape[1], token_idx + 1, logits.shape[-1]),
+                )
 
         # Argmax supports TILE inputs only in single-core mode; this avoids an expensive untilize.
         token_ids = ttnn.argmax(


### PR DESCRIPTION
Fixes #138

Updates the n150 optimized Llama-3.2-1B bringup to match current measured metrics and long-seq capability.

- Validated `--max_seq_len 131072` with updated `demo.log`/`eval.log` (Top-1 90%, Top-5 100%).
- Updated `MODELS.md` optimized row (Seq len 131072, TTFT 27ms, t/s/u 63.0).
- Added `metrics.json` and refreshed `MODEL_BRINGUP.md`.
- Small TTFT win: `next_token_device()` prefill path now uses last-logits so greedy demo avoids materializing full prefill logits.
