### PR TITLE
opt: arcee-ai/Arcee-Spark n150 optimized

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -9,6 +9,7 @@ Note: Keep the table columns padded with spaces and right-justify numeric cells 
 | Model                               | Hardware |  Variant   | Top-1 | Top-5 |   TTFT | t/s/u | Seq len |
 | ----------------------------------- | :------: | :--------: | ----: | ----: | -----: | ----: | ------: |
 | arcee-ai/Arcee-Spark                |   n150   | functional |   92% |  100% |   99ms |  13.9 |   29952 |
+| arcee-ai/Arcee-Spark                |   n150   | optimized  |   91% |  100% |   77ms |  14.5 |   29952 |
 | arcee-ai/Arcee-Spark                |   n300   | functional |   91% |  100% |  338ms |   5.0 |   32768 |
 | arcee-ai/Arcee-Spark                |  t3000   | functional |   90% |  100% |  343ms |   4.9 |   32768 |
 | arcee-ai/Arcee-Spark                |  t3000   | optimized  |   90% |  100% |   72ms |  17.6 |   32768 |

--- a/models/arcee-ai/Arcee-Spark/n150/optimized/MODEL_BRINGUP.md
+++ b/models/arcee-ai/Arcee-Spark/n150/optimized/MODEL_BRINGUP.md
@@ -1,11 +1,10 @@
-# MODEL_BRINGUP.md — Arcee-Spark (n150 optimized)
+# MODEL_BRINGUP.md — arcee-ai/Arcee-Spark (n150 optimized)
 
 ## Overview
 Optimized TTNN bringup of `arcee-ai/Arcee-Spark` (Qwen2 family) on Wormhole n150.
 
 - Model code: `models/arcee-ai/Arcee-Spark/n150/optimized/model.py`
-- Eval harness: `eval.py` (teacher forcing) and `scripts/run_eval.py`
-- Directory convention: `models/<org>/<model_name>/<system>/optimized/model.py`
+- Logs: `models/arcee-ai/Arcee-Spark/n150/optimized/demo.log`, `models/arcee-ai/Arcee-Spark/n150/optimized/eval.log`
 
 ## Functional Baseline (n150)
 From `MODELS.md` for `arcee-ai/Arcee-Spark` n150 functional:
@@ -16,39 +15,53 @@ From `MODELS.md` for `arcee-ai/Arcee-Spark` n150 functional:
 - t/s/u: 13.9
 - Seq len: 29952
 
-## Optimization Goals
-- Decode uses traced execution.
-- TTFT strictly lower than functional baseline.
-- Decode throughput (t/s/u) strictly higher than functional baseline.
-- No capability regression: max sequence length >= 29952.
+## Final Results (n150 optimized)
+From `demo.log` + `eval.log`:
 
-## Kept Changes
-- Decode trace + persistent device buffers for token ids, positions, and RoPE cos/sin.
-- Prefill computes only last-token logits (`prefill_logits_last_device`).
-- Fuse Q/K/V projections into a single matmul.
-- Slice decode hidden-state down to 1 token before LM head to avoid a 32-lane padded LM head.
+- Top-1: 91%
+- Top-5: 100%
+- TTFT: 77ms
+- t/s/u: 14.5
+- Seq len: 29952
 
-## Rejected Changes
-- None yet.
+## Kept Optimizations
+- Decode uses traced execution with persistent device buffers (token ids, positions, RoPE cos/sin).
+- Prefill computes only last-token logits for TTFT.
+- Attention: fuse Q/K/V projection into a single matmul.
+- MLP: fuse gate+up projection into a single matmul + split.
+- Decode attention intermediates in L1 where supported (`nlp_create_qkv_heads_decode(..., memory_config=L1)` and `paged_scaled_dot_product_attention_decode(..., memory_config=L1)`).
+- LM head weights in `bfloat8_b` (big decode throughput win versus `bfloat16`).
+- Decode trace lifecycle cleanup: release trace on `reset()` so multiple sequences do not leak traces.
+
+## Rejected / Notes
+- `decode_pos_buffer` in L1: crashes with paged KV cache update; keep in DRAM.
+- Decode concat-heads output in L1: slight decode throughput regression; keep in DRAM.
+- `decode_token_buffer` in L1: large decode throughput regression when updated via `copy_host_to_device_tensor`; keep in DRAM.
 
 ## Commands
+Demo timing (max seq len 29952):
+
+```bash
+HF_HOME=/proj_sw/user_dev/moconnor/hf-cache \
+TT_METAL_CACHE=/tmp/tt-metal-cache \
+TT_METAL_INSPECTOR_LOG_PATH=/tmp/tt-metal-inspector \
+TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT=0 \
+PYTHONUNBUFFERED=1 \
+/proj_sw/user_dev/moconnor/tt-metal/python_env/bin/python -u demo.py \
+  models/arcee-ai/Arcee-Spark/n150/optimized/model.py \
+  --max_seq_len 29952 --seed 0 --device-id 0
+```
+
 Teacher-forcing eval (100 tokens):
 
+```bash
+HF_HOME=/proj_sw/user_dev/moconnor/hf-cache \
+TT_METAL_CACHE=/tmp/tt-metal-cache \
+TT_METAL_INSPECTOR_LOG_PATH=/tmp/tt-metal-inspector \
+TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT=0 \
+PYTHONUNBUFFERED=1 \
+/proj_sw/user_dev/moconnor/tt-metal/python_env/bin/python -u eval.py \
+  models/arcee-ai/Arcee-Spark/n150/optimized/model.py \
+  --model arcee-ai/Arcee-Spark --prompt_file prompts/bringup_eval_long.txt \
+  --max_new_tokens 100 --max_seq_len 29952 --seed 0 --device_id 0
 ```
-python eval.py models/arcee-ai/Arcee-Spark/n150/optimized/model.py --model arcee-ai/Arcee-Spark --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100
-```
-
-Demo timing:
-
-```
-python demo.py models/arcee-ai/Arcee-Spark/n150/optimized/model.py
-```
-
-Max sequence length validation (prefill only, 1-token decode):
-
-```
-python scripts/run_eval.py --mode tt --hf-model arcee-ai/Arcee-Spark --system n150 --prefill-len 128 --decode-len 1 --max-seq-len 29952
-```
-
-## Results
-TODO: Fill in final Top-1/Top-5/TTFT/t/s/u and confirm seq-len validation after runs.

--- a/models/arcee-ai/Arcee-Spark/n150/optimized/demo.log
+++ b/models/arcee-ai/Arcee-Spark/n150/optimized/demo.log
@@ -1,0 +1,69 @@
+COMMAND: HF_HOME=/proj_sw/user_dev/moconnor/hf-cache TT_METAL_CACHE=/tmp/tt-metal-cache TT_METAL_INSPECTOR_LOG_PATH=/tmp/tt-metal-inspector TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT=0 PYTHONUNBUFFERED=1 /proj_sw/user_dev/moconnor/tt-metal/python_env/bin/python -u demo.py models/arcee-ai/Arcee-Spark/n150/optimized/model.py --max_seq_len 29952 --seed 0 --device-id 0
+/proj_sw/user_dev/moconnor/tt-metal/python_env/lib/python3.10/site-packages/transformers/utils/hub.py:111: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
+  warnings.warn(
+2026-02-12 14:25:57.671 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
+Loading tokenizer: arcee-ai/Arcee-Spark
+Opening TT device...
+2026-02-12 14:25:58.455 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 14:25:58.456 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-12 14:25:58.459 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 14:25:58.477 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 14:25:58.477 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x40 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 14:25:58.559 | info     |             UMD | Opening local chip ids/PCIe ids: {0}/[3] and remote chip ids {} (cluster.cpp:186)
+2026-02-12 14:25:58.559 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-12 14:25:58.559 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-12 14:25:58.560 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-12 14:25:58.565 | info     |             UMD | Mapped hugepage 0x4c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 14:25:58.622 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.WORKER
+2026-02-12 14:25:58.622 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-12 14:25:58.622 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:863)
+2026-02-12 14:25:58.622 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:840)
+2026-02-12 14:25:58.623 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
+2026-02-12 14:25:58.623 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
+2026-02-12 14:25:58.638 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+Loading HuggingFace reference model on CPU: arcee-ai/Arcee-Spark
+Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]Loading checkpoint shards:  25%|██▌       | 1/4 [00:00<00:02,  1.36it/s]Loading checkpoint shards:  50%|█████     | 2/4 [00:01<00:01,  1.28it/s]Loading checkpoint shards:  75%|███████▌  | 3/4 [00:02<00:00,  1.22it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:02<00:00,  1.72it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:02<00:00,  1.52it/s]
+Building TT model...
+  Loading embeddings...
+  Computing RoPE cache...
+  Loading 28 layers...
+Running one warmup prefill+decode pass (kernel compile warmup)...
+2026-02-12 14:29:22.204 | warning  |    BuildKernels | Compute kernel 'tilize/15018517563973709478/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:29:22.292 | warning  |    BuildKernels | Compute kernel 'layernorm/4393001257389957809/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:29:22.380 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/8463634101324122582/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:29:22.479 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/15977828201954068243/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:29:22.555 | warning  |    BuildKernels | Compute kernel 'sdpa/16537920458028298373/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:29:22.648 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/7517597377572897993/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:29:22.740 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/1759249364934931830/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:29:22.917 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/8929485927259071040/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:29:22.979 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/13876807266639731151/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:29:23.024 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/18182733032816319527/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:29:23.074 | warning  |    BuildKernels | Compute kernel 'pack_untilize_wh/7086840538318172595/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:29:23.168 | warning  |    BuildKernels | Compute kernel 'tilize_wh/4709288304851342762/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:29:23.223 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/15236418414305256786/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:29:27.230 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/15247249197865754424/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:29:27.412 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/18025573480810144695/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:29:27.567 | warning  |    BuildKernels | Compute kernel 'update_cache/4072058481346503601/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:29:27.616 | warning  |    BuildKernels | Compute kernel 'sdpa_flash_decode/15297216664974153974/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:29:27.759 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/7255830942752183330/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:29:27.804 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/17688712872264743550/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:29:27.928 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/16753059734065165711/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:29:27.995 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/11991188472054853523/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:29:28.040 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/1065806234516852725/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+TT demo (n150)
+Model: arcee-ai/Arcee-Spark
+Mesh shape: 1x1
+Prompt tokens: 56 | Generated tokens: 128
+TTFT: 77 ms | Decode: 14.5 t/s/u (126 tokens)
+
+Prompt:
+Journal entry, 1957: Tonight a tiny sphere called Sputnik 1 crossed the sky, beeping like a metronome for a new era. The neighbors gathered on the roof, listening and arguing about what comes next. I wrote in my notebook that
+
+Output:
+ this event would change everything. We would no longer be the center of the universe.
+This essay was originally published in a collection of essays called The Other Side of The Moon: Reflections & Stories of Space & Exploration, edited by Michael Rurch and published by Ooligan Press. I’m including it here because the book is out of print, and I think it is a very good book.
+I was born in 1957. I was born at the very moment when Sputnik was launched. I was born into the space age, and now as an astronomer, I look back at my own birth and feel
+YT_METRICS={"mode": "tt_demo", "model": "arcee-ai/Arcee-Spark", "system": "n150", "mesh_shape": [1, 1], "prompt_tokens": 56, "generated_tokens": 128, "ttft_ms": 77.048409730196, "decode_tps_u": 14.501067597052916, "decode_tokens": 126, "max_seq_len": 29952}
+2026-02-12 14:29:39.760 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-12 14:29:39.760 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/arcee-ai/Arcee-Spark/n150/optimized/eval.log
+++ b/models/arcee-ai/Arcee-Spark/n150/optimized/eval.log
@@ -1,0 +1,64 @@
+COMMAND: HF_HOME=/proj_sw/user_dev/moconnor/hf-cache TT_METAL_CACHE=/tmp/tt-metal-cache TT_METAL_INSPECTOR_LOG_PATH=/tmp/tt-metal-inspector TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT=0 PYTHONUNBUFFERED=1 /proj_sw/user_dev/moconnor/tt-metal/python_env/bin/python -u eval.py models/arcee-ai/Arcee-Spark/n150/optimized/model.py --model arcee-ai/Arcee-Spark --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 29952 --seed 0 --device_id 0
+2026-02-12 14:30:59.514 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
+/proj_sw/user_dev/moconnor/tt-metal/python_env/lib/python3.10/site-packages/transformers/utils/hub.py:111: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
+  warnings.warn(
+Loading model module: /localdev/moconnor/ttnn_models_worktrees/opt_arcee-ai-Arcee-Spark-n150-optimized/models/arcee-ai/Arcee-Spark/n150/optimized/model.py
+Loading HuggingFace tokenizer...
+Loading HuggingFace reference model on CPU...
+Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]Loading checkpoint shards:  25%|██▌       | 1/4 [00:01<00:03,  1.09s/it]Loading checkpoint shards:  50%|█████     | 2/4 [00:01<00:01,  1.11it/s]Loading checkpoint shards:  75%|███████▌  | 3/4 [00:02<00:00,  1.28it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:02<00:00,  1.86it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:02<00:00,  1.50it/s]
+Generating reference tokens...
+The following generation flags are not valid and may be ignored: ['temperature', 'top_p', 'top_k']. Set `TRANSFORMERS_VERBOSITY=info` for more details.
+Opening device (1x1)...
+2026-02-12 14:34:55.270 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 14:34:55.271 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-12 14:34:55.274 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 14:34:55.295 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 14:34:55.295 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x40 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 14:34:55.391 | info     |             UMD | Opening local chip ids/PCIe ids: {0}/[3] and remote chip ids {} (cluster.cpp:186)
+2026-02-12 14:34:55.392 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-12 14:34:55.392 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-12 14:34:55.393 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-12 14:34:55.398 | info     |             UMD | Mapped hugepage 0x4c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 14:34:55.459 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.WORKER
+2026-02-12 14:34:55.460 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-12 14:34:55.460 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:863)
+2026-02-12 14:34:55.460 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:840)
+2026-02-12 14:34:55.460 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
+2026-02-12 14:34:55.460 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
+2026-02-12 14:34:55.475 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+Loading ttnn model...
+  Loading embeddings...
+  Computing RoPE cache...
+  Loading 28 layers...
+Running teacher-forcing eval (100 tokens)...
+2026-02-12 14:37:24.695 | warning  |    BuildKernels | Compute kernel 'tilize/15018517563973709478/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:37:24.786 | warning  |    BuildKernels | Compute kernel 'layernorm/4393001257389957809/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:37:24.871 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/2072014004267722064/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:37:24.972 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/7317598834983320959/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:37:24.973 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/3500961269753639563/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:37:25.022 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/15977828201954068243/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:37:25.095 | warning  |    BuildKernels | Compute kernel 'sdpa/4883444330574703025/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:37:25.190 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/18435879690229640355/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:37:25.285 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/8243071248602699647/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:37:25.473 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/7290002302945079702/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:37:25.532 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/14918747720061020527/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:37:25.589 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/1455963000299525494/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:37:25.640 | warning  |    BuildKernels | Compute kernel 'pack_untilize_wh/8237910100408685478/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:37:25.640 | warning  |    BuildKernels | Compute kernel 'pack_untilize_wh/3404247873314408370/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:37:25.730 | warning  |    BuildKernels | Compute kernel 'tilize_wh/4709288304851342762/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:37:25.810 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/15236418414305256786/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:37:25.899 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/15247249197865754424/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:37:26.049 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/18025573480810144695/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:37:26.200 | warning  |    BuildKernels | Compute kernel 'update_cache/4072058481346503601/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:37:26.250 | warning  |    BuildKernels | Compute kernel 'sdpa_flash_decode/15297216664974153974/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:37:26.379 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/7255830942752183330/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:37:26.428 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/17688712872264743550/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:37:26.543 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/16753059734065165711/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:37:26.609 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/11991188472054853523/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 14:37:26.654 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/1065806234516852725/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+Top-1 accuracy: 91.00% (0.9100)
+Top-5 accuracy: 100.00% (1.0000)
+YT_METRICS={"mode": "tt_eval", "model": "arcee-ai/Arcee-Spark", "top1": 0.91, "top5": 1.0, "top1_pct": 91.0, "top5_pct": 100.0, "total_tokens": 100, "max_new_tokens": 100, "max_seq_len": 29952}
+2026-02-12 14:37:35.923 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-12 14:37:35.923 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/arcee-ai/Arcee-Spark/n150/optimized/metrics.json
+++ b/models/arcee-ai/Arcee-Spark/n150/optimized/metrics.json
@@ -1,0 +1,26 @@
+{
+  "model": "arcee-ai/Arcee-Spark",
+  "hardware": "n150",
+  "variant": "optimized",
+  "functional_baseline": {
+    "top1_pct": 92.0,
+    "top5_pct": 100.0,
+    "ttft_ms": 99.0,
+    "decode_tps_u": 13.9,
+    "seq_len": 29952
+  },
+  "optimized_final": {
+    "top1_pct": 91.0,
+    "top5_pct": 100.0,
+    "ttft_ms": 77.048409730196,
+    "decode_tps_u": 14.501067597052916,
+    "seq_len": 29952
+  },
+  "acceptance": {
+    "top1_top5_pass": true,
+    "decode_trace_enabled": true,
+    "ttft_improved": true,
+    "decode_tps_improved": true,
+    "seq_len_non_regressed": true
+  }
+}

--- a/models/arcee-ai/Arcee-Spark/n150/optimized/model.py
+++ b/models/arcee-ai/Arcee-Spark/n150/optimized/model.py
@@ -32,7 +32,7 @@ WEIGHT_LAYOUT = ttnn.TILE_LAYOUT
 ATTN_WEIGHT_DTYPE = ttnn.bfloat16
 MLP_WEIGHT_DTYPE = ttnn.bfloat8_b
 EMBED_DTYPE = ttnn.bfloat16
-LM_HEAD_DTYPE = ttnn.bfloat16
+LM_HEAD_DTYPE = ttnn.bfloat8_b
 
 ATTN_KERNEL_CONFIG = ttnn.WormholeComputeKernelConfig(
     math_fidelity=ttnn.MathFidelity.HiFi4,
@@ -174,13 +174,17 @@ class Attention:
         self.sin_cache = sin_cache
 
         p = f"model.layers.{layer_idx}.self_attn."
-        self.q_proj = self._load_weight(state_dict[f"{p}q_proj.weight"])
-        self.k_proj = self._load_weight(state_dict[f"{p}k_proj.weight"])
-        self.v_proj = self._load_weight(state_dict[f"{p}v_proj.weight"])
+        self.qkv_proj = self._load_qkv_weight(
+            state_dict[f"{p}q_proj.weight"],
+            state_dict[f"{p}k_proj.weight"],
+            state_dict[f"{p}v_proj.weight"],
+        )
+        self.qkv_bias = self._load_qkv_bias(
+            state_dict[f"{p}q_proj.bias"],
+            state_dict[f"{p}k_proj.bias"],
+            state_dict[f"{p}v_proj.bias"],
+        )
         self.o_proj = self._load_weight(state_dict[f"{p}o_proj.weight"])
-        self.q_bias = self._load_bias(state_dict[f"{p}q_proj.bias"])
-        self.k_bias = self._load_bias(state_dict[f"{p}k_proj.bias"])
-        self.v_bias = self._load_bias(state_dict[f"{p}v_proj.bias"])
 
         cache_shape = (
             self.paged_attention_config.max_num_blocks,
@@ -213,9 +217,20 @@ class Attention:
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
 
-    def _load_bias(self, b: torch.Tensor) -> ttnn.Tensor:
+    def _load_qkv_weight(self, wq: torch.Tensor, wk: torch.Tensor, wv: torch.Tensor) -> ttnn.Tensor:
+        w_qkv = torch.cat([wq.T, wk.T, wv.T], dim=-1)
         return ttnn.as_tensor(
-            b.reshape(1, 1, 1, -1).to(torch.bfloat16).contiguous(),
+            w_qkv.unsqueeze(0).unsqueeze(0).to(torch.bfloat16).contiguous(),
+            dtype=ATTN_WEIGHT_DTYPE,
+            layout=WEIGHT_LAYOUT,
+            device=self.tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+    def _load_qkv_bias(self, bq: torch.Tensor, bk: torch.Tensor, bv: torch.Tensor) -> ttnn.Tensor:
+        b_qkv = torch.cat([bq, bk, bv], dim=-1)
+        return ttnn.as_tensor(
+            b_qkv.reshape(1, 1, 1, -1).to(torch.bfloat16).contiguous(),
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
             device=self.tt_device,
@@ -237,28 +252,13 @@ class Attention:
         padded_seq = pad_to_tile(seq_len)
 
         x = ttnn.to_dtype(x, dtype=ttnn.bfloat16)
-        q = ttnn.linear(
+        qkv = ttnn.linear(
             x,
-            self.q_proj,
-            bias=self.q_bias,
+            self.qkv_proj,
+            bias=self.qkv_bias,
             dtype=ttnn.bfloat16,
             compute_kernel_config=ATTN_KERNEL_CONFIG,
         )
-        k = ttnn.linear(
-            x,
-            self.k_proj,
-            bias=self.k_bias,
-            dtype=ttnn.bfloat16,
-            compute_kernel_config=ATTN_KERNEL_CONFIG,
-        )
-        v = ttnn.linear(
-            x,
-            self.v_proj,
-            bias=self.v_bias,
-            dtype=ttnn.bfloat16,
-            compute_kernel_config=ATTN_KERNEL_CONFIG,
-        )
-        qkv = ttnn.concat([q, k, v], dim=-1)
 
         if is_prefill:
             q, k, v = ttnn.experimental.nlp_create_qkv_heads(
@@ -295,7 +295,7 @@ class Attention:
                 qkv,
                 num_heads=self.n_heads,
                 num_kv_heads=self.n_kv_heads,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                memory_config=ttnn.L1_MEMORY_CONFIG,
             )
             if not trace_decode:
                 ttnn.deallocate(qkv)
@@ -342,6 +342,7 @@ class Attention:
                 page_table_tensor=self.page_table,
                 cur_pos_tensor=cur_pos_tensor,
                 scale=self.scale,
+                memory_config=ttnn.L1_MEMORY_CONFIG,
                 compute_kernel_config=ATTN_KERNEL_CONFIG,
             )
             attn_out = ttnn.transpose(attn_out, 1, 2)
@@ -369,9 +370,21 @@ class MLP:
     def __init__(self, layer_idx: int, state_dict: dict, tt_device, weight_dtype: ttnn.DataType):
         p = f"model.layers.{layer_idx}.mlp."
         self.weight_dtype = weight_dtype
-        self.gate_proj = self._load_weight(state_dict[f"{p}gate_proj.weight"], tt_device)
-        self.up_proj = self._load_weight(state_dict[f"{p}up_proj.weight"], tt_device)
+        gate_w = state_dict[f"{p}gate_proj.weight"]
+        up_w = state_dict[f"{p}up_proj.weight"]
+        self.intermediate_size = gate_w.shape[0]
+        self.gate_up_proj = self._load_gate_up_weight(gate_w, up_w, tt_device)
         self.down_proj = self._load_weight(state_dict[f"{p}down_proj.weight"], tt_device)
+
+    def _load_gate_up_weight(self, gate_w: torch.Tensor, up_w: torch.Tensor, tt_device) -> ttnn.Tensor:
+        w_gate_up = torch.cat([gate_w.T, up_w.T], dim=-1)
+        return ttnn.as_tensor(
+            w_gate_up.unsqueeze(0).unsqueeze(0).to(torch.bfloat16).contiguous(),
+            dtype=self.weight_dtype,
+            layout=WEIGHT_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
 
     def _load_weight(self, w: torch.Tensor, tt_device) -> ttnn.Tensor:
         return ttnn.as_tensor(
@@ -383,20 +396,14 @@ class MLP:
         )
 
     def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
-        gate = ttnn.silu(
-            ttnn.linear(
-                x,
-                self.gate_proj,
-                dtype=ttnn.bfloat16,
-                compute_kernel_config=ATTN_KERNEL_CONFIG,
-            )
-        )
-        up = ttnn.linear(
+        gate_up = ttnn.linear(
             x,
-            self.up_proj,
+            self.gate_up_proj,
             dtype=ttnn.bfloat16,
             compute_kernel_config=ATTN_KERNEL_CONFIG,
         )
+        gate, up = ttnn.split(gate_up, split_size=self.intermediate_size, dim=3)
+        gate = ttnn.silu(gate)
         return ttnn.linear(
             ttnn.mul(gate, up),
             self.down_proj,
@@ -528,7 +535,7 @@ class TtnnQwen2ForCausalLM(torch.nn.Module, GenerationMixin):
             dtype=ttnn.uint32,
             layout=ttnn.ROW_MAJOR_LAYOUT,
             device=tt_device,
-            memory_config=ttnn.L1_MEMORY_CONFIG,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
         self.decode_pos_buffer = ttnn.from_torch(
             torch.zeros((TILE_SIZE,), dtype=torch.int32),
@@ -599,9 +606,17 @@ class TtnnQwen2ForCausalLM(torch.nn.Module, GenerationMixin):
     def device(self) -> torch.device:
         return self._torch_dummy.device
 
+    def _release_decode_trace(self) -> None:
+        if self.decode_trace_id is None:
+            return
+        ttnn.release_trace(self.tt_device, self.decode_trace_id)
+        self.decode_trace_id = None
+        self.decode_trace_logits = None
+
     def reset(self):
         """Reset position counter for new sequence."""
         self._pos = 0
+        self._release_decode_trace()
 
     def prepare_inputs_for_generation(self, input_ids, past_key_values=None, **kwargs):
         if past_key_values is not None:


### PR DESCRIPTION
Optimized `models/arcee-ai/Arcee-Spark/n150/optimized` using `tasks/optimize_model.yaml`.

Results (n150, max_seq_len=29952):
- Top-1: 91%
- Top-5: 100%
- TTFT: 77ms (functional: 99ms)
- Decode: 14.5 t/s/u (functional: 13.9)

Key changes:
- Decode traced execution + persistent device input buffers
- Prefill last-token logits fast path for TTFT
- Fused QKV projection and fused MLP gate+up projection
- Decode attention intermediates in L1 where supported
- LM head weights quantized to `bfloat8_b` (major decode throughput win)

See `models/arcee-ai/Arcee-Spark/n150/optimized/demo.log` and `models/arcee-ai/Arcee-Spark/n150/optimized/eval.log` for exact commands and outputs.

Fixes #129
