### PR TITLE
mistralai/Mistral-7B-Instruct-v0.3 n300: add optimized path (trace decode)

### DIFF
--- a/models/mistralai/Mistral-7B-Instruct-v0.3/n300/optimized/MODEL_BRINGUP.md
+++ b/models/mistralai/Mistral-7B-Instruct-v0.3/n300/optimized/MODEL_BRINGUP.md
@@ -1,0 +1,70 @@
+# MODEL_BRINGUP.md - Mistral-7B-Instruct-v0.3 (n300 optimized)
+
+## Overview
+This is the optimized N300 path for `mistralai/Mistral-7B-Instruct-v0.3` using 1D tensor parallel.
+
+- Model code: `models/mistralai/Mistral-7B-Instruct-v0.3/n300/optimized/model.py`
+- Demo log: `models/mistralai/Mistral-7B-Instruct-v0.3/n300/optimized/demo.log`
+- Eval log: `models/mistralai/Mistral-7B-Instruct-v0.3/n300/optimized/eval.log`
+- Parallelism: 1x2 mesh, linear topology (N300)
+- Max seq len: `32768` (no capability regression target)
+- Decode path: traced execution (`ttnn.begin_trace_capture` / `ttnn.execute_trace`)
+
+## Baseline vs Final (same hardware)
+| Metric | Functional baseline | Optimized final |
+| --- | ---: | ---: |
+| Top-1 | 96% | TBD |
+| Top-5 | 100% | TBD |
+| TTFT | 112 ms | TBD |
+| t/s/u | 11.1 | TBD |
+| Seq len | 32768 | 32768 |
+
+Note: On this host, the N300 2-chip fabric link is not healthy, so the real 1x2 mesh cannot be opened.
+`demo.py` / `eval.py` fail during mesh discovery with `phys_deg_hist={0:2}` when using the standard
+`n300_mesh_graph_descriptor`. This must be rerun on a healthy N300 host to collect final metrics.
+
+## Commands used
+Demo:
+```bash
+env HF_HOME=/proj_sw/user_dev/moconnor/hf-cache \
+  TRANSFORMERS_CACHE=/proj_sw/user_dev/moconnor/hf-cache \
+  HF_HUB_CACHE=/proj_sw/user_dev/moconnor/hf-cache/hub \
+  TT_VISIBLE_DEVICES=5,6 \
+  TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto \
+  TT_METAL_CACHE=/tmp/tt-metal-cache \
+  TT_METAL_RUNTIME_ROOT=/proj_sw/user_dev/moconnor/tt-metal \
+  PYTHONUNBUFFERED=1 \
+  python -u demo.py models/mistralai/Mistral-7B-Instruct-v0.3/n300/optimized/model.py --max_seq_len 32768
+```
+
+Eval:
+```bash
+env HF_HOME=/proj_sw/user_dev/moconnor/hf-cache \
+  TRANSFORMERS_CACHE=/proj_sw/user_dev/moconnor/hf-cache \
+  HF_HUB_CACHE=/proj_sw/user_dev/moconnor/hf-cache/hub \
+  TT_VISIBLE_DEVICES=5,6 \
+  TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto \
+  TT_METAL_CACHE=/tmp/tt-metal-cache \
+  TT_METAL_RUNTIME_ROOT=/proj_sw/user_dev/moconnor/tt-metal \
+  PYTHONUNBUFFERED=1 \
+  python -u eval.py models/mistralai/Mistral-7B-Instruct-v0.3/n300/optimized/model.py \
+    --model mistralai/Mistral-7B-Instruct-v0.3 \
+    --prompt_file prompts/bringup_eval_long.txt \
+    --max_new_tokens 100 \
+    --max_seq_len 32768
+```
+
+## Kept optimizations
+1. Fused attention Q/K/V projection into a single matmul (`self.qkv_proj`) with per-device chunk ordering matching width sharding.
+2. `prefill_logits_last_device()` prefill fast path for demo/eval TTFT (compute and transfer only last-token logits).
+3. Decode trace with preallocated token/position/RoPE buffers and `ttnn.execute_trace` replay.
+4. Decode LM head runs on a sliced `[1, 1, 1, hidden]` activation (avoid padded-32 LM head work).
+
+## Mesh health check
+To validate whether this host can run a real N300 1x2 mesh, run:
+
+```bash
+/proj_sw/user_dev/moconnor/tt-metal/build_Release/tools/umd/system_health
+```
+
+If all "internal trace" ETH links report `DOWN/unconnected`, the host cannot run multi-chip N300 workloads.

--- a/models/mistralai/Mistral-7B-Instruct-v0.3/n300/optimized/demo.log
+++ b/models/mistralai/Mistral-7B-Instruct-v0.3/n300/optimized/demo.log
@@ -1,0 +1,88 @@
+env HF_HOME=/proj_sw/user_dev/moconnor/hf-cache TRANSFORMERS_CACHE=/proj_sw/user_dev/moconnor/hf-cache HF_HUB_CACHE=/proj_sw/user_dev/moconnor/hf-cache/hub TT_VISIBLE_DEVICES=5,6 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto TT_METAL_CACHE=/tmp/tt-metal-cache TT_METAL_RUNTIME_ROOT=/proj_sw/user_dev/moconnor/tt-metal PYTHONUNBUFFERED=1 python -u demo.py models/mistralai/Mistral-7B-Instruct-v0.3/n300/optimized/model.py --max_seq_len 32768
+/proj_sw/user_dev/moconnor/tt-metal/python_env/lib/python3.10/site-packages/transformers/utils/hub.py:111: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
+  warnings.warn(
+2026-02-12 17:24:12.807 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
+Loading tokenizer: mistralai/Mistral-7B-Instruct-v0.3
+Opening TT device...
+2026-02-12 17:24:13.853 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 17:24:13.855 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-12 17:24:13.862 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 17:24:13.898 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 17:24:13.899 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x20 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 17:24:13.988 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x80 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 17:24:14.006 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1}/[6, 5] and remote chip ids {} (cluster.cpp:186)
+2026-02-12 17:24:14.006 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-12 17:24:14.006 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-12 17:24:14.009 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-12 17:24:14.010 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 17:24:14.012 | info     |             UMD | Mapped hugepage 0x4140000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 17:24:14.109 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto (metal_context.cpp:858)
+2026-02-12 17:24:14.110 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=2, n_phys=2, log_deg_hist={1:2}, phys_deg_hist={0:2} (topology_mapper_utils.cpp:171)
+2026-02-12 17:24:14.110 | critical |          Always | TT_FATAL: The logical graph specified in the Mesh Graph Descriptor (MGD) could not fit in the discovered physical topology for mesh 0.
+The Mesh Graph Descriptor (MGD) file is located at: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto. 
+Could not find valid mapping for mesh 0 under the given constraints. Logical graph may not fit in the physical topology.
+Expected: The logical graph topology from the MGD.
+Found: The physical topology discovered from the system.
+Either relax pinnings in the MGD or modify the MGD to match the physical topology.
+To debug this issue, you can run with TT_METAL_LOGGER_LEVEL=debug to view the logical and physical adjacency graphs.
+If this is unexpected, run ./build/test/tt_metal/tt_fabric/test_system_health to check connectivity. (assert.hpp:104)
+Traceback (most recent call last):
+  File "/localdev/moconnor/ttnn_models/demo.py", line 506, in <module>
+    main()
+  File "/localdev/moconnor/ttnn_models/demo.py", line 482, in main
+    run_tt_demo(
+  File "/localdev/moconnor/ttnn_models/demo.py", line 393, in run_tt_demo
+    tt_device, is_mesh, fabric_config = open_tt_device(mesh_shape, device_id)
+  File "/localdev/moconnor/ttnn_models/device_utils.py", line 95, in open_tt_device
+    system_mesh_desc = ttnn._ttnn.multi_device.SystemMeshDescriptor()
+RuntimeError: TT_FATAL @ /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/topology_mapper.cpp:676: result.success
+info:
+The logical graph specified in the Mesh Graph Descriptor (MGD) could not fit in the discovered physical topology for mesh 0.
+The Mesh Graph Descriptor (MGD) file is located at: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto. 
+Could not find valid mapping for mesh 0 under the given constraints. Logical graph may not fit in the physical topology.
+Expected: The logical graph topology from the MGD.
+Found: The physical topology discovered from the system.
+Either relax pinnings in the MGD or modify the MGD to match the physical topology.
+To debug this issue, you can run with TT_METAL_LOGGER_LEVEL=debug to view the logical and physical adjacency graphs.
+If this is unexpected, run ./build/test/tt_metal/tt_fabric/test_system_health to check connectivity.
+backtrace:
+ --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x8af5fa) [0x78432a3b95fa]
+ --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(_ZN2tt9tt_fabric14TopologyMapper43populate_fabric_node_id_to_asic_id_mappingsEN4ttsl10StrongTypeIjNS0_9MeshIdTagEEERKSt3mapINS3_ImNS_8tt_metal9AsicIDTagEEESt6vectorIS9_SaIS9_EESt4lessIS9_ESaISt4pairIKS9_SC_EEERKS6_INS0_12FabricNodeIdESA_ISM_SaISM_EESD_ISM_ESaISF_IKSM_SO_EEERKS6_IS9_NS3_IjNS0_11HostRankTagEEESE_SaISF_ISG_SX_EEERKS6_ISM_SX_SP_SaISF_ISQ_SX_EEE+0xa52) [0x78432a3a5d62]
+ --- tt::tt_fabric::TopologyMapper::build_mapping()
+ --- tt::tt_fabric::TopologyMapper::TopologyMapper(tt::tt_fabric::MeshGraph const&, tt::tt_metal::PhysicalSystemDescriptor const&, tt::tt_fabric::LocalMeshBinding const&, std::vector<std::pair<std::pair<ttsl::StrongType<unsigned int, tt::tt_metal::TrayIDTag>, ttsl::StrongType<unsigned int, tt::tt_metal::ASICLocationTag> >, tt::tt_fabric::FabricNodeId>, std::allocator<std::pair<std::pair<ttsl::StrongType<unsigned int, tt::tt_metal::TrayIDTag>, ttsl::StrongType<unsigned int, tt::tt_metal::ASICLocationTag> >, tt::tt_fabric::FabricNodeId> > > const&)
+ --- tt::tt_fabric::ControlPlane::init_control_plane(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::optional<std::reference_wrapper<std::map<tt::tt_fabric::FabricNodeId, int, std::less<tt::tt_fabric::FabricNodeId>, std::allocator<std::pair<tt::tt_fabric::FabricNodeId const, int> > > const> >)
+ --- tt::tt_fabric::ControlPlane::ControlPlane(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
+ --- tt::tt_metal::MetalContext::construct_control_plane(std::filesystem::__cxx11::path const&)
+ --- tt::tt_metal::MetalContext::initialize_control_plane_impl()
+ --- tt::tt_metal::MetalContext::get_control_plane()
+ --- tt::tt_metal::distributed::SystemMesh::Impl::Impl()
+ --- tt::tt_metal::distributed::SystemMesh::SystemMesh()
+ --- tt::tt_metal::distributed::SystemMesh::instance()
+ --- /proj_sw/user_dev/moconnor/tt-metal/ttnn/ttnn/_ttnn.so(+0x5dcc18) [0x78432d279c18]
+ --- /proj_sw/user_dev/moconnor/tt-metal/ttnn/ttnn/_ttnn.so(+0x239431) [0x78432ced6431]
+ --- python(_PyObject_FastCallDictTstate+0x253) [0x602bb06af423]
+ --- python(+0x194474) [0x602bb06c3474]
+ --- python(_PyObject_MakeTpCall+0x1fc) [0x602bb06b005c]
+ --- python(_PyEval_EvalFrameDefault+0x60ae) [0x602bb06a9dfe]
+ --- python(_PyFunction_Vectorcall+0x7c) [0x602bb06ba02c]
+ --- python(_PyEval_EvalFrameDefault+0x6c0) [0x602bb06a4410]
+ --- python(_PyFunction_Vectorcall+0x7c) [0x602bb06ba02c]
+ --- python(_PyEval_EvalFrameDefault+0x6c0) [0x602bb06a4410]
+ --- python(_PyFunction_Vectorcall+0x7c) [0x602bb06ba02c]
+ --- python(_PyEval_EvalFrameDefault+0x6c0) [0x602bb06a4410]
+ --- python(+0x259a86) [0x602bb0788a86]
+ --- python(PyEval_EvalCode+0x86) [0x602bb0788956]
+ --- python(+0x280678) [0x602bb07af678]
+ --- python(+0x27accf) [0x602bb07a9ccf]
+ --- python(+0x280415) [0x602bb07af415]
+ --- python(_PyRun_SimpleFileObject+0x1a8) [0x602bb07ae958]
+ --- python(_PyRun_AnyFileObject+0x47) [0x602bb07ae637]
+ --- python(Py_RunMain+0x2be) [0x602bb07a29be]
+ --- python(Py_BytesMain+0x2d) [0x602bb077c99d]
+ --- /lib/x86_64-linux-gnu/libc.so.6(+0x29d90) [0x7843e403cd90]
+ --- /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x80) [0x7843e403ce40]
+ --- python(_start+0x25) [0x602bb077c895]
+
+2026-02-12 17:24:14.871 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-12 17:24:14.871 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/mistralai/Mistral-7B-Instruct-v0.3/n300/optimized/eval.log
+++ b/models/mistralai/Mistral-7B-Instruct-v0.3/n300/optimized/eval.log
@@ -1,0 +1,88 @@
+env HF_HOME=/proj_sw/user_dev/moconnor/hf-cache TRANSFORMERS_CACHE=/proj_sw/user_dev/moconnor/hf-cache HF_HUB_CACHE=/proj_sw/user_dev/moconnor/hf-cache/hub TT_VISIBLE_DEVICES=5,6 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto TT_METAL_CACHE=/tmp/tt-metal-cache TT_METAL_RUNTIME_ROOT=/proj_sw/user_dev/moconnor/tt-metal PYTHONUNBUFFERED=1 python -u eval.py models/mistralai/Mistral-7B-Instruct-v0.3/n300/optimized/model.py --model mistralai/Mistral-7B-Instruct-v0.3 --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 32768
+2026-02-12 17:24:36.763 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
+/proj_sw/user_dev/moconnor/tt-metal/python_env/lib/python3.10/site-packages/transformers/utils/hub.py:111: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
+  warnings.warn(
+Loading model module: /localdev/moconnor/ttnn_models/models/mistralai/Mistral-7B-Instruct-v0.3/n300/optimized/model.py
+Loading HuggingFace tokenizer...
+Loading HuggingFace reference model on CPU...
+Loading checkpoint shards:   0%|          | 0/3 [00:00<?, ?it/s]Loading checkpoint shards:  33%|███▎      | 1/3 [00:24<00:48, 24.34s/it]Loading checkpoint shards:  67%|██████▋   | 2/3 [00:49<00:24, 24.73s/it]Loading checkpoint shards: 100%|██████████| 3/3 [01:12<00:00, 24.14s/it]Loading checkpoint shards: 100%|██████████| 3/3 [01:12<00:00, 24.26s/it]
+Generating reference tokens...
+Opening device (1x2)...
+2026-02-12 17:29:06.795 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 17:29:06.796 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-12 17:29:06.804 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 17:29:06.843 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 17:29:06.844 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x20 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 17:29:06.936 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x80 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 17:29:06.951 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1}/[6, 5] and remote chip ids {} (cluster.cpp:186)
+2026-02-12 17:29:06.951 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-12 17:29:06.951 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-12 17:29:06.955 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-12 17:29:06.956 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 17:29:06.957 | info     |             UMD | Mapped hugepage 0x4140000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 17:29:07.057 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto (metal_context.cpp:858)
+2026-02-12 17:29:07.059 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=2, n_phys=2, log_deg_hist={1:2}, phys_deg_hist={0:2} (topology_mapper_utils.cpp:171)
+2026-02-12 17:29:07.059 | critical |          Always | TT_FATAL: The logical graph specified in the Mesh Graph Descriptor (MGD) could not fit in the discovered physical topology for mesh 0.
+The Mesh Graph Descriptor (MGD) file is located at: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto. 
+Could not find valid mapping for mesh 0 under the given constraints. Logical graph may not fit in the physical topology.
+Expected: The logical graph topology from the MGD.
+Found: The physical topology discovered from the system.
+Either relax pinnings in the MGD or modify the MGD to match the physical topology.
+To debug this issue, you can run with TT_METAL_LOGGER_LEVEL=debug to view the logical and physical adjacency graphs.
+If this is unexpected, run ./build/test/tt_metal/tt_fabric/test_system_health to check connectivity. (assert.hpp:104)
+Traceback (most recent call last):
+  File "/localdev/moconnor/ttnn_models/eval.py", line 227, in <module>
+    main()
+  File "/localdev/moconnor/ttnn_models/eval.py", line 179, in main
+    tt_device, is_mesh, fabric_config = open_tt_device(mesh_shape, args.device_id)
+  File "/localdev/moconnor/ttnn_models/device_utils.py", line 95, in open_tt_device
+    system_mesh_desc = ttnn._ttnn.multi_device.SystemMeshDescriptor()
+RuntimeError: TT_FATAL @ /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/topology_mapper.cpp:676: result.success
+info:
+The logical graph specified in the Mesh Graph Descriptor (MGD) could not fit in the discovered physical topology for mesh 0.
+The Mesh Graph Descriptor (MGD) file is located at: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto. 
+Could not find valid mapping for mesh 0 under the given constraints. Logical graph may not fit in the physical topology.
+Expected: The logical graph topology from the MGD.
+Found: The physical topology discovered from the system.
+Either relax pinnings in the MGD or modify the MGD to match the physical topology.
+To debug this issue, you can run with TT_METAL_LOGGER_LEVEL=debug to view the logical and physical adjacency graphs.
+If this is unexpected, run ./build/test/tt_metal/tt_fabric/test_system_health to check connectivity.
+backtrace:
+ --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(+0x8af5fa) [0x718699a595fa]
+ --- /proj_sw/user_dev/moconnor/tt-metal/build_Release/lib/libtt_metal.so(_ZN2tt9tt_fabric14TopologyMapper43populate_fabric_node_id_to_asic_id_mappingsEN4ttsl10StrongTypeIjNS0_9MeshIdTagEEERKSt3mapINS3_ImNS_8tt_metal9AsicIDTagEEESt6vectorIS9_SaIS9_EESt4lessIS9_ESaISt4pairIKS9_SC_EEERKS6_INS0_12FabricNodeIdESA_ISM_SaISM_EESD_ISM_ESaISF_IKSM_SO_EEERKS6_IS9_NS3_IjNS0_11HostRankTagEEESE_SaISF_ISG_SX_EEERKS6_ISM_SX_SP_SaISF_ISQ_SX_EEE+0xa52) [0x718699a45d62]
+ --- tt::tt_fabric::TopologyMapper::build_mapping()
+ --- tt::tt_fabric::TopologyMapper::TopologyMapper(tt::tt_fabric::MeshGraph const&, tt::tt_metal::PhysicalSystemDescriptor const&, tt::tt_fabric::LocalMeshBinding const&, std::vector<std::pair<std::pair<ttsl::StrongType<unsigned int, tt::tt_metal::TrayIDTag>, ttsl::StrongType<unsigned int, tt::tt_metal::ASICLocationTag> >, tt::tt_fabric::FabricNodeId>, std::allocator<std::pair<std::pair<ttsl::StrongType<unsigned int, tt::tt_metal::TrayIDTag>, ttsl::StrongType<unsigned int, tt::tt_metal::ASICLocationTag> >, tt::tt_fabric::FabricNodeId> > > const&)
+ --- tt::tt_fabric::ControlPlane::init_control_plane(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::optional<std::reference_wrapper<std::map<tt::tt_fabric::FabricNodeId, int, std::less<tt::tt_fabric::FabricNodeId>, std::allocator<std::pair<tt::tt_fabric::FabricNodeId const, int> > > const> >)
+ --- tt::tt_fabric::ControlPlane::ControlPlane(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
+ --- tt::tt_metal::MetalContext::construct_control_plane(std::filesystem::__cxx11::path const&)
+ --- tt::tt_metal::MetalContext::initialize_control_plane_impl()
+ --- tt::tt_metal::MetalContext::get_control_plane()
+ --- tt::tt_metal::distributed::SystemMesh::Impl::Impl()
+ --- tt::tt_metal::distributed::SystemMesh::SystemMesh()
+ --- tt::tt_metal::distributed::SystemMesh::instance()
+ --- /proj_sw/user_dev/moconnor/tt-metal/ttnn/ttnn/_ttnn.so(+0x5dcc18) [0x71869c919c18]
+ --- /proj_sw/user_dev/moconnor/tt-metal/ttnn/ttnn/_ttnn.so(+0x239431) [0x71869c576431]
+ --- python(_PyObject_FastCallDictTstate+0x253) [0x573dc8896423]
+ --- python(+0x194474) [0x573dc88aa474]
+ --- python(_PyObject_MakeTpCall+0x1fc) [0x573dc889705c]
+ --- python(_PyEval_EvalFrameDefault+0x60ae) [0x573dc8890dfe]
+ --- python(_PyFunction_Vectorcall+0x7c) [0x573dc88a102c]
+ --- python(_PyEval_EvalFrameDefault+0x6c0) [0x573dc888b410]
+ --- python(_PyFunction_Vectorcall+0x7c) [0x573dc88a102c]
+ --- python(_PyEval_EvalFrameDefault+0x6c0) [0x573dc888b410]
+ --- python(+0x259a86) [0x573dc896fa86]
+ --- python(PyEval_EvalCode+0x86) [0x573dc896f956]
+ --- python(+0x280678) [0x573dc8996678]
+ --- python(+0x27accf) [0x573dc8990ccf]
+ --- python(+0x280415) [0x573dc8996415]
+ --- python(_PyRun_SimpleFileObject+0x1a8) [0x573dc8995958]
+ --- python(_PyRun_AnyFileObject+0x47) [0x573dc8995637]
+ --- python(Py_RunMain+0x2be) [0x573dc89899be]
+ --- python(Py_BytesMain+0x2d) [0x573dc896399d]
+ --- /lib/x86_64-linux-gnu/libc.so.6(+0x29d90) [0x7186f9fd5d90]
+ --- /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x80) [0x7186f9fd5e40]
+ --- python(_start+0x25) [0x573dc8963895]
+
+2026-02-12 17:29:11.708 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-12 17:29:11.708 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/mistralai/Mistral-7B-Instruct-v0.3/n300/optimized/model.py
+++ b/models/mistralai/Mistral-7B-Instruct-v0.3/n300/optimized/model.py
@@ -1,0 +1,842 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Optimized Mistral 7B Instruct v0.3 implementation in ttnn for N300.
+
+This version uses 1D tensor parallel across a 1x2 mesh:
+- QKV, gate, and up projections are column-parallel (width sharded).
+- Output and down projections are row-parallel (height sharded) followed by all-reduce.
+
+Key optimizations versus functional:
+- Fused Q/K/V projection into a single matmul (`self.qkv_proj`)
+- `prefill_logits_last_device()` fast path for demo/eval TTFT (compute + transfer last-token logits only)
+- Traced decode execution with preallocated token/position/RoPE buffers
+- Decode LM head runs on a sliced `[1, 1, 1, hidden]` activation (avoid padded-32 LM head work)
+
+This file defines the ttnn model only. Use `eval.py` at repo root for
+teacher-forcing accuracy checks against the HuggingFace reference.
+"""
+
+import math
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import ttnn
+from transformers import GenerationConfig
+from transformers.generation.utils import GenerationMixin
+from transformers.modeling_outputs import CausalLMOutputWithPast
+
+
+TILE_SIZE = 32
+MESH_SHAPE = (1, 2)
+MESH_TOPOLOGY = ttnn.Topology.Linear
+MESH_NUM_LINKS = 1
+PAGED_BLOCK_SIZE = 64
+WEIGHT_DTYPE = ttnn.bfloat8_b
+WEIGHT_LAYOUT = ttnn.TILE_LAYOUT
+USE_DECODE_TRACE = os.environ.get("TTNN_USE_DECODE_TRACE", "1").lower() not in ("0", "false", "no", "off")
+
+
+def pad_to_tile(x: int) -> int:
+    """Pad to tile boundary (32)."""
+    return ((x + TILE_SIZE - 1) // TILE_SIZE) * TILE_SIZE
+
+
+def mesh_shape_to_axis(mesh_shape: tuple[int, int]) -> int:
+    """Return the mesh axis used for 1D tensor parallel."""
+    if mesh_shape[0] == 1 and mesh_shape[1] > 1:
+        return 1
+    if mesh_shape[1] == 1 and mesh_shape[0] > 1:
+        return 0
+    raise ValueError(f"Expected 1D mesh shape for N300, got {mesh_shape}")
+
+
+def num_mesh_devices(mesh_shape: tuple[int, int]) -> int:
+    return mesh_shape[0] * mesh_shape[1]
+
+
+@dataclass
+class ModelConfig:
+    """Model configuration extracted from HuggingFace."""
+
+    vocab_size: int
+    hidden_size: int
+    intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    rms_norm_eps: float
+    rope_theta: float
+    rope_scaling: Optional[dict]
+    hidden_act: str
+    tie_word_embeddings: bool
+
+    @classmethod
+    def from_hf(cls, hf_config) -> "ModelConfig":
+        num_kv_heads = getattr(hf_config, "num_key_value_heads", hf_config.num_attention_heads)
+        head_dim = getattr(hf_config, "head_dim", None)
+        if head_dim is None:
+            head_dim = hf_config.hidden_size // hf_config.num_attention_heads
+        return cls(
+            hf_config.vocab_size,
+            hf_config.hidden_size,
+            hf_config.intermediate_size,
+            hf_config.num_hidden_layers,
+            hf_config.num_attention_heads,
+            num_kv_heads,
+            head_dim,
+            hf_config.rms_norm_eps,
+            hf_config.rope_theta,
+            getattr(hf_config, "rope_scaling", None),
+            hf_config.hidden_act,
+            hf_config.tie_word_embeddings,
+        )
+
+
+@dataclass
+class ParallelConfig:
+    mesh_device: ttnn.MeshDevice
+    mesh_shape: tuple[int, int]
+    num_devices: int
+    mesh_axis: int
+    num_links: int
+    topology: ttnn.Topology
+    replicate_mapper: object
+    shard_width_mapper: object
+    shard_height_mapper: object
+    shard_kv_mapper: object
+    vocab_composer: object
+
+
+@dataclass
+class PagedAttentionConfig:
+    """Paged KV cache configuration."""
+
+    block_size: int
+    max_num_blocks: int
+
+
+def validate_parallel_config(config: ModelConfig, num_devices: int) -> None:
+    if num_devices < 2:
+        raise ValueError("N300 model expects a 2-device mesh")
+    if config.num_attention_heads % num_devices != 0:
+        raise ValueError("num_attention_heads must divide evenly across devices")
+    if config.num_key_value_heads % num_devices != 0:
+        raise ValueError("num_key_value_heads must divide evenly across devices")
+    if config.hidden_size % num_devices != 0:
+        raise ValueError("hidden_size must divide evenly across devices")
+    if config.intermediate_size % num_devices != 0:
+        raise ValueError("intermediate_size must divide evenly across devices")
+
+
+def all_reduce_tensor(x: ttnn.Tensor, parallel: ParallelConfig) -> ttnn.Tensor:
+    if parallel.num_devices == 1:
+        return x
+    return ttnn.all_reduce(
+        x,
+        cluster_axis=parallel.mesh_axis,
+        num_links=parallel.num_links,
+        topology=parallel.topology,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+def compute_rope_cache(config: ModelConfig, max_seq_len: int) -> tuple:
+    """
+    Precompute RoPE cos/sin cache in HuggingFace format.
+    Returns cos, sin tensors of shape [1, 1, max_seq_len, head_dim].
+    """
+    if config.rope_scaling:
+        rope_type = config.rope_scaling.get("rope_type", config.rope_scaling.get("type"))
+        raise ValueError(f"rope_scaling {rope_type} is not supported in this bringup")
+
+    head_dim = config.head_dim
+    inv_freq = 1.0 / (config.rope_theta ** (torch.arange(0, head_dim, 2).float() / head_dim))
+    t = torch.arange(max_seq_len, dtype=inv_freq.dtype)
+    freqs = torch.outer(t, inv_freq)
+    emb = torch.cat((freqs, freqs), dim=-1)
+    cos = emb.cos().unsqueeze(0).unsqueeze(0).to(torch.bfloat16)
+    sin = emb.sin().unsqueeze(0).unsqueeze(0).to(torch.bfloat16)
+    return cos, sin
+
+
+def resolve_max_seq_len(hf_config, max_seq_len: Optional[int]) -> int:
+    """Resolve max sequence length from HF config when not provided."""
+    config_max = getattr(hf_config, "max_position_embeddings", None)
+    if max_seq_len is None:
+        if config_max is None:
+            raise ValueError("max_seq_len is required when config has no max_position_embeddings")
+        return config_max
+    if config_max is not None and max_seq_len > config_max:
+        raise ValueError(f"max_seq_len {max_seq_len} exceeds config max {config_max}")
+    return max_seq_len
+
+
+class RMSNorm:
+    """RMSNorm layer."""
+
+    def __init__(self, weight: torch.Tensor, eps: float, parallel: ParallelConfig):
+        self.eps = eps
+        self.weight = ttnn.as_tensor(
+            weight.unsqueeze(0).unsqueeze(0).unsqueeze(0).to(torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=parallel.replicate_mapper,
+        )
+
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        return ttnn.rms_norm(x, epsilon=self.eps, weight=self.weight)
+
+
+class Attention:
+    """
+    Multi-head attention with GQA support, 1D tensor parallel.
+
+    QKV projections are column-parallel. Output projection is row-parallel with
+    an all-reduce to replicate the result.
+    """
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        layer_idx: int,
+        state_dict: dict,
+        cos_cache: ttnn.Tensor,
+        sin_cache: ttnn.Tensor,
+        parallel: ParallelConfig,
+        paged_attention_config: PagedAttentionConfig,
+        page_table: ttnn.Tensor,
+    ):
+        self.parallel = parallel
+        self.n_heads = config.num_attention_heads
+        self.n_kv_heads = config.num_key_value_heads
+        self.n_local_heads = self.n_heads // parallel.num_devices
+        self.n_local_kv_heads = self.n_kv_heads // parallel.num_devices
+        self.head_dim = config.head_dim
+        self.hidden_size = config.hidden_size
+        self.scale = 1.0 / math.sqrt(self.head_dim)
+
+        self.cos_cache = cos_cache
+        self.sin_cache = sin_cache
+        self.paged_attention_config = paged_attention_config
+        self.page_table = page_table
+
+        p = f"model.layers.{layer_idx}.self_attn."
+        self.qkv_proj = self._load_qkv_weight(
+            state_dict[f"{p}q_proj.weight"],
+            state_dict[f"{p}k_proj.weight"],
+            state_dict[f"{p}v_proj.weight"],
+            parallel.shard_width_mapper,
+        )
+        self.o_proj = self._load_weight(state_dict[f"{p}o_proj.weight"], parallel.shard_height_mapper)
+
+        cache_shape = (
+            self.paged_attention_config.max_num_blocks,
+            self.n_kv_heads,
+            self.paged_attention_config.block_size,
+            self.head_dim,
+        )
+        self.k_cache = ttnn.as_tensor(
+            torch.zeros(cache_shape, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=parallel.shard_kv_mapper,
+        )
+        self.v_cache = ttnn.as_tensor(
+            torch.zeros(cache_shape, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=parallel.shard_kv_mapper,
+        )
+
+    def _load_weight(self, w: torch.Tensor, mesh_mapper) -> ttnn.Tensor:
+        """Load weight transposed for ttnn.linear: [out, in] -> [1, 1, in, out]."""
+        return ttnn.as_tensor(
+            w.T.unsqueeze(0).unsqueeze(0).to(torch.bfloat16).contiguous(),
+            dtype=WEIGHT_DTYPE,
+            layout=WEIGHT_LAYOUT,
+            device=self.parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=mesh_mapper,
+        )
+
+    def _load_qkv_weight(
+        self, q_weight: torch.Tensor, k_weight: torch.Tensor, v_weight: torch.Tensor, mesh_mapper
+    ) -> ttnn.Tensor:
+        q_chunks = torch.chunk(q_weight, self.parallel.num_devices, dim=0)
+        k_chunks = torch.chunk(k_weight, self.parallel.num_devices, dim=0)
+        v_chunks = torch.chunk(v_weight, self.parallel.num_devices, dim=0)
+        qkv_weight = torch.cat(
+            [torch.cat((q_chunks[i], k_chunks[i], v_chunks[i]), dim=0) for i in range(self.parallel.num_devices)],
+            dim=0,
+        )
+        return self._load_weight(qkv_weight, mesh_mapper)
+
+    def __call__(
+        self,
+        x: ttnn.Tensor,
+        start_pos: int,
+        seq_len: int,
+        cur_pos_tensor: Optional[ttnn.Tensor] = None,
+        decode_cos: Optional[ttnn.Tensor] = None,
+        decode_sin: Optional[ttnn.Tensor] = None,
+        trace_decode: bool = False,
+    ) -> ttnn.Tensor:
+        """Forward pass for prefill (seq_len > 1) or decode (seq_len == 1)."""
+        is_prefill = seq_len > 1
+        padded_seq = pad_to_tile(seq_len)
+
+        qkv = ttnn.linear(x, self.qkv_proj)
+
+        num_heads = self.n_local_heads
+        num_kv_heads = self.n_local_kv_heads
+
+        if is_prefill:
+            q, k, v = ttnn.experimental.nlp_create_qkv_heads(
+                qkv,
+                num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
+                transpose_k_heads=False,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            ttnn.deallocate(qkv)
+
+            cos = self.cos_cache[:, :, :padded_seq, :]
+            sin = self.sin_cache[:, :, :padded_seq, :]
+            q = ttnn.experimental.rotary_embedding(q, cos, sin)
+            k = ttnn.experimental.rotary_embedding(k, cos, sin)
+
+            ttnn.experimental.paged_fill_cache(self.k_cache, k, self.page_table, batch_idx=0)
+            ttnn.experimental.paged_fill_cache(self.v_cache, v, self.page_table, batch_idx=0)
+
+            attn_out = ttnn.transformer.scaled_dot_product_attention(
+                q, k, v, is_causal=True, scale=self.scale
+            )
+            attn_out = ttnn.experimental.nlp_concat_heads(attn_out, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        else:
+            if cur_pos_tensor is None:
+                raise ValueError("cur_pos_tensor is required for decode")
+
+            q, k, v = ttnn.experimental.nlp_create_qkv_heads_decode(
+                qkv,
+                num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            if not trace_decode:
+                ttnn.deallocate(qkv)
+
+            rope_cos = self.cos_cache
+            rope_sin = self.sin_cache
+            rope_pos = start_pos
+            if decode_cos is not None and decode_sin is not None:
+                rope_cos = decode_cos
+                rope_sin = decode_sin
+                rope_pos = 0
+
+            q_batch = q.shape[1]
+            q_heads = q.shape[2]
+            q_bh = q_batch * q_heads
+            q_bh_padded = pad_to_tile(q_bh)
+            q = ttnn.reshape(q, (1, 1, q_bh, self.head_dim), (1, 1, q_bh_padded, self.head_dim))
+            q = ttnn.experimental.rotary_embedding(q, rope_cos, rope_sin, rope_pos)
+            q = ttnn.reshape(q, (1, q_batch, q_heads, self.head_dim), (1, q_batch, q_heads, self.head_dim))
+
+            k_batch = k.shape[1]
+            k_heads = k.shape[2]
+            k_bh = k_batch * k_heads
+            k_bh_padded = pad_to_tile(k_bh)
+            k = ttnn.reshape(k, (1, 1, k_bh, self.head_dim), (1, 1, k_bh_padded, self.head_dim))
+            k = ttnn.experimental.rotary_embedding(k, rope_cos, rope_sin, rope_pos)
+            k = ttnn.reshape(k, (1, k_batch, k_heads, self.head_dim), (1, k_batch, k_heads, self.head_dim))
+
+            ttnn.experimental.paged_update_cache(
+                self.k_cache,
+                k,
+                update_idxs_tensor=cur_pos_tensor,
+                page_table=self.page_table,
+            )
+            ttnn.experimental.paged_update_cache(
+                self.v_cache,
+                v,
+                update_idxs_tensor=cur_pos_tensor,
+                page_table=self.page_table,
+            )
+
+            attn_out = ttnn.transformer.paged_scaled_dot_product_attention_decode(
+                q,
+                self.k_cache,
+                self.v_cache,
+                page_table_tensor=self.page_table,
+                cur_pos_tensor=cur_pos_tensor,
+                scale=self.scale,
+            )
+            attn_out = ttnn.transpose(attn_out, 1, 2)
+            attn_out = ttnn.experimental.nlp_concat_heads(attn_out, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+        expected_width = num_heads * self.head_dim
+        if attn_out.shape[-1] != expected_width:
+            attn_out = ttnn.slice(
+                attn_out,
+                (0, 0, 0, 0),
+                (attn_out.shape[0], attn_out.shape[1], attn_out.shape[2], expected_width),
+            )
+
+        out = ttnn.linear(attn_out, self.o_proj)
+        return all_reduce_tensor(out, self.parallel)
+
+
+class MLP:
+    """SwiGLU MLP, 1D tensor parallel."""
+
+    def __init__(self, layer_idx: int, state_dict: dict, parallel: ParallelConfig):
+        p = f"model.layers.{layer_idx}.mlp."
+        self.parallel = parallel
+        self.gate_proj = self._load_weight(state_dict[f"{p}gate_proj.weight"], parallel.shard_width_mapper)
+        self.up_proj = self._load_weight(state_dict[f"{p}up_proj.weight"], parallel.shard_width_mapper)
+        self.down_proj = self._load_weight(state_dict[f"{p}down_proj.weight"], parallel.shard_height_mapper)
+
+    def _load_weight(self, w: torch.Tensor, mesh_mapper) -> ttnn.Tensor:
+        return ttnn.as_tensor(
+            w.T.unsqueeze(0).unsqueeze(0).to(torch.bfloat16).contiguous(),
+            dtype=WEIGHT_DTYPE,
+            layout=WEIGHT_LAYOUT,
+            device=self.parallel.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=mesh_mapper,
+        )
+
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        gate = ttnn.silu(ttnn.linear(x, self.gate_proj))
+        up = ttnn.linear(x, self.up_proj)
+        out = ttnn.linear(ttnn.mul(gate, up), self.down_proj)
+        return all_reduce_tensor(out, self.parallel)
+
+
+class DecoderLayer:
+    """Single transformer layer."""
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        layer_idx: int,
+        state_dict: dict,
+        cos_cache: ttnn.Tensor,
+        sin_cache: ttnn.Tensor,
+        parallel: ParallelConfig,
+        paged_attention_config: PagedAttentionConfig,
+        page_table: ttnn.Tensor,
+    ):
+        p = f"model.layers.{layer_idx}."
+        self.attn_norm = RMSNorm(state_dict[f"{p}input_layernorm.weight"], config.rms_norm_eps, parallel)
+        self.ffn_norm = RMSNorm(state_dict[f"{p}post_attention_layernorm.weight"], config.rms_norm_eps, parallel)
+        self.attn = Attention(
+            config,
+            layer_idx,
+            state_dict,
+            cos_cache,
+            sin_cache,
+            parallel,
+            paged_attention_config,
+            page_table,
+        )
+        self.mlp = MLP(layer_idx, state_dict, parallel)
+
+    def __call__(
+        self,
+        x: ttnn.Tensor,
+        start_pos: int,
+        seq_len: int,
+        cur_pos_tensor: Optional[ttnn.Tensor] = None,
+        decode_cos: Optional[ttnn.Tensor] = None,
+        decode_sin: Optional[ttnn.Tensor] = None,
+        trace_decode: bool = False,
+    ) -> ttnn.Tensor:
+        x = ttnn.add(
+            x,
+            self.attn(self.attn_norm(x), start_pos, seq_len, cur_pos_tensor, decode_cos, decode_sin, trace_decode),
+        )
+        x = ttnn.add(x, self.mlp(self.ffn_norm(x)))
+        return x
+
+
+class TtnnMistralForCausalLM(torch.nn.Module, GenerationMixin):
+    """
+    Mistral model with 100% ttnn execution and 1D tensor parallel on N300.
+    HuggingFace `generate()`-compatible via `GenerationMixin`.
+    """
+
+    def __init__(self, hf_model, tt_device, max_seq_len: Optional[int] = None):
+        super().__init__()
+
+        self.tt_device = tt_device
+        self.hf_config = hf_model.config
+        self.tt_config = ModelConfig.from_hf(hf_model.config)
+        self.max_seq_len = resolve_max_seq_len(self.hf_config, max_seq_len)
+        self._pos = 0
+        self.paged_attention_config = PagedAttentionConfig(
+            PAGED_BLOCK_SIZE,
+            math.ceil(self.max_seq_len / PAGED_BLOCK_SIZE),
+        )
+
+        if self.tt_config.hidden_act != "silu":
+            raise ValueError(f"hidden_act {self.tt_config.hidden_act} is not supported in this bringup")
+
+        self.config = self.hf_config
+        self.generation_config = GenerationConfig.from_model_config(self.config)
+        if self.generation_config.pad_token_id is None:
+            self.generation_config.pad_token_id = self.generation_config.eos_token_id
+        self._supports_cache_class = False
+        self.main_input_name = "input_ids"
+        self.register_buffer("_torch_dummy", torch.empty(0, dtype=torch.float32), persistent=False)
+
+        mesh_shape = tuple(tt_device.shape)
+        num_devices = num_mesh_devices(mesh_shape)
+        mesh_axis = mesh_shape_to_axis(mesh_shape)
+        validate_parallel_config(self.tt_config, num_devices)
+
+        self.parallel = ParallelConfig(
+            mesh_device=tt_device,
+            mesh_shape=mesh_shape,
+            num_devices=num_devices,
+            mesh_axis=mesh_axis,
+            num_links=MESH_NUM_LINKS,
+            topology=MESH_TOPOLOGY,
+            replicate_mapper=ttnn.ReplicateTensorToMesh(tt_device),
+            shard_width_mapper=ttnn.ShardTensorToMesh(tt_device, dim=3),
+            shard_height_mapper=ttnn.ShardTensorToMesh(tt_device, dim=2),
+            shard_kv_mapper=ttnn.ShardTensorToMesh(tt_device, dim=1),
+            vocab_composer=ttnn.ConcatMeshToTensor(tt_device, dim=3),
+        )
+
+        state_dict = hf_model.state_dict()
+
+        print("  Loading embeddings...")
+        self.embed = ttnn.as_tensor(
+            state_dict["model.embed_tokens.weight"].unsqueeze(0).unsqueeze(0).to(torch.bfloat16),
+            dtype=WEIGHT_DTYPE,
+            layout=WEIGHT_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+
+        print("  Computing RoPE cache...")
+        cos, sin = compute_rope_cache(self.tt_config, self.max_seq_len)
+        self.cos_cache_host = cos
+        self.sin_cache_host = sin
+        self.cos_cache = ttnn.as_tensor(
+            cos,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.sin_cache = ttnn.as_tensor(
+            sin,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+
+        self.decode_token_buffer = ttnn.from_torch(
+            torch.zeros((1, 1, 1, TILE_SIZE), dtype=torch.int32),
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.decode_pos_buffer = ttnn.from_torch(
+            torch.zeros((TILE_SIZE,), dtype=torch.int32),
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.decode_cos_buffer = ttnn.from_torch(
+            torch.zeros((1, 1, 1, self.tt_config.head_dim), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.decode_sin_buffer = ttnn.from_torch(
+            torch.zeros((1, 1, 1, self.tt_config.head_dim), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        self.use_decode_trace = USE_DECODE_TRACE
+        self.decode_trace_id = None
+        self.decode_trace_logits = None
+
+        page_table = torch.arange(self.paged_attention_config.max_num_blocks, dtype=torch.int32)
+        page_table = page_table.repeat(TILE_SIZE, 1)
+        self.page_table = ttnn.as_tensor(
+            page_table,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+
+        print(f"  Loading {self.tt_config.num_hidden_layers} layers...")
+        self.layers = [
+            DecoderLayer(
+                self.tt_config,
+                i,
+                state_dict,
+                self.cos_cache,
+                self.sin_cache,
+                self.parallel,
+                self.paged_attention_config,
+                self.page_table,
+            )
+            for i in range(self.tt_config.num_hidden_layers)
+        ]
+
+        self.norm = RMSNorm(state_dict["model.norm.weight"], self.tt_config.rms_norm_eps, self.parallel)
+        lm_head_weight = state_dict.get("lm_head.weight", state_dict["model.embed_tokens.weight"])
+        self.lm_head = ttnn.as_tensor(
+            lm_head_weight.T.unsqueeze(0).unsqueeze(0).to(torch.bfloat16).contiguous(),
+            dtype=WEIGHT_DTYPE,
+            layout=WEIGHT_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=self.parallel.shard_width_mapper,
+        )
+
+        self._tt_past_key_values = object()
+
+    @property
+    def device(self) -> torch.device:
+        return self._torch_dummy.device
+
+    def reset(self):
+        """Reset position counter for new sequence."""
+        self._pos = 0
+        if self.decode_trace_id is not None:
+            ttnn.release_trace(self.tt_device, self.decode_trace_id)
+            self.decode_trace_id = None
+            self.decode_trace_logits = None
+
+    def prepare_inputs_for_generation(self, input_ids, past_key_values=None, **kwargs):
+        if past_key_values is not None:
+            input_ids = input_ids[:, -1:]
+        return {"input_ids": input_ids, "past_key_values": past_key_values, "use_cache": True}
+
+    def _reorder_cache(self, past_key_values, beam_idx):
+        return past_key_values
+
+    def _update_decode_token_buffer(self, input_ids: torch.Tensor) -> None:
+        token_ids = torch.zeros((TILE_SIZE,), dtype=torch.int32)
+        token_ids[: input_ids.numel()] = input_ids.view(-1).to(torch.int32)
+        token_ids = token_ids.reshape(1, 1, 1, -1)
+        host_tokens = ttnn.from_torch(
+            token_ids,
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        ttnn.copy_host_to_device_tensor(host_tokens, self.decode_token_buffer)
+
+    def _update_decode_pos_buffer(self, start_pos: int) -> None:
+        pos = torch.full((TILE_SIZE,), -1, dtype=torch.int32)
+        pos[0] = start_pos
+        host_pos = ttnn.from_torch(
+            pos,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        ttnn.copy_host_to_device_tensor(host_pos, self.decode_pos_buffer)
+
+    def _update_decode_rope_buffers(self, start_pos: int) -> None:
+        cos_slice = self.cos_cache_host[:, :, start_pos : start_pos + 1, :]
+        sin_slice = self.sin_cache_host[:, :, start_pos : start_pos + 1, :]
+        host_cos = ttnn.from_torch(
+            cos_slice,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+        )
+        host_sin = ttnn.from_torch(
+            sin_slice,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+        )
+        ttnn.copy_host_to_device_tensor(host_cos, self.decode_cos_buffer)
+        ttnn.copy_host_to_device_tensor(host_sin, self.decode_sin_buffer)
+
+    def _forward_prefill_last_logits(self, input_ids: torch.Tensor, start_pos: int, seq_len: int) -> ttnn.Tensor:
+        tokens = ttnn.from_torch(
+            input_ids.reshape(1, 1, 1, -1),
+            dtype=ttnn.uint32,
+            device=self.tt_device,
+            mesh_mapper=self.parallel.replicate_mapper,
+        )
+        h = ttnn.embedding(tokens, self.embed, layout=ttnn.TILE_LAYOUT)
+        for layer in self.layers:
+            h = layer(h, start_pos, seq_len)
+        h = self.norm(h)
+
+        token_idx = seq_len - 1
+        h_last = ttnn.slice(
+            h,
+            (0, 0, token_idx, 0),
+            (h.shape[0], h.shape[1], token_idx + 1, h.shape[-1]),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        ttnn.deallocate(h)
+        return ttnn.linear(h_last, self.lm_head, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    def prefill_logits_last_device(self, input_ids: torch.Tensor, use_cache: bool = True) -> tuple[torch.Tensor, object]:
+        batch, seq_len = input_ids.shape
+        assert batch == 1, "Only batch=1 supported"
+
+        self.reset()
+        start_pos = self._pos
+        if start_pos != 0:
+            raise ValueError("prefill_logits_last_device must be called at start_pos=0")
+        if start_pos + seq_len > self.max_seq_len:
+            raise ValueError(f"sequence length {start_pos + seq_len} exceeds max_seq_len {self.max_seq_len}")
+
+        padded_seq = pad_to_tile(seq_len)
+        if seq_len < padded_seq:
+            input_ids = torch.nn.functional.pad(input_ids, (0, padded_seq - seq_len), value=0)
+
+        logits = self._forward_prefill_last_logits(input_ids, start_pos, seq_len)
+        self._pos = start_pos + seq_len
+
+        if self.parallel.num_devices > 1:
+            logits_torch = ttnn.to_torch(logits, mesh_composer=self.parallel.vocab_composer)
+        else:
+            logits_torch = ttnn.to_torch(logits)
+        logits_torch = logits_torch.reshape(batch, 1, -1)[:, 0, :].float()
+        ttnn.deallocate(logits)
+        past = self._tt_past_key_values if use_cache else None
+        return logits_torch, past
+
+    def _forward_decode_device(self, start_pos: int, trace_decode: bool) -> ttnn.Tensor:
+        h = ttnn.embedding(self.decode_token_buffer, self.embed, layout=ttnn.TILE_LAYOUT)
+        for layer in self.layers:
+            h = layer(
+                h,
+                start_pos,
+                1,
+                self.decode_pos_buffer,
+                self.decode_cos_buffer,
+                self.decode_sin_buffer,
+                trace_decode,
+            )
+        h = self.norm(h)
+        h = ttnn.slice(
+            h,
+            (0, 0, 0, 0),
+            (h.shape[0], h.shape[1], 1, h.shape[-1]),
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+        )
+        logits = ttnn.linear(h, self.lm_head, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        if not trace_decode:
+            ttnn.deallocate(h)
+        return logits
+
+    def _forward_decode(self, input_ids: torch.Tensor, start_pos: int) -> ttnn.Tensor:
+        self._update_decode_token_buffer(input_ids)
+        self._update_decode_pos_buffer(start_pos)
+        self._update_decode_rope_buffers(start_pos)
+
+        if self.use_decode_trace:
+            if self.decode_trace_id is None:
+                warmup_logits = self._forward_decode_device(start_pos, False)
+                ttnn.deallocate(warmup_logits)
+                self.decode_trace_id = ttnn.begin_trace_capture(self.tt_device)
+                self.decode_trace_logits = self._forward_decode_device(start_pos, True)
+                ttnn.end_trace_capture(self.tt_device, self.decode_trace_id)
+            else:
+                ttnn.execute_trace(self.tt_device, self.decode_trace_id, blocking=False)
+            logits = self.decode_trace_logits
+        else:
+            logits = self._forward_decode_device(start_pos, False)
+        return logits
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        past_key_values=None,
+        use_cache: bool = True,
+        cache_position: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> CausalLMOutputWithPast:
+        """Forward pass compatible with HuggingFace generate()."""
+        batch, seq_len = input_ids.shape
+        assert batch == 1, "Only batch=1 supported"
+
+        if past_key_values is None:
+            self.reset()
+        else:
+            assert seq_len == 1, "Only 1-token decode supported when using cache"
+
+        start_pos = self._pos
+        if start_pos + seq_len > self.max_seq_len:
+            raise ValueError(
+                f"sequence length {start_pos + seq_len} exceeds max_seq_len {self.max_seq_len}; "
+                "increase --max_seq_len if memory allows"
+            )
+
+        if seq_len == 1:
+            logits_device = self._forward_decode(input_ids, start_pos)
+            padded_seq = 1
+        else:
+            padded_seq = pad_to_tile(seq_len)
+            if seq_len < padded_seq:
+                input_ids = torch.nn.functional.pad(input_ids, (0, padded_seq - seq_len), value=0)
+
+            tokens = ttnn.from_torch(
+                input_ids.reshape(1, 1, 1, -1),
+                dtype=ttnn.uint32,
+                device=self.tt_device,
+                mesh_mapper=self.parallel.replicate_mapper,
+            )
+            h = ttnn.embedding(tokens, self.embed, layout=ttnn.TILE_LAYOUT)
+            for layer in self.layers:
+                h = layer(h, start_pos, seq_len)
+            h = self.norm(h)
+            logits_device = ttnn.linear(h, self.lm_head)
+
+        if self.parallel.num_devices > 1:
+            logits_torch = ttnn.to_torch(logits_device, mesh_composer=self.parallel.vocab_composer)
+        else:
+            logits_torch = ttnn.to_torch(logits_device)
+        logits_torch = logits_torch.reshape(batch, padded_seq, -1)[:, :seq_len, :]
+        if seq_len > 1 or not self.use_decode_trace:
+            ttnn.deallocate(logits_device)
+
+        self._pos = start_pos + seq_len
+
+        return CausalLMOutputWithPast(
+            logits=logits_torch.float(),
+            past_key_values=(self._tt_past_key_values if use_cache else None),
+        )
+
+
+def build_model(hf_model, tt_device, max_seq_len: Optional[int] = None) -> TtnnMistralForCausalLM:
+    """Build the ttnn model from a HuggingFace reference model."""
+    return TtnnMistralForCausalLM(hf_model, tt_device, max_seq_len)


### PR DESCRIPTION
Refs #142

Adds initial optimized path for `models/mistralai/Mistral-7B-Instruct-v0.3/n300/optimized`:
- Fused QKV projection per-layer (`qkv_proj`) with per-device chunk ordering
- `prefill_logits_last_device()` for TTFT (compute + transfer last-token logits only)
- Traced decode with preallocated token/position/RoPE buffers
- Decode LM head slicing to avoid padded-32 LM head work

Blocker: this host cannot form a real 1x2 N300 mesh.
- `/proj_sw/user_dev/moconnor/tt-metal/build_Release/tools/umd/system_health` reports all internal-trace ETH links DOWN/unconnected.
- TTNN fails to map `n300_mesh_graph_descriptor.textproto` with `phys_deg_hist={0:2}` (see `demo.log` / `eval.log`).

Next: rerun demo/eval on a healthy N300 host (internal-trace links UP) and then update `MODELS.md` with the n300 optimized row + final metrics.
