### PR TITLE
models/microsoft/Phi-3-mini-128k-instruct/n150/optimized

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -48,6 +48,7 @@ Note: Keep the table columns padded with spaces and right-justify numeric cells 
 | google/gemma-3-4b-it                |  t3000   | functional |   92% |  100% |  330ms |   4.7 |   40960 |
 | google/gemma-3-4b-it                |  t3000   | optimized  |   91% |  100% |   78ms |  19.4 |   40960 |
 | microsoft/Phi-3-mini-128k-instruct  |   n150   | functional |   92% |   99% |   80ms |  13.7 |   12288 |
+| microsoft/Phi-3-mini-128k-instruct  |   n150   | optimized  |   94% |   99% |   69ms |  15.9 |   12288 |
 | microsoft/Phi-3-mini-128k-instruct  |   n300   | functional |   90% |  100% |  193ms |   6.7 |   12288 |
 | microsoft/Phi-3-mini-128k-instruct  |  t3000   | functional |   90% |  100% |  184ms |   6.8 |   12288 |
 | microsoft/Phi-3-mini-128k-instruct  |  t3000   | optimized  |   92% |   99% |  105ms |  23.6 |   12288 |

--- a/models/microsoft/Phi-3-mini-128k-instruct/n150/optimized/MODEL_BRINGUP.md
+++ b/models/microsoft/Phi-3-mini-128k-instruct/n150/optimized/MODEL_BRINGUP.md
@@ -1,0 +1,56 @@
+# MODEL_BRINGUP.md - Phi-3 Mini 128k Instruct (n150 optimized)
+
+## Overview
+This is the optimized TTNN bringup of `microsoft/Phi-3-mini-128k-instruct` for `n150`.
+
+- Model code: `models/microsoft/Phi-3-mini-128k-instruct/n150/optimized/model.py`
+- Demo log: `models/microsoft/Phi-3-mini-128k-instruct/n150/optimized/demo.log`
+- Eval log: `models/microsoft/Phi-3-mini-128k-instruct/n150/optimized/eval.log`
+- Machine-readable metrics: `models/microsoft/Phi-3-mini-128k-instruct/n150/optimized/metrics.json`
+- Decode path uses traced execution (`ttnn.begin_trace_capture` + `ttnn.execute_trace`).
+
+## Baseline vs final
+| Metric | Functional baseline (`MODELS.md`) | Final optimized |
+| --- | ---: | ---: |
+| Top-1 | 92% | 94% |
+| Top-5 | 99% | 99% |
+| TTFT | 80 ms | 69 ms |
+| t/s/u | 13.7 | 15.9 |
+| Seq len | 12288 | 12288 |
+
+Note: TTFT and t/s/u depend on the demo prompt and sampling settings. See `demo.log` for the exact command and output.
+
+## Kept optimization decisions
+1. Decode trace with preallocated decode buffers.
+- Preallocates decode token ids, position tensor, and per-token RoPE cos/sin buffers.
+- Captures a stable decode graph after prefill and replays it with `ttnn.execute_trace`.
+- LongRoPE short/long cache selection is handled by updating per-token RoPE buffers on host based on `start_pos`.
+
+2. Prefill last-token logits fast path (`prefill_logits_last_device`).
+- Avoids materializing full prefill logits when only the final prompt token is needed (demo/eval TTFT).
+
+3. BFP8 MLP weights.
+- Switched `gate_up_proj` and `down_proj` weights to `ttnn.bfloat8_b`.
+- Kept attention and LM head weights in `ttnn.bfloat16`.
+- This change provided the throughput gain needed to clear the n150 baseline while keeping long-eval quality above target.
+
+## Rejected optimization attempts
+1. Oversized trace region (`TTNN_TRACE_REGION_SIZE=50000000`).
+- It fixed trace-capacity errors but caused DRAM OOM during model load.
+- Kept `TTNN_TRACE_REGION_SIZE=13000000` instead, which is enough for trace capture and still fits the model.
+
+## Commands used
+```bash
+TTNN_TRACE_REGION_SIZE=13000000 TT_METAL_CACHE=/tmp/tt-metal-cache PYTHONUNBUFFERED=1 \
+python -u demo.py models/microsoft/Phi-3-mini-128k-instruct/n150/optimized/model.py \
+  --seed 0 \
+  --max_seq_len 12288
+
+TTNN_TRACE_REGION_SIZE=13000000 TT_METAL_CACHE=/tmp/tt-metal-cache PYTHONUNBUFFERED=1 \
+python -u eval.py models/microsoft/Phi-3-mini-128k-instruct/n150/optimized/model.py \
+  --model microsoft/Phi-3-mini-128k-instruct \
+  --prompt_file prompts/bringup_eval_long.txt \
+  --max_new_tokens 100 \
+  --max_seq_len 12288 \
+  --seed 0
+```

--- a/models/microsoft/Phi-3-mini-128k-instruct/n150/optimized/demo.log
+++ b/models/microsoft/Phi-3-mini-128k-instruct/n150/optimized/demo.log
@@ -1,0 +1,70 @@
+TTNN_TRACE_REGION_SIZE=13000000 TT_METAL_CACHE=/tmp/tt-metal-cache PYTHONUNBUFFERED=1 python -u demo.py models/microsoft/Phi-3-mini-128k-instruct/n150/optimized/model.py --seed 0 --max_seq_len 12288
+/proj_sw/user_dev/moconnor/tt-metal/python_env/lib/python3.10/site-packages/transformers/utils/hub.py:111: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
+  warnings.warn(
+2026-02-12 18:07:40.203 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
+Loading tokenizer: microsoft/Phi-3-mini-128k-instruct
+Opening TT device...
+2026-02-12 18:07:40.909 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 18:07:40.910 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-12 18:07:40.913 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 18:07:40.931 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 18:07:40.932 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x40 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 18:07:40.989 | info     |             UMD | Opening local chip ids/PCIe ids: {0}/[3] and remote chip ids {} (cluster.cpp:186)
+2026-02-12 18:07:40.989 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-12 18:07:40.989 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-12 18:07:40.991 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-12 18:07:40.995 | info     |             UMD | Mapped hugepage 0x4c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 18:07:41.055 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.WORKER
+2026-02-12 18:07:41.056 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-12 18:07:41.056 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:863)
+2026-02-12 18:07:41.056 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:840)
+2026-02-12 18:07:41.056 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
+2026-02-12 18:07:41.056 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
+2026-02-12 18:07:41.070 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+Loading HuggingFace reference model on CPU: microsoft/Phi-3-mini-128k-instruct
+Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:00<00:00,  1.35it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.81it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.72it/s]
+Building TT model...
+  Loading embeddings...
+  Computing RoPE cache...
+  Loading 32 layers...
+Running one warmup prefill+decode pass (kernel compile warmup)...
+2026-02-12 18:09:02.207 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/7944994127753528348/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:09:02.298 | warning  |    BuildKernels | Compute kernel 'tilize/17731151790256603023/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:09:02.346 | warning  |    BuildKernels | Compute kernel 'layernorm/4884704230036260402/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:09:02.443 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/6459158174352101094/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:09:02.539 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/10380771056115669711/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:09:02.607 | warning  |    BuildKernels | Compute kernel 'tilize/11337404802072393109/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:09:02.652 | warning  |    BuildKernels | Compute kernel 'pack_untilize/15529522441930124248/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:09:02.697 | warning  |    BuildKernels | Compute kernel 'pack_untilize/5445543247183471221/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:09:02.808 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/15977828201954068243/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:09:02.877 | warning  |    BuildKernels | Compute kernel 'tilize/5674158030118682369/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:09:02.948 | warning  |    BuildKernels | Compute kernel 'sdpa/18318591445458372772/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:09:03.047 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4931792159892224567/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:09:03.142 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/7706102712792064502/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:09:07.369 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/5953438839754737534/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:09:11.488 | warning  |    BuildKernels | Compute kernel 'pack_untilize_wh/7086840538318172595/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:09:11.573 | warning  |    BuildKernels | Compute kernel 'tilize_wh/4709288304851342762/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:09:11.623 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/10208751014080416571/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:09:11.735 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/771060300310080457/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:09:11.910 | warning  |    BuildKernels | Compute kernel 'update_cache/1108314601679714129/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:09:11.961 | warning  |    BuildKernels | Compute kernel 'sdpa_flash_decode/7191414720724713666/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:09:12.110 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/9455956975227903173/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:09:12.181 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/17158196280174090207/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:09:16.322 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/8685630001070688810/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+TT demo (n150)
+Model: microsoft/Phi-3-mini-128k-instruct
+Mesh shape: 1x1
+Prompt tokens: 60 | Generated tokens: 128
+TTFT: 69 ms | Decode: 15.9 t/s/u (126 tokens)
+
+Prompt:
+Journal entry, 1957: Tonight a tiny sphere called Sputnik 1 crossed the sky, beeping like a metronome for a new era. The neighbors gathered on the roof, listening and arguing about what comes next. I wrote in my notebook that
+
+Output:
+we, the human race, might just find ourselves at a crossroads. But tonight, I'm a spectator.
+
+Year 2150: The stars no longer just twinkle; they are waypoints guiding space-faring traders across the galactic trade routes. I, a veteran spacer, navigate by their light to the Andromeda Bazaar. These celest śips, once seen as mere sparks of the cosmos, have become the backbone of our economy. In my worn space-time journal, I jot down, "Galactic
+YT_METRICS={"mode": "tt_demo", "model": "microsoft/Phi-3-mini-128k-instruct", "system": "n150", "mesh_shape": [1, 1], "prompt_tokens": 60, "generated_tokens": 128, "ttft_ms": 68.67167633026838, "decode_tps_u": 15.910978595708624, "decode_tokens": 126, "max_seq_len": 12288}
+2026-02-12 18:09:30.464 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-12 18:09:30.464 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/microsoft/Phi-3-mini-128k-instruct/n150/optimized/eval.log
+++ b/models/microsoft/Phi-3-mini-128k-instruct/n150/optimized/eval.log
@@ -1,0 +1,68 @@
+TTNN_TRACE_REGION_SIZE=13000000 TT_METAL_CACHE=/tmp/tt-metal-cache PYTHONUNBUFFERED=1 python -u eval.py models/microsoft/Phi-3-mini-128k-instruct/n150/optimized/model.py --model microsoft/Phi-3-mini-128k-instruct --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 12288 --seed 0
+2026-02-12 18:09:52.473 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
+/proj_sw/user_dev/moconnor/tt-metal/python_env/lib/python3.10/site-packages/transformers/utils/hub.py:111: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
+  warnings.warn(
+Loading model module: /localdev/moconnor/ttnn_models_worktrees/opt_microsoft-Phi-3-mini-128k-instruct-n150-optimized/models/microsoft/Phi-3-mini-128k-instruct/n150/optimized/model.py
+Loading HuggingFace tokenizer...
+Loading HuggingFace reference model on CPU...
+Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:00<00:00,  1.36it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.87it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.77it/s]
+Generating reference tokens...
+Opening device (1x1)...
+2026-02-12 18:12:06.659 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 18:12:06.659 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-12 18:12:06.662 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 18:12:06.683 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-12 18:12:06.683 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x40 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-12 18:12:06.757 | info     |             UMD | Opening local chip ids/PCIe ids: {0}/[3] and remote chip ids {} (cluster.cpp:186)
+2026-02-12 18:12:06.757 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-12 18:12:06.757 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-12 18:12:06.759 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-12 18:12:06.763 | info     |             UMD | Mapped hugepage 0x4c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-12 18:12:06.821 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.WORKER
+2026-02-12 18:12:06.821 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-12 18:12:06.822 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:863)
+2026-02-12 18:12:06.822 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:840)
+2026-02-12 18:12:06.822 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
+2026-02-12 18:12:06.822 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=1, n_phys=1, log_deg_hist={0:1}, phys_deg_hist={0:1} (topology_mapper_utils.cpp:171)
+2026-02-12 18:12:06.837 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+Loading ttnn model...
+  Loading embeddings...
+  Computing RoPE cache...
+  Loading 32 layers...
+Running teacher-forcing eval (100 tokens)...
+2026-02-12 18:13:13.593 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/7944994127753528348/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:13:13.689 | warning  |    BuildKernels | Compute kernel 'tilize/17731151790256603023/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:13:17.314 | warning  |    BuildKernels | Compute kernel 'layernorm/4884704230036260402/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:13:17.424 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/12265219684519922531/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:13:25.294 | warning  |    BuildKernels | Compute kernel 'pack_untilize_variable_num_blocks/10380771056115669711/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:13:25.395 | warning  |    BuildKernels | Compute kernel 'tilize/11337404802072393109/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:13:25.395 | warning  |    BuildKernels | Compute kernel 'tilize/1982224783747614441/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:13:28.411 | warning  |    BuildKernels | Compute kernel 'pack_untilize/15529522441930124248/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:13:28.411 | warning  |    BuildKernels | Compute kernel 'pack_untilize/1369520511343747262/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:13:31.398 | warning  |    BuildKernels | Compute kernel 'pack_untilize/5445543247183471221/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:13:31.398 | warning  |    BuildKernels | Compute kernel 'pack_untilize/808529285405081447/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:13:34.461 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/7317598834983320959/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:13:34.462 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/3500961269753639563/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:13:34.556 | warning  |    BuildKernels | Compute kernel 'tilize/5674158030118682369/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:13:34.556 | warning  |    BuildKernels | Compute kernel 'tilize/3616169035476323512/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:13:41.394 | warning  |    BuildKernels | Compute kernel 'sdpa/16476601990160721599/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:13:49.174 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/4487912705438789235/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:13:53.196 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/6074376382363038100/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:14:00.890 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/14892443699040698692/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:14:04.901 | warning  |    BuildKernels | Compute kernel 'pack_untilize_wh/8237910100408685478/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:14:04.901 | warning  |    BuildKernels | Compute kernel 'pack_untilize_wh/3404247873314408370/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:14:08.596 | warning  |    BuildKernels | Compute kernel 'tilize_wh/4709288304851342762/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:14:08.679 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/10208751014080416571/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:14:08.793 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/771060300310080457/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:14:08.917 | warning  |    BuildKernels | Compute kernel 'rotary_embedding/15977828201954068243/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:14:08.997 | warning  |    BuildKernels | Compute kernel 'update_cache/1108314601679714129/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:14:09.049 | warning  |    BuildKernels | Compute kernel 'sdpa_flash_decode/7191414720724713666/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:14:09.197 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/9455956975227903173/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:14:09.278 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/17158196280174090207/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+2026-02-12 18:14:09.393 | warning  |    BuildKernels | Compute kernel 'bmm_large_block_zm_fused_bias_activation/8685630001070688810/' uses deprecated 'namespace NAMESPACE { void MAIN { } }' syntax. Please migrate to simplified 'void kernel_main() { }' syntax. (genfiles.cpp:187)
+Top-1 accuracy: 94.00% (0.9400)
+Top-5 accuracy: 99.00% (0.9900)
+YT_METRICS={"mode": "tt_eval", "model": "microsoft/Phi-3-mini-128k-instruct", "top1": 0.94, "top5": 0.99, "top1_pct": 94.0, "top5_pct": 99.0, "total_tokens": 100, "max_new_tokens": 100, "max_seq_len": 12288}
+2026-02-12 18:14:17.524 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-12 18:14:17.524 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/microsoft/Phi-3-mini-128k-instruct/n150/optimized/metrics.json
+++ b/models/microsoft/Phi-3-mini-128k-instruct/n150/optimized/metrics.json
@@ -1,0 +1,26 @@
+{
+  "model": "microsoft/Phi-3-mini-128k-instruct",
+  "hardware": "n150",
+  "variant": "optimized",
+  "functional_baseline": {
+    "top1_pct": 92.0,
+    "top5_pct": 99.0,
+    "ttft_ms": 80.0,
+    "decode_tps_u": 13.7,
+    "seq_len": 12288
+  },
+  "optimized_final": {
+    "top1_pct": 94.0,
+    "top5_pct": 99.0,
+    "ttft_ms": 68.67167633026838,
+    "decode_tps_u": 15.910978595708624,
+    "seq_len": 12288
+  },
+  "acceptance": {
+    "top1_top5_pass": true,
+    "decode_trace_enabled": true,
+    "ttft_improved": true,
+    "decode_tps_improved": true,
+    "seq_len_non_regressed": true
+  }
+}

--- a/models/microsoft/Phi-3-mini-128k-instruct/n150/optimized/model.py
+++ b/models/microsoft/Phi-3-mini-128k-instruct/n150/optimized/model.py
@@ -1,0 +1,1008 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Phi-3 Mini 128k Instruct optimized TTNN model for n150.
+
+Optimizations versus the functional bringup:
+- Prefill last-token logits fast path (`prefill_logits_last_device`) to lower TTFT.
+- Decode trace with preallocated token/pos/RoPE buffers.
+
+Use `demo.py` and `eval.py` at repo root for timing and teacher-forcing accuracy checks.
+"""
+
+import math
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import ttnn
+from transformers import GenerationConfig
+from transformers.generation.utils import GenerationMixin
+from transformers.modeling_outputs import CausalLMOutputWithPast
+
+
+TILE_SIZE = 32
+HEAD_DIM_TILE = 64
+PAGED_BLOCK_SIZE = 64
+ATTN_WEIGHT_DTYPE = ttnn.bfloat16
+MLP_WEIGHT_DTYPE = ttnn.bfloat8_b
+LM_HEAD_WEIGHT_DTYPE = ttnn.bfloat16
+WEIGHT_LAYOUT = ttnn.TILE_LAYOUT
+MAX_CACHE_SEQ_LEN = 12288
+USE_DECODE_TRACE = True
+
+
+def pad_to_tile(x: int) -> int:
+    """Pad to tile boundary (32)."""
+    return ((x + TILE_SIZE - 1) // TILE_SIZE) * TILE_SIZE
+
+
+def pad_head_dim(x: int) -> int:
+    """Pad head dimension to the rotary tile requirement (64)."""
+    return ((x + HEAD_DIM_TILE - 1) // HEAD_DIM_TILE) * HEAD_DIM_TILE
+
+
+@dataclass
+class ModelConfig:
+    """Model configuration extracted from HuggingFace."""
+
+    vocab_size: int
+    hidden_size: int
+    intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    rms_norm_eps: float
+    rope_theta: float
+    rope_scaling: Optional[dict]
+    hidden_act: str
+    tie_word_embeddings: bool
+    max_position_embeddings: int
+    original_max_position_embeddings: int
+    partial_rotary_factor: float
+
+    @classmethod
+    def from_hf(cls, hf_config) -> "ModelConfig":
+        num_kv_heads = getattr(hf_config, "num_key_value_heads", hf_config.num_attention_heads)
+        head_dim = getattr(hf_config, "head_dim", None)
+        if head_dim is None:
+            head_dim = hf_config.hidden_size // hf_config.num_attention_heads
+        original_max = getattr(hf_config, "original_max_position_embeddings", hf_config.max_position_embeddings)
+        partial_rotary = getattr(hf_config, "partial_rotary_factor", 1.0)
+        return cls(
+            hf_config.vocab_size,
+            hf_config.hidden_size,
+            hf_config.intermediate_size,
+            hf_config.num_hidden_layers,
+            hf_config.num_attention_heads,
+            num_kv_heads,
+            head_dim,
+            hf_config.rms_norm_eps,
+            hf_config.rope_theta,
+            getattr(hf_config, "rope_scaling", None),
+            hf_config.hidden_act,
+            hf_config.tie_word_embeddings,
+            hf_config.max_position_embeddings,
+            original_max,
+            partial_rotary,
+        )
+
+
+@dataclass
+class PagedAttentionConfig:
+    """Paged KV cache configuration."""
+
+    block_size: int
+    max_num_blocks: int
+
+
+def compute_attention_scaling(config: ModelConfig) -> float:
+    factor = config.max_position_embeddings / config.original_max_position_embeddings
+    if factor <= 1.0:
+        return 1.0
+    return math.sqrt(1 + math.log(factor) / math.log(config.original_max_position_embeddings))
+
+
+def compute_rope_cache(
+    config: ModelConfig,
+    max_seq_len: int,
+    use_long: Optional[bool] = None,
+) -> tuple:
+    """Precompute LongRoPE cos/sin caches in HuggingFace format.
+
+    Returns cos, sin tensors of shape [1, 1, max_seq_len, head_dim_padded].
+    """
+    if config.partial_rotary_factor != 1.0:
+        raise ValueError("partial_rotary_factor != 1.0 is not supported in this bringup")
+
+    head_dim = config.head_dim
+    padded_head_dim = pad_head_dim(head_dim)
+    attention_scaling = 1.0
+
+    if config.rope_scaling:
+        rope_type = config.rope_scaling.get("rope_type", config.rope_scaling.get("type"))
+        if rope_type != "longrope":
+            raise ValueError(f"rope_scaling {rope_type} is not supported in this bringup")
+
+        long_factor = config.rope_scaling["long_factor"]
+        short_factor = config.rope_scaling["short_factor"]
+        if use_long is None:
+            use_long = max_seq_len > config.original_max_position_embeddings
+        ext_factors = torch.tensor(long_factor if use_long else short_factor, dtype=torch.float32)
+
+        inv_freq = 1.0 / (
+            ext_factors * (config.rope_theta ** (torch.arange(0, head_dim, 2).float() / head_dim))
+        )
+        attention_scaling = config.rope_scaling.get("attention_factor")
+        if attention_scaling is None:
+            attention_scaling = compute_attention_scaling(config)
+    else:
+        inv_freq = 1.0 / (config.rope_theta ** (torch.arange(0, head_dim, 2).float() / head_dim))
+
+    t = torch.arange(max_seq_len, dtype=inv_freq.dtype)
+    freqs = torch.outer(t, inv_freq)
+    emb = torch.cat((freqs, freqs), dim=-1)
+    cos = emb.cos()
+    sin = emb.sin()
+    if attention_scaling != 1.0:
+        cos = cos * attention_scaling
+        sin = sin * attention_scaling
+    if padded_head_dim != head_dim:
+        half = head_dim // 2
+        half_padded = padded_head_dim // 2
+        pad = half_padded - half
+        cos_left = torch.cat([cos[:, :half], torch.ones((max_seq_len, pad), dtype=cos.dtype)], dim=-1)
+        cos_right = torch.cat([cos[:, half:], torch.ones((max_seq_len, pad), dtype=cos.dtype)], dim=-1)
+        sin_left = torch.cat([sin[:, :half], torch.zeros((max_seq_len, pad), dtype=sin.dtype)], dim=-1)
+        sin_right = torch.cat([sin[:, half:], torch.zeros((max_seq_len, pad), dtype=sin.dtype)], dim=-1)
+        cos = torch.cat([cos_left, cos_right], dim=-1)
+        sin = torch.cat([sin_left, sin_right], dim=-1)
+    cos = cos.unsqueeze(0).unsqueeze(0).to(torch.bfloat16)
+    sin = sin.unsqueeze(0).unsqueeze(0).to(torch.bfloat16)
+    return cos, sin
+
+
+def resolve_max_seq_len(hf_config, max_seq_len: Optional[int]) -> int:
+    """Resolve max sequence length and cap it to the known n150 cache limit."""
+    config_max = getattr(hf_config, "max_position_embeddings", None)
+    if config_max is None:
+        config_max = getattr(hf_config, "max_seq_len", None)
+
+    if max_seq_len is None:
+        if config_max is None:
+            raise ValueError("max_seq_len is required when config has no max_position_embeddings")
+        max_seq_len = config_max
+
+    if config_max is not None and max_seq_len > config_max:
+        raise ValueError(f"max_seq_len {max_seq_len} exceeds config max {config_max}")
+
+    if max_seq_len > MAX_CACHE_SEQ_LEN:
+        max_seq_len = MAX_CACHE_SEQ_LEN
+
+    return max_seq_len
+
+
+class RMSNorm:
+    """RMSNorm layer."""
+
+    def __init__(self, weight: torch.Tensor, eps: float, tt_device):
+        self.eps = eps
+        self.weight = ttnn.as_tensor(
+            weight.unsqueeze(0).unsqueeze(0).unsqueeze(0).to(torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        return ttnn.rms_norm(x, epsilon=self.eps, weight=self.weight)
+
+
+class Attention:
+    """Multi-head attention with a fused QKV projection."""
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        layer_idx: int,
+        state_dict: dict,
+        cos_cache_short: ttnn.Tensor,
+        sin_cache_short: ttnn.Tensor,
+        cos_cache_long: ttnn.Tensor,
+        sin_cache_long: ttnn.Tensor,
+        tt_device,
+        paged_attention_config: PagedAttentionConfig,
+        page_table: ttnn.Tensor,
+    ):
+        self.tt_device = tt_device
+        self.n_heads = config.num_attention_heads
+        self.n_kv_heads = config.num_key_value_heads
+        self.original_max_position_embeddings = config.original_max_position_embeddings
+        self.head_dim = config.head_dim
+        self.head_dim_padded = pad_head_dim(self.head_dim)
+        self.head_dim_half = self.head_dim // 2
+        self.head_dim_half_padded = self.head_dim_padded // 2
+        self.scale = 1.0 / math.sqrt(self.head_dim)
+        self.paged_attention_config = paged_attention_config
+        self.page_table = page_table
+
+        self.decode_q_pad_zeros = None
+        self.decode_k_pad_zeros = None
+        if self.head_dim_padded != self.head_dim:
+            pad = self.head_dim_half_padded - self.head_dim_half
+            pad_tile = pad_to_tile(pad)
+            self.decode_q_pad_zeros = ttnn.zeros(
+                (1, 1, TILE_SIZE * self.n_heads, pad_tile),
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=self.tt_device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            self.decode_k_pad_zeros = ttnn.zeros(
+                (1, 1, TILE_SIZE * self.n_kv_heads, pad_tile),
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=self.tt_device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+
+        self.cos_cache_short = cos_cache_short
+        self.sin_cache_short = sin_cache_short
+        self.cos_cache_long = cos_cache_long
+        self.sin_cache_long = sin_cache_long
+
+        p = f"model.layers.{layer_idx}.self_attn."
+        self.qkv_proj = self._load_weight(state_dict[f"{p}qkv_proj.weight"])
+        self.o_proj = self._load_weight(state_dict[f"{p}o_proj.weight"])
+
+        cache_shape = (
+            self.paged_attention_config.max_num_blocks,
+            self.n_kv_heads,
+            self.paged_attention_config.block_size,
+            self.head_dim,
+        )
+        self.k_cache = ttnn.as_tensor(
+            torch.zeros(cache_shape, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        self.v_cache = ttnn.as_tensor(
+            torch.zeros(cache_shape, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+    def _load_weight(self, w: torch.Tensor) -> ttnn.Tensor:
+        return ttnn.as_tensor(
+            w.T.unsqueeze(0).unsqueeze(0).to(torch.bfloat16).contiguous(),
+            dtype=ATTN_WEIGHT_DTYPE,
+            layout=WEIGHT_LAYOUT,
+            device=self.tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+    def _pad_head_dim(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        if self.head_dim_padded == self.head_dim:
+            return x
+        pad = self.head_dim_half_padded - self.head_dim_half
+        pad_tile = pad_to_tile(pad)
+        zeros = ttnn.zeros(
+            (x.shape[0], x.shape[1], x.shape[2], pad_tile),
+            dtype=x.dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=self.tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        zeros = ttnn.slice(
+            zeros,
+            (0, 0, 0, 0),
+            (zeros.shape[0], zeros.shape[1], zeros.shape[2], pad),
+        )
+        left = ttnn.slice(
+            x,
+            (0, 0, 0, 0),
+            (x.shape[0], x.shape[1], x.shape[2], self.head_dim_half),
+        )
+        right = ttnn.slice(
+            x,
+            (0, 0, 0, self.head_dim_half),
+            (x.shape[0], x.shape[1], x.shape[2], self.head_dim),
+        )
+        left = ttnn.concat([left, zeros], dim=-1, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        right = ttnn.concat([right, zeros], dim=-1, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        return ttnn.concat([left, right], dim=-1, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    def _pad_head_dim_decode(self, x: ttnn.Tensor, zeros_padded: ttnn.Tensor) -> ttnn.Tensor:
+        if self.head_dim_padded == self.head_dim:
+            return x
+        pad = self.head_dim_half_padded - self.head_dim_half
+        zeros = ttnn.slice(
+            zeros_padded,
+            (0, 0, 0, 0),
+            (zeros_padded.shape[0], zeros_padded.shape[1], zeros_padded.shape[2], pad),
+        )
+        left = ttnn.slice(
+            x,
+            (0, 0, 0, 0),
+            (x.shape[0], x.shape[1], x.shape[2], self.head_dim_half),
+        )
+        right = ttnn.slice(
+            x,
+            (0, 0, 0, self.head_dim_half),
+            (x.shape[0], x.shape[1], x.shape[2], self.head_dim),
+        )
+        left = ttnn.concat([left, zeros], dim=-1, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        right = ttnn.concat([right, zeros], dim=-1, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        return ttnn.concat([left, right], dim=-1, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    def _slice_head_dim(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        if self.head_dim_padded == self.head_dim:
+            return x
+        left = ttnn.slice(
+            x,
+            (0, 0, 0, 0),
+            (x.shape[0], x.shape[1], x.shape[2], self.head_dim_half_padded),
+        )
+        right = ttnn.slice(
+            x,
+            (0, 0, 0, self.head_dim_half_padded),
+            (x.shape[0], x.shape[1], x.shape[2], self.head_dim_padded),
+        )
+        left = ttnn.slice(
+            left,
+            (0, 0, 0, 0),
+            (left.shape[0], left.shape[1], left.shape[2], self.head_dim_half),
+        )
+        right = ttnn.slice(
+            right,
+            (0, 0, 0, 0),
+            (right.shape[0], right.shape[1], right.shape[2], self.head_dim_half),
+        )
+        return ttnn.concat([left, right], dim=-1, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    def __call__(
+        self,
+        x: ttnn.Tensor,
+        start_pos: int,
+        seq_len: int,
+        cur_pos_tensor: Optional[ttnn.Tensor] = None,
+        decode_cos_q: Optional[ttnn.Tensor] = None,
+        decode_sin_q: Optional[ttnn.Tensor] = None,
+        decode_cos_k: Optional[ttnn.Tensor] = None,
+        decode_sin_k: Optional[ttnn.Tensor] = None,
+        trace_decode: bool = False,
+    ) -> ttnn.Tensor:
+        is_prefill = seq_len > 1
+        padded_seq = pad_to_tile(seq_len)
+
+        if is_prefill:
+            use_long = seq_len > self.original_max_position_embeddings
+            cos_cache = self.cos_cache_long if use_long else self.cos_cache_short
+            sin_cache = self.sin_cache_long if use_long else self.sin_cache_short
+        else:
+            cos_cache = None
+            sin_cache = None
+
+        qkv = ttnn.linear(x, self.qkv_proj)
+
+        if is_prefill:
+            q, k, v = ttnn.experimental.nlp_create_qkv_heads(
+                qkv,
+                num_heads=self.n_heads,
+                num_kv_heads=self.n_kv_heads,
+                transpose_k_heads=False,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            ttnn.deallocate(qkv)
+
+            q_mem = ttnn.get_memory_config(q)
+            k_mem = ttnn.get_memory_config(k)
+            q = ttnn.to_memory_config(q, ttnn.DRAM_MEMORY_CONFIG)
+            k = ttnn.to_memory_config(k, ttnn.DRAM_MEMORY_CONFIG)
+
+            cos = cos_cache[:, :, :padded_seq, :]
+            sin = sin_cache[:, :, :padded_seq, :]
+            q = self._slice_head_dim(ttnn.experimental.rotary_embedding(self._pad_head_dim(q), cos, sin))
+            k = self._slice_head_dim(ttnn.experimental.rotary_embedding(self._pad_head_dim(k), cos, sin))
+
+            q = ttnn.to_memory_config(q, q_mem)
+            k = ttnn.to_memory_config(k, k_mem)
+
+            ttnn.experimental.paged_fill_cache(self.k_cache, k, self.page_table, batch_idx=0)
+            ttnn.experimental.paged_fill_cache(self.v_cache, v, self.page_table, batch_idx=0)
+
+            attn_out = ttnn.transformer.scaled_dot_product_attention(q, k, v, is_causal=True, scale=self.scale)
+            attn_out = ttnn.experimental.nlp_concat_heads(attn_out, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        else:
+            if cur_pos_tensor is None:
+                raise ValueError("cur_pos_tensor is required for decode")
+
+            q, k, v = ttnn.experimental.nlp_create_qkv_heads_decode(
+                qkv,
+                num_heads=self.n_heads,
+                num_kv_heads=self.n_kv_heads,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            if not trace_decode:
+                ttnn.deallocate(qkv)
+
+            q_mem = ttnn.get_memory_config(q)
+            k_mem = ttnn.get_memory_config(k)
+            q = ttnn.to_memory_config(q, ttnn.DRAM_MEMORY_CONFIG)
+            k = ttnn.to_memory_config(k, ttnn.DRAM_MEMORY_CONFIG)
+
+            q_batch = q.shape[1]
+            q_heads = q.shape[2]
+            q_bh = q_batch * q_heads
+            q_bh_padded = pad_to_tile(q_bh)
+            q = ttnn.reshape(q, (1, 1, q_bh, self.head_dim), (1, 1, q_bh_padded, self.head_dim))
+            if decode_cos_q is None or decode_sin_q is None:
+                use_long = start_pos >= self.original_max_position_embeddings
+                cos_cache = self.cos_cache_long if use_long else self.cos_cache_short
+                sin_cache = self.sin_cache_long if use_long else self.sin_cache_short
+                q = self._slice_head_dim(
+                    ttnn.experimental.rotary_embedding(self._pad_head_dim(q), cos_cache, sin_cache, start_pos)
+                )
+            else:
+                q = self._slice_head_dim(
+                    ttnn.experimental.rotary_embedding(
+                        self._pad_head_dim_decode(q, self.decode_q_pad_zeros),
+                        decode_cos_q,
+                        decode_sin_q,
+                    )
+                )
+            q = ttnn.reshape(q, (1, q_batch, q_heads, self.head_dim), (1, q_batch, q_heads, self.head_dim))
+
+            k_batch = k.shape[1]
+            k_heads = k.shape[2]
+            k_bh = k_batch * k_heads
+            k_bh_padded = pad_to_tile(k_bh)
+            k = ttnn.reshape(k, (1, 1, k_bh, self.head_dim), (1, 1, k_bh_padded, self.head_dim))
+            if decode_cos_k is None or decode_sin_k is None:
+                use_long = start_pos >= self.original_max_position_embeddings
+                cos_cache = self.cos_cache_long if use_long else self.cos_cache_short
+                sin_cache = self.sin_cache_long if use_long else self.sin_cache_short
+                k = self._slice_head_dim(
+                    ttnn.experimental.rotary_embedding(self._pad_head_dim(k), cos_cache, sin_cache, start_pos)
+                )
+            else:
+                k = self._slice_head_dim(
+                    ttnn.experimental.rotary_embedding(
+                        self._pad_head_dim_decode(k, self.decode_k_pad_zeros),
+                        decode_cos_k,
+                        decode_sin_k,
+                    )
+                )
+            k = ttnn.reshape(k, (1, k_batch, k_heads, self.head_dim), (1, k_batch, k_heads, self.head_dim))
+
+            q = ttnn.to_memory_config(q, q_mem)
+            k = ttnn.to_memory_config(k, k_mem)
+
+            ttnn.experimental.paged_update_cache(
+                self.k_cache,
+                k,
+                update_idxs_tensor=cur_pos_tensor,
+                page_table=self.page_table,
+            )
+            ttnn.experimental.paged_update_cache(
+                self.v_cache,
+                v,
+                update_idxs_tensor=cur_pos_tensor,
+                page_table=self.page_table,
+            )
+
+            attn_out = ttnn.transformer.paged_scaled_dot_product_attention_decode(
+                q,
+                self.k_cache,
+                self.v_cache,
+                page_table_tensor=self.page_table,
+                cur_pos_tensor=cur_pos_tensor,
+                scale=self.scale,
+            )
+            attn_out = ttnn.transpose(attn_out, 1, 2)
+            attn_out = ttnn.experimental.nlp_concat_heads(attn_out, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+        expected_width = self.n_heads * self.head_dim
+        if attn_out.shape[-1] != expected_width:
+            attn_out = ttnn.slice(
+                attn_out,
+                (0, 0, 0, 0),
+                (attn_out.shape[0], attn_out.shape[1], attn_out.shape[2], expected_width),
+            )
+
+        return ttnn.linear(attn_out, self.o_proj)
+
+
+class MLP:
+    """Gated MLP using a single gate_up projection."""
+
+    def __init__(self, layer_idx: int, state_dict: dict, tt_device):
+        p = f"model.layers.{layer_idx}.mlp."
+        self.gate_up_proj = self._load_weight(state_dict[f"{p}gate_up_proj.weight"], tt_device, MLP_WEIGHT_DTYPE)
+        self.down_proj = self._load_weight(state_dict[f"{p}down_proj.weight"], tt_device, MLP_WEIGHT_DTYPE)
+
+    def _load_weight(self, w: torch.Tensor, tt_device, dtype: ttnn.DataType) -> ttnn.Tensor:
+        return ttnn.as_tensor(
+            w.T.unsqueeze(0).unsqueeze(0).to(torch.bfloat16).contiguous(),
+            dtype=dtype,
+            layout=WEIGHT_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+    def __call__(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        gate_up = ttnn.linear(x, self.gate_up_proj)
+        half = gate_up.shape[-1] // 2
+        gate = ttnn.slice(
+            gate_up,
+            (0, 0, 0, 0),
+            (gate_up.shape[0], gate_up.shape[1], gate_up.shape[2], half),
+        )
+        up = ttnn.slice(
+            gate_up,
+            (0, 0, 0, half),
+            (gate_up.shape[0], gate_up.shape[1], gate_up.shape[2], half * 2),
+        )
+        gate = ttnn.silu(gate)
+        return ttnn.linear(ttnn.mul(gate, up), self.down_proj)
+
+
+class DecoderLayer:
+    """Single transformer layer."""
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        layer_idx: int,
+        state_dict: dict,
+        cos_cache_short: ttnn.Tensor,
+        sin_cache_short: ttnn.Tensor,
+        cos_cache_long: ttnn.Tensor,
+        sin_cache_long: ttnn.Tensor,
+        tt_device,
+        paged_attention_config: PagedAttentionConfig,
+        page_table: ttnn.Tensor,
+    ):
+        p = f"model.layers.{layer_idx}."
+        self.attn_norm = RMSNorm(state_dict[f"{p}input_layernorm.weight"], config.rms_norm_eps, tt_device)
+        self.ffn_norm = RMSNorm(state_dict[f"{p}post_attention_layernorm.weight"], config.rms_norm_eps, tt_device)
+        self.attn = Attention(
+            config,
+            layer_idx,
+            state_dict,
+            cos_cache_short,
+            sin_cache_short,
+            cos_cache_long,
+            sin_cache_long,
+            tt_device,
+            paged_attention_config,
+            page_table,
+        )
+        self.mlp = MLP(layer_idx, state_dict, tt_device)
+
+    def __call__(
+        self,
+        x: ttnn.Tensor,
+        start_pos: int,
+        seq_len: int,
+        cur_pos_tensor: Optional[ttnn.Tensor] = None,
+        decode_cos_q: Optional[ttnn.Tensor] = None,
+        decode_sin_q: Optional[ttnn.Tensor] = None,
+        decode_cos_k: Optional[ttnn.Tensor] = None,
+        decode_sin_k: Optional[ttnn.Tensor] = None,
+        trace_decode: bool = False,
+    ) -> ttnn.Tensor:
+        x = ttnn.add(
+            x,
+            self.attn(
+                self.attn_norm(x),
+                start_pos,
+                seq_len,
+                cur_pos_tensor,
+                decode_cos_q,
+                decode_sin_q,
+                decode_cos_k,
+                decode_sin_k,
+                trace_decode,
+            ),
+        )
+        x = ttnn.add(x, self.mlp(self.ffn_norm(x)))
+        return x
+
+
+class TtnnPhi3ForCausalLM(torch.nn.Module, GenerationMixin):
+    """Phi-3 model with 100% ttnn execution.
+
+    HuggingFace `generate()`-compatible via `GenerationMixin`.
+    """
+
+    def __init__(self, hf_model, tt_device, max_seq_len: Optional[int] = None):
+        super().__init__()
+
+        self.tt_device = tt_device
+        self.hf_config = hf_model.config
+        self.tt_config = ModelConfig.from_hf(hf_model.config)
+        self.max_seq_len = resolve_max_seq_len(self.hf_config, max_seq_len)
+        self._pos = 0
+        self.paged_attention_config = PagedAttentionConfig(
+            PAGED_BLOCK_SIZE,
+            math.ceil(self.max_seq_len / PAGED_BLOCK_SIZE),
+        )
+
+        if self.tt_config.hidden_act != "silu":
+            raise ValueError(f"hidden_act {self.tt_config.hidden_act} is not supported in this bringup")
+
+        self.config = self.hf_config
+        self.generation_config = GenerationConfig.from_model_config(self.config)
+        if self.generation_config.pad_token_id is None:
+            self.generation_config.pad_token_id = self.generation_config.eos_token_id
+        self._supports_cache_class = False
+        self.main_input_name = "input_ids"
+        self.register_buffer("_torch_dummy", torch.empty(0, dtype=torch.float32), persistent=False)
+
+        state_dict = hf_model.state_dict()
+
+        print("  Loading embeddings...")
+        self.embed = ttnn.as_tensor(
+            state_dict["model.embed_tokens.weight"].unsqueeze(0).unsqueeze(0).to(torch.bfloat16),
+            dtype=ATTN_WEIGHT_DTYPE,
+            layout=WEIGHT_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        print("  Computing RoPE cache...")
+        cos_short, sin_short = compute_rope_cache(self.tt_config, self.max_seq_len, use_long=False)
+        cos_long, sin_long = compute_rope_cache(self.tt_config, self.max_seq_len, use_long=True)
+        self.cos_cache_short_host = cos_short
+        self.sin_cache_short_host = sin_short
+        self.cos_cache_long_host = cos_long
+        self.sin_cache_long_host = sin_long
+        self.cos_cache_short = ttnn.as_tensor(
+            cos_short,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        self.sin_cache_short = ttnn.as_tensor(
+            sin_short,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        self.cos_cache_long = ttnn.as_tensor(
+            cos_long,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        self.sin_cache_long = ttnn.as_tensor(
+            sin_long,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        page_table = torch.arange(self.paged_attention_config.max_num_blocks, dtype=torch.int32)
+        page_table = page_table.repeat(TILE_SIZE, 1)
+        self.page_table = ttnn.as_tensor(
+            page_table,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        head_dim_padded = pad_head_dim(self.tt_config.head_dim)
+        self.decode_token_buffer = ttnn.from_torch(
+            torch.zeros((1, 1, 1, TILE_SIZE), dtype=torch.int32),
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+        )
+        self.decode_pos_buffer = ttnn.from_torch(
+            torch.zeros((TILE_SIZE,), dtype=torch.int32),
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        self.decode_q_rope_seq = self.tt_config.num_attention_heads * TILE_SIZE
+        self.decode_k_rope_seq = self.tt_config.num_key_value_heads * TILE_SIZE
+        self.decode_cos_q_buffer = ttnn.from_torch(
+            torch.zeros((1, 1, self.decode_q_rope_seq, head_dim_padded), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+        )
+        self.decode_sin_q_buffer = ttnn.from_torch(
+            torch.zeros((1, 1, self.decode_q_rope_seq, head_dim_padded), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+        )
+        self.decode_cos_k_buffer = ttnn.from_torch(
+            torch.zeros((1, 1, self.decode_k_rope_seq, head_dim_padded), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+        )
+        self.decode_sin_k_buffer = ttnn.from_torch(
+            torch.zeros((1, 1, self.decode_k_rope_seq, head_dim_padded), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+        )
+        self.use_decode_trace = USE_DECODE_TRACE
+        self.decode_trace_id = None
+        self.decode_trace_logits = None
+
+        print(f"  Loading {self.tt_config.num_hidden_layers} layers...")
+        self.layers = [
+            DecoderLayer(
+                self.tt_config,
+                i,
+                state_dict,
+                self.cos_cache_short,
+                self.sin_cache_short,
+                self.cos_cache_long,
+                self.sin_cache_long,
+                tt_device,
+                self.paged_attention_config,
+                self.page_table,
+            )
+            for i in range(self.tt_config.num_hidden_layers)
+        ]
+
+        self.norm = RMSNorm(state_dict["model.norm.weight"], self.tt_config.rms_norm_eps, tt_device)
+        lm_head_weight = state_dict.get("lm_head.weight", state_dict["model.embed_tokens.weight"])
+        self.lm_head = ttnn.as_tensor(
+            lm_head_weight.T.unsqueeze(0).unsqueeze(0).to(torch.bfloat16).contiguous(),
+            dtype=LM_HEAD_WEIGHT_DTYPE,
+            layout=WEIGHT_LAYOUT,
+            device=tt_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        self._tt_past_key_values = object()
+
+    @property
+    def device(self) -> torch.device:
+        return self._torch_dummy.device
+
+    def _release_decode_trace(self) -> None:
+        if self.decode_trace_id is None:
+            return
+        ttnn.release_trace(self.tt_device, self.decode_trace_id)
+        self.decode_trace_id = None
+        self.decode_trace_logits = None
+
+    def reset(self):
+        """Reset position counter for new sequence."""
+        self._pos = 0
+        self._release_decode_trace()
+
+    def prepare_inputs_for_generation(self, input_ids, past_key_values=None, **kwargs):
+        if past_key_values is not None:
+            input_ids = input_ids[:, -1:]
+        return {"input_ids": input_ids, "past_key_values": past_key_values, "use_cache": True}
+
+    def _reorder_cache(self, past_key_values, beam_idx):
+        return past_key_values
+
+    def _forward_prefill(self, input_ids: torch.Tensor, start_pos: int, seq_len: int) -> ttnn.Tensor:
+        tokens = ttnn.from_torch(
+            input_ids.reshape(1, 1, 1, -1),
+            dtype=ttnn.uint32,
+            device=self.tt_device,
+        )
+        h = ttnn.embedding(tokens, self.embed, layout=ttnn.TILE_LAYOUT)
+        for layer in self.layers:
+            h = layer(h, start_pos, seq_len)
+        h = self.norm(h)
+        return ttnn.linear(h, self.lm_head)
+
+    def _forward_prefill_last_logits(self, input_ids: torch.Tensor, start_pos: int, seq_len: int) -> ttnn.Tensor:
+        tokens = ttnn.from_torch(
+            input_ids.reshape(1, 1, 1, -1),
+            dtype=ttnn.uint32,
+            device=self.tt_device,
+        )
+        h = ttnn.embedding(tokens, self.embed, layout=ttnn.TILE_LAYOUT)
+        for layer in self.layers:
+            h = layer(h, start_pos, seq_len)
+        h = self.norm(h)
+        last_token_idx = seq_len - 1
+        h_last = ttnn.slice(
+            h,
+            (0, 0, last_token_idx, 0),
+            (h.shape[0], h.shape[1], last_token_idx + 1, h.shape[-1]),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        ttnn.deallocate(h)
+        return ttnn.linear(h_last, self.lm_head)
+
+    def _update_decode_token_buffer(self, input_ids: torch.Tensor) -> None:
+        token_ids = torch.zeros((TILE_SIZE,), dtype=torch.int32)
+        token_ids[: input_ids.numel()] = input_ids.view(-1).to(torch.int32)
+        token_ids = token_ids.reshape(1, 1, 1, -1)
+        host_tokens = ttnn.from_torch(
+            token_ids,
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        ttnn.copy_host_to_device_tensor(host_tokens, self.decode_token_buffer)
+
+    def _update_decode_pos_buffer(self, start_pos: int) -> None:
+        pos = torch.full((TILE_SIZE,), -1, dtype=torch.int32)
+        pos[0] = start_pos
+        host_pos = ttnn.from_torch(
+            pos,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        ttnn.copy_host_to_device_tensor(host_pos, self.decode_pos_buffer)
+
+    def _update_decode_rope_buffers(self, start_pos: int) -> None:
+        use_long = start_pos >= self.tt_config.original_max_position_embeddings
+        cos_cache = self.cos_cache_long_host if use_long else self.cos_cache_short_host
+        sin_cache = self.sin_cache_long_host if use_long else self.sin_cache_short_host
+        cos_token = cos_cache[:, :, start_pos : start_pos + 1, :]
+        sin_token = sin_cache[:, :, start_pos : start_pos + 1, :]
+        cos_q = cos_token.repeat(1, 1, self.decode_q_rope_seq, 1)
+        sin_q = sin_token.repeat(1, 1, self.decode_q_rope_seq, 1)
+        cos_k = cos_token.repeat(1, 1, self.decode_k_rope_seq, 1)
+        sin_k = sin_token.repeat(1, 1, self.decode_k_rope_seq, 1)
+
+        host_cos_q = ttnn.from_torch(cos_q, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+        host_sin_q = ttnn.from_torch(sin_q, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+        host_cos_k = ttnn.from_torch(cos_k, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+        host_sin_k = ttnn.from_torch(sin_k, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+
+        ttnn.copy_host_to_device_tensor(host_cos_q, self.decode_cos_q_buffer)
+        ttnn.copy_host_to_device_tensor(host_sin_q, self.decode_sin_q_buffer)
+        ttnn.copy_host_to_device_tensor(host_cos_k, self.decode_cos_k_buffer)
+        ttnn.copy_host_to_device_tensor(host_sin_k, self.decode_sin_k_buffer)
+
+    def _forward_decode_device(self, start_pos: int, trace_decode: bool) -> ttnn.Tensor:
+        h = ttnn.embedding(self.decode_token_buffer, self.embed, layout=ttnn.TILE_LAYOUT)
+        for layer in self.layers:
+            h = layer(
+                h,
+                start_pos,
+                1,
+                cur_pos_tensor=self.decode_pos_buffer,
+                decode_cos_q=self.decode_cos_q_buffer,
+                decode_sin_q=self.decode_sin_q_buffer,
+                decode_cos_k=self.decode_cos_k_buffer,
+                decode_sin_k=self.decode_sin_k_buffer,
+                trace_decode=trace_decode,
+            )
+        h = self.norm(h)
+        h = ttnn.slice(
+            h,
+            (0, 0, 0, 0),
+            (h.shape[0], h.shape[1], 1, h.shape[-1]),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        logits = ttnn.linear(h, self.lm_head)
+        if not trace_decode:
+            ttnn.deallocate(h)
+        return logits
+
+    def _forward_decode(self, input_ids: torch.Tensor, start_pos: int) -> ttnn.Tensor:
+        self._update_decode_token_buffer(input_ids)
+        self._update_decode_pos_buffer(start_pos)
+        self._update_decode_rope_buffers(start_pos)
+
+        if self.use_decode_trace:
+            if self.decode_trace_id is None:
+                warmup_logits = self._forward_decode_device(start_pos, False)
+                ttnn.deallocate(warmup_logits)
+                self.decode_trace_id = ttnn.begin_trace_capture(self.tt_device)
+                self.decode_trace_logits = self._forward_decode_device(start_pos, True)
+                ttnn.end_trace_capture(self.tt_device, self.decode_trace_id)
+            else:
+                ttnn.execute_trace(self.tt_device, self.decode_trace_id, blocking=False)
+            return self.decode_trace_logits
+
+        return self._forward_decode_device(start_pos, False)
+
+    def _forward_device_logits(self, input_ids: torch.Tensor, past_key_values, use_cache: bool):
+        batch, seq_len = input_ids.shape
+        if batch != 1:
+            raise ValueError("Only batch=1 supported")
+
+        if past_key_values is None:
+            self.reset()
+        elif seq_len != 1:
+            raise ValueError("Only 1-token decode supported when using cache")
+
+        start_pos = self._pos
+        if start_pos + seq_len > self.max_seq_len:
+            raise ValueError(
+                f"sequence length {start_pos + seq_len} exceeds max_seq_len {self.max_seq_len}; "
+                "increase --max-seq-len if memory allows"
+            )
+
+        if seq_len == 1:
+            logits_device = self._forward_decode(input_ids, start_pos)
+            padded_seq = 1
+        else:
+            padded_seq = pad_to_tile(seq_len)
+            if seq_len < padded_seq:
+                input_ids = torch.nn.functional.pad(input_ids, (0, padded_seq - seq_len), value=0)
+            logits_device = self._forward_prefill(input_ids, start_pos, seq_len)
+
+        self._pos = start_pos + seq_len
+        past = self._tt_past_key_values if use_cache else None
+        return logits_device, seq_len, padded_seq, past
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        past_key_values=None,
+        use_cache: bool = True,
+        cache_position: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> CausalLMOutputWithPast:
+        batch = input_ids.shape[0]
+        logits_device, seq_len, padded_seq, past = self._forward_device_logits(input_ids, past_key_values, use_cache)
+        logits = ttnn.to_torch(logits_device).reshape(batch, padded_seq, -1)[:, :seq_len, :]
+
+        if seq_len > 1 or not self.use_decode_trace:
+            ttnn.deallocate(logits_device)
+
+        return CausalLMOutputWithPast(
+            logits=logits.float(),
+            past_key_values=past,
+        )
+
+    def prefill_logits_last_device(self, input_ids: torch.Tensor, use_cache: bool = True) -> tuple[torch.Tensor, object]:
+        batch, seq_len = input_ids.shape
+        if batch != 1:
+            raise ValueError("Only batch=1 supported")
+
+        self.reset()
+        start_pos = self._pos
+        if start_pos != 0:
+            raise ValueError("prefill_logits_last_device must be called at start_pos=0")
+        if start_pos + seq_len > self.max_seq_len:
+            raise ValueError(
+                f"sequence length {start_pos + seq_len} exceeds max_seq_len {self.max_seq_len}; "
+                "increase --max-seq-len if memory allows"
+            )
+
+        padded_seq = pad_to_tile(seq_len)
+        if seq_len < padded_seq:
+            input_ids = torch.nn.functional.pad(input_ids, (0, padded_seq - seq_len), value=0)
+
+        logits_device = self._forward_prefill_last_logits(input_ids, start_pos, seq_len)
+        self._pos = start_pos + seq_len
+
+        logits = ttnn.to_torch(logits_device).reshape(batch, 1, -1)[:, 0, :].float()
+        ttnn.deallocate(logits_device)
+
+        past = self._tt_past_key_values if use_cache else None
+        return logits, past
+
+
+def build_model(hf_model, tt_device, max_seq_len: Optional[int] = None) -> TtnnPhi3ForCausalLM:
+    """Build the ttnn model from a HuggingFace reference model."""
+    return TtnnPhi3ForCausalLM(hf_model, tt_device, max_seq_len)


### PR DESCRIPTION
Target: optimize `models/microsoft/Phi-3-mini-128k-instruct/n150/optimized` using `tasks/optimize_model.yaml`.

## Summary
- Added optimized implementation and notes:
  - `models/microsoft/Phi-3-mini-128k-instruct/n150/optimized/model.py`
  - `models/microsoft/Phi-3-mini-128k-instruct/n150/optimized/MODEL_BRINGUP.md`
- Added run artifacts:
  - `models/microsoft/Phi-3-mini-128k-instruct/n150/optimized/demo.log`
  - `models/microsoft/Phi-3-mini-128k-instruct/n150/optimized/eval.log`
  - `models/microsoft/Phi-3-mini-128k-instruct/n150/optimized/metrics.json`
- Updated `MODELS.md` optimized row for this target.
- Cleared local contents under `generated/`.

## Results (n150 optimized)
- Top-1: 94%
- Top-5: 99%
- TTFT: 69ms
- t/s/u: 15.9
- Seq len: 12288

## Acceptance check
- Long eval: Top-1 >= 85%, Top-5 >= 95%: PASS
- Decode uses traced execution: PASS
- TTFT strictly lower than functional baseline (80ms): PASS
- t/s/u strictly higher than functional baseline (13.7): PASS
- No capability regression (seq len >= 12288): PASS
- `demo.log` and `eval.log` present with commands and outputs: PASS

Fixes #150
