### PR TITLE
models/arcee-ai/Arcee-Spark/t3000/optimized (1x8 mesh port)

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -37,7 +37,7 @@ Note: Keep the table columns padded with spaces and right-justify numeric cells 
 | tiiuae/Falcon3-7B-Instruct          |  t3000   | functional |   97% |  100% |  199ms |   7.3 |   32768 |
 | arcee-ai/Arcee-Spark                |   n150   | optimized  |   91% |  100% |   77ms |  14.5 |   29952 |
 | arcee-ai/Arcee-Spark                |   n300   | optimized  |   85% |  100% |  101ms |  16.0 |   32768 |
-| arcee-ai/Arcee-Spark                |  t3000   | optimized  |   90% |  100% |   72ms |  17.6 |   32768 |
+| arcee-ai/Arcee-Spark                |  t3000   | optimized  |   87% |  100% |   64ms |  21.5 |   32768 |
 | arcee-ai/AFM-4.5B                   |   n150   | optimized  |   98% |  100% |   57ms |  19.6 |   65536 |
 | arcee-ai/AFM-4.5B                   |   n300   | optimized  |   99% |  100% |   56ms |  23.6 |   65536 |
 | arcee-ai/AFM-4.5B                   |  t3000   | optimized  |   98% |  100% |   69ms |  29.0 |   65536 |

--- a/device_utils.py
+++ b/device_utils.py
@@ -94,14 +94,25 @@ def open_tt_device(mesh_shape: Tuple[int, int], device_id: int):
     allow_mesh_fallback = env_flag("TTNN_ALLOW_SYSTEM_MESH_FALLBACK")
     system_mesh_desc = ttnn._ttnn.multi_device.SystemMeshDescriptor()
     system_shape = tuple(system_mesh_desc.shape())
+    requested_device_count = requested_mesh_shape[0] * requested_mesh_shape[1]
+    system_device_count = system_shape[0] * system_shape[1]
     if requested_mesh_shape[0] > system_shape[0] or requested_mesh_shape[1] > system_shape[1]:
-        if not allow_mesh_fallback:
-            raise RuntimeError(f"Requested mesh {requested_mesh_shape} exceeds system mesh {system_shape}")
-        print(
-            f"Requested mesh {requested_mesh_shape} exceeds discovered system mesh {system_shape}; "
-            "falling back to discovered mesh because TTNN_ALLOW_SYSTEM_MESH_FALLBACK is enabled."
-        )
-        mesh_shape = system_shape
+        if requested_device_count <= system_device_count:
+            print(
+                f"Requested mesh {requested_mesh_shape} differs from discovered system mesh {system_shape}; "
+                "proceeding because requested device count fits within discovered capacity."
+            )
+        elif not allow_mesh_fallback:
+            raise RuntimeError(
+                f"Requested mesh {requested_mesh_shape} exceeds system mesh {system_shape} "
+                f"(requested devices={requested_device_count}, discovered devices={system_device_count})"
+            )
+        else:
+            print(
+                f"Requested mesh {requested_mesh_shape} exceeds discovered system mesh {system_shape}; "
+                "falling back to discovered mesh because TTNN_ALLOW_SYSTEM_MESH_FALLBACK is enabled."
+            )
+            mesh_shape = system_shape
 
     if mesh_shape != (1, 1):
         fabric_config = ttnn.FabricConfig.FABRIC_2D if mesh_shape[0] > 1 and mesh_shape[1] > 1 else ttnn.FabricConfig.FABRIC_1D

--- a/models/arcee-ai/Arcee-Spark/t3000/optimized/demo.log
+++ b/models/arcee-ai/Arcee-Spark/t3000/optimized/demo.log
@@ -1,65 +1,66 @@
-env TT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 /proj_sw/user_dev/moconnor/tt-metal/python_env/bin/python demo.py models/arcee-ai/Arcee-Spark/t3000/optimized/model.py
-2026-02-11 22:54:48.363 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+python demo.py models/arcee-ai/Arcee-Spark/t3000/optimized/model.py
+2026-02-17 10:31:10.678 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
+2026-02-17 10:31:11.290 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-17 10:31:11.321 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-17 10:31:11.331 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-17 10:31:11.408 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-17 10:31:11.471 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x202 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 10:31:11.531 | info     |             UMD | Harvesting masks for chip 2 tensix: 0xc dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 10:31:11.541 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 10:31:11.551 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 10:31:11.562 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 10:31:11.575 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x30 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 10:31:11.589 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 10:31:11.602 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x300 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 10:31:11.615 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 3, 1, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
+2026-02-17 10:31:11.615 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-17 10:31:11.615 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-17 10:31:11.623 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-17 10:31:11.624 | info     |             UMD | Mapped hugepage 0x200000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 10:31:11.625 | info     |             UMD | Mapped hugepage 0x140000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 10:31:11.626 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 10:31:11.626 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 10:31:11.627 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 10:31:11.628 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 10:31:11.629 | info     |             UMD | Mapped hugepage 0x42c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 10:31:11.630 | info     |             UMD | Mapped hugepage 0x4280000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 10:31:11.686 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:827)
+2026-02-17 10:31:11.686 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:804)
+2026-02-17 10:31:11.686 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-17 10:31:11.686 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-17 10:31:11.692 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-17 10:31:11.692 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-17 10:31:11.697 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 10:31:11.700 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 10:31:11.700 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 10:31:11.701 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 10:31:11.701 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 10:31:11.702 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 10:31:11.702 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 10:31:11.703 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 10:31:12.038 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
+2026-02-17 10:31:12.038 | info     |           Metal | Dispatch on FabricConfig::FABRIC_1D with 1 Command Queues
+ (device_manager.cpp:328)
+2026-02-17 10:31:12.060 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
+2026-02-17 10:31:12.476 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
+2026-02-17 10:31:12.477 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
+2026-02-17 10:31:12.717 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
+2026-02-17 10:31:12.717 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
+2026-02-17 10:31:12.720 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
+2026-02-17 10:31:12.726 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
+2026-02-17 10:31:12.729 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
+2026-02-17 10:31:12.734 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
+2026-02-17 10:31:12.734 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_1D (device_manager.cpp:409)
+2026-02-17 10:31:13.160 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
+2026-02-17 10:31:13.160 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
+2026-02-17 10:31:13.162 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
+2026-02-17 10:31:13.162 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
 Loading tokenizer: arcee-ai/Arcee-Spark
 Opening TT device...
-2026-02-11 22:54:48.977 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-11 22:54:49.007 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-02-11 22:54:49.016 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-11 22:54:49.087 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-11 22:54:49.150 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-11 22:54:49.201 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x208 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-11 22:54:49.212 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-11 22:54:49.223 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x41 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-11 22:54:49.233 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-11 22:54:49.246 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x208 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-11 22:54:49.259 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x300 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-11 22:54:49.273 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x42 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-11 22:54:49.287 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 1, 2, 3] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
-2026-02-11 22:54:49.287 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-02-11 22:54:49.287 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
-2026-02-11 22:54:49.295 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-02-11 22:54:49.296 | info     |             UMD | Mapped hugepage 0x340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-11 22:54:49.297 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-11 22:54:49.298 | info     |             UMD | Mapped hugepage 0x440000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-11 22:54:49.299 | info     |             UMD | Mapped hugepage 0x400000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-11 22:54:49.300 | info     |             UMD | Mapped hugepage 0x4240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-11 22:54:49.300 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-11 22:54:49.301 | info     |             UMD | Mapped hugepage 0x4340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-11 22:54:49.302 | info     |             UMD | Mapped hugepage 0x4300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-11 22:54:49.356 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:827)
-2026-02-11 22:54:49.356 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:804)
-2026-02-11 22:54:49.356 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
-2026-02-11 22:54:49.357 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
-2026-02-11 22:54:49.361 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
-2026-02-11 22:54:49.362 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-02-11 22:54:49.367 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-11 22:54:49.370 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-11 22:54:49.371 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-11 22:54:49.371 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-11 22:54:49.372 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-11 22:54:49.372 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-11 22:54:49.373 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-11 22:54:49.373 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-11 22:54:49.710 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
-2026-02-11 22:54:49.710 | info     |           Metal | Dispatch on FabricConfig::FABRIC_2D with 1 Command Queues
- (device_manager.cpp:328)
-2026-02-11 22:54:49.733 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
-2026-02-11 22:54:49.956 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
-2026-02-11 22:54:50.004 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
-2026-02-11 22:54:50.004 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
-2026-02-11 22:54:50.005 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
-2026-02-11 22:54:50.008 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
-2026-02-11 22:54:50.011 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
-2026-02-11 22:54:50.017 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
-2026-02-11 22:54:50.023 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
-2026-02-11 22:54:50.023 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_2D (device_manager.cpp:409)
-2026-02-11 22:54:50.176 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
-2026-02-11 22:54:50.176 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
-2026-02-11 22:54:50.178 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
-2026-02-11 22:54:50.179 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
+Requested mesh (1, 8) differs from discovered system mesh (2, 4); proceeding because requested device count fits within discovered capacity.
 Loading HuggingFace reference model on CPU: arcee-ai/Arcee-Spark
-Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]Loading checkpoint shards:  25%|██▌       | 1/4 [00:00<00:02,  1.36it/s]Loading checkpoint shards:  50%|█████     | 2/4 [00:01<00:01,  1.41it/s]Loading checkpoint shards:  75%|███████▌  | 3/4 [00:02<00:00,  1.53it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:02<00:00,  2.21it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:02<00:00,  1.85it/s]
+Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]Loading checkpoint shards:  25%|██▌       | 1/4 [00:00<00:02,  1.46it/s]Loading checkpoint shards:  50%|█████     | 2/4 [00:01<00:01,  1.47it/s]Loading checkpoint shards:  75%|███████▌  | 3/4 [00:01<00:00,  1.51it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:02<00:00,  2.17it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:02<00:00,  1.86it/s]
 Building TT model...
   Loading embeddings...
   Computing RoPE cache...
@@ -67,15 +68,16 @@ Building TT model...
 Running one warmup prefill+decode pass (kernel compile warmup)...
 TT demo (t3000)
 Model: arcee-ai/Arcee-Spark
-Mesh shape: 2x4
+Mesh shape: 1x8
 Prompt tokens: 56 | Generated tokens: 128
-TTFT: 72 ms | Decode: 17.6 t/s/u (126 tokens)
+TTFT: 64 ms | Decode: 21.5 t/s/u (126 tokens)
 
 Prompt:
 Journal entry, 1957: Tonight a tiny sphere called Sputnik 1 crossed the sky, beeping like a metronome for a new era. The neighbors gathered on the roof, listening and arguing about what comes next. I wrote in my notebook that
 
 Output:
- this might be the start of something big, the birth of a new space race. My friend said, "But there’s nothing there. It’s just a box with a clock in it, and it won’t break soon."
-Journal entry, 1971: Man has set foot on the moon. It’s a small, fragile rock that we’ve visited like a garden, but taken only a tiny fraction of its mass. In a few years, we’ll break that too, and then the Earth will be the only planet we’ve been to. Some think we won have to live on the moon. I wonder if it
-2026-02-11 22:57:31.064 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-02-11 22:57:31.064 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
+ this event would change everything. That it had already. That the future was here, but it’s not what we were told it would look like. That the future is now and it won’t be a mirror of the past.
+Journal entry, 2057: “Future’s now’, said my great-grandmother. I looked at the screen. It read 24:51. I’d already been up for 15 hours. I kept my eyes on the screen as the time, date, and temperature scrolled by. “Tomorrow’s Wednesday’. The time moved on. I didn’t see anything. I stared
+YT_METRICS={"mode": "tt_demo", "model": "arcee-ai/Arcee-Spark", "system": "t3000", "mesh_shape": [1, 8], "prompt_tokens": 56, "generated_tokens": 128, "ttft_ms": 63.54394555091858, "decode_tps_u": 21.501463513579907, "decode_tokens": 126, "max_seq_len": 2048}
+2026-02-17 10:33:55.283 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-17 10:33:55.283 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/arcee-ai/Arcee-Spark/t3000/optimized/eval.log
+++ b/models/arcee-ai/Arcee-Spark/t3000/optimized/eval.log
@@ -1,74 +1,76 @@
-env TT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 /proj_sw/user_dev/moconnor/tt-metal/python_env/bin/python eval.py models/arcee-ai/Arcee-Spark/t3000/optimized/model.py --model arcee-ai/Arcee-Spark --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 32768
-2026-02-11 22:57:47.979 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+python eval.py models/arcee-ai/Arcee-Spark/t3000/optimized/model.py --model arcee-ai/Arcee-Spark --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 32768
+2026-02-17 10:34:19.075 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
 Loading model module: /localdev/moconnor/ttnn_models/models/arcee-ai/Arcee-Spark/t3000/optimized/model.py
 Loading HuggingFace tokenizer...
 Loading HuggingFace reference model on CPU...
-Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]Loading checkpoint shards:  25%|██▌       | 1/4 [00:00<00:02,  1.44it/s]Loading checkpoint shards:  50%|█████     | 2/4 [00:01<00:01,  1.48it/s]Loading checkpoint shards:  75%|███████▌  | 3/4 [00:01<00:00,  1.60it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:02<00:00,  2.31it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:02<00:00,  1.94it/s]
-Generating reference tokens...
+Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]Loading checkpoint shards:  25%|██▌       | 1/4 [00:00<00:02,  1.44it/s]Loading checkpoint shards:  50%|█████     | 2/4 [00:01<00:01,  1.48it/s]Loading checkpoint shards:  75%|███████▌  | 3/4 [00:01<00:00,  1.55it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:02<00:00,  2.22it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:02<00:00,  1.89it/s]
 The following generation flags are not valid and may be ignored: ['temperature', 'top_p', 'top_k']. Set `TRANSFORMERS_VERBOSITY=info` for more details.
-Opening device (2x4)...
-2026-02-11 22:58:44.162 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-11 22:58:44.194 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-02-11 22:58:44.204 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-11 22:58:44.280 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-11 22:58:44.342 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-11 22:58:44.397 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x208 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-11 22:58:44.407 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-11 22:58:44.417 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x41 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-11 22:58:44.427 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-11 22:58:44.440 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x208 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-11 22:58:44.453 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x300 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-11 22:58:44.467 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x42 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-11 22:58:44.481 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 1, 2, 3] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
-2026-02-11 22:58:44.481 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-02-11 22:58:44.481 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
-2026-02-11 22:58:44.489 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-02-11 22:58:44.490 | info     |             UMD | Mapped hugepage 0x340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-11 22:58:44.491 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-11 22:58:44.492 | info     |             UMD | Mapped hugepage 0x440000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-11 22:58:44.492 | info     |             UMD | Mapped hugepage 0x400000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-11 22:58:44.493 | info     |             UMD | Mapped hugepage 0x4240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-11 22:58:44.494 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-11 22:58:44.495 | info     |             UMD | Mapped hugepage 0x4340000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-11 22:58:44.496 | info     |             UMD | Mapped hugepage 0x4300000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-11 22:58:44.547 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:827)
-2026-02-11 22:58:44.547 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:804)
-2026-02-11 22:58:44.548 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
-2026-02-11 22:58:44.548 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
-2026-02-11 22:58:44.553 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
-2026-02-11 22:58:44.553 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-02-11 22:58:44.558 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-11 22:58:44.561 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-11 22:58:44.561 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-11 22:58:44.562 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-11 22:58:44.562 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-11 22:58:44.564 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-11 22:58:44.564 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-11 22:58:44.565 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-11 22:58:44.902 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
-2026-02-11 22:58:44.902 | info     |           Metal | Dispatch on FabricConfig::FABRIC_2D with 1 Command Queues
+2026-02-17 10:35:21.607 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-17 10:35:21.639 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-17 10:35:21.649 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-17 10:35:21.723 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-17 10:35:21.784 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x202 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 10:35:21.839 | info     |             UMD | Harvesting masks for chip 2 tensix: 0xc dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 10:35:21.849 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 10:35:21.859 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 10:35:21.869 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 10:35:21.883 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x30 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 10:35:21.896 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 10:35:21.910 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x300 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 10:35:21.924 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 3, 1, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
+2026-02-17 10:35:21.924 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-17 10:35:21.924 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-17 10:35:21.932 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-17 10:35:21.933 | info     |             UMD | Mapped hugepage 0x200000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 10:35:21.934 | info     |             UMD | Mapped hugepage 0x140000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 10:35:21.935 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 10:35:21.935 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 10:35:21.936 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 10:35:21.937 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 10:35:21.938 | info     |             UMD | Mapped hugepage 0x42c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 10:35:21.939 | info     |             UMD | Mapped hugepage 0x4280000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 10:35:21.989 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:827)
+2026-02-17 10:35:21.989 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:804)
+2026-02-17 10:35:21.990 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-17 10:35:21.990 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-17 10:35:21.995 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-17 10:35:21.996 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-17 10:35:22.001 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 10:35:22.004 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 10:35:22.004 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 10:35:22.005 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 10:35:22.005 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 10:35:22.006 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 10:35:22.006 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 10:35:22.007 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 10:35:22.341 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
+2026-02-17 10:35:22.341 | info     |           Metal | Dispatch on FabricConfig::FABRIC_1D with 1 Command Queues
  (device_manager.cpp:328)
-2026-02-11 22:58:44.914 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
-2026-02-11 22:58:45.124 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
-2026-02-11 22:58:45.143 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
-2026-02-11 22:58:45.144 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
-2026-02-11 22:58:45.144 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
-2026-02-11 22:58:45.147 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
-2026-02-11 22:58:45.150 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
-2026-02-11 22:58:45.157 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
-2026-02-11 22:58:45.163 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
-2026-02-11 22:58:45.163 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_2D (device_manager.cpp:409)
-2026-02-11 22:58:45.283 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
-2026-02-11 22:58:45.283 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
-2026-02-11 22:58:45.284 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
-2026-02-11 22:58:45.285 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
+2026-02-17 10:35:22.355 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
+2026-02-17 10:35:22.514 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
+2026-02-17 10:35:22.514 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
+2026-02-17 10:35:22.558 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
+2026-02-17 10:35:22.559 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
+2026-02-17 10:35:22.562 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
+2026-02-17 10:35:22.568 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
+2026-02-17 10:35:22.571 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
+2026-02-17 10:35:22.577 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
+2026-02-17 10:35:22.577 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_1D (device_manager.cpp:409)
+2026-02-17 10:35:22.695 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
+2026-02-17 10:35:22.697 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
+2026-02-17 10:35:22.697 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
+2026-02-17 10:35:22.697 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
+Generating reference tokens...
+Opening device (1x8)...
+Requested mesh (1, 8) differs from discovered system mesh (2, 4); proceeding because requested device count fits within discovered capacity.
 Loading ttnn model...
   Loading embeddings...
   Computing RoPE cache...
   Loading 28 layers...
 Running teacher-forcing eval (100 tokens)...
-Top-1 accuracy: 90.00% (0.9000)
+Top-1 accuracy: 87.00% (0.8700)
 Top-5 accuracy: 100.00% (1.0000)
-2026-02-11 23:01:16.856 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-02-11 23:01:16.856 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
+YT_METRICS={"mode": "tt_eval", "model": "arcee-ai/Arcee-Spark", "top1": 0.87, "top5": 1.0, "top1_pct": 87.0, "top5_pct": 100.0, "total_tokens": 100, "max_new_tokens": 100, "max_seq_len": 32768}
+2026-02-17 10:37:55.730 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-17 10:37:55.730 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/arcee-ai/Arcee-Spark/t3000/optimized/model.py
+++ b/models/arcee-ai/Arcee-Spark/t3000/optimized/model.py
@@ -4,8 +4,8 @@
 """
 Simple Arcee-Spark (Qwen2) implementation in ttnn - 100% device execution on T3000.
 
-This is a minimal bringup on an 8-device (2x4 mesh) system with 4-way
-tensor parallel across the mesh columns and replication across rows.
+This is a minimal bringup on an 8-device (1x8 mesh) system with 8-way
+tensor parallel across the mesh columns.
 """
 
 import math
@@ -21,7 +21,7 @@ from transformers.modeling_outputs import CausalLMOutputWithPast
 
 TILE_SIZE = 32
 PAGED_BLOCK_SIZE = 64
-MESH_SHAPE = (2, 4)
+MESH_SHAPE = (1, 8)
 MESH_TOPOLOGY = ttnn.Topology.Linear
 MESH_NUM_LINKS = 1
 WEIGHT_LAYOUT = ttnn.TILE_LAYOUT
@@ -42,23 +42,17 @@ def pad_to_tile(x: int) -> int:
     return ((x + TILE_SIZE - 1) // TILE_SIZE) * TILE_SIZE
 
 
-def mesh_tp_axis(mesh_shape: tuple[int, int]) -> int:
-    """Return the mesh axis used for tensor parallel."""
-    if mesh_shape[1] > 1:
+def mesh_shape_to_axis(mesh_shape: tuple[int, int]) -> int:
+    """Return the mesh axis used for 1D tensor parallel."""
+    if mesh_shape[0] == 1 and mesh_shape[1] > 1:
         return 1
-    if mesh_shape[0] > 1:
+    if mesh_shape[1] == 1 and mesh_shape[0] > 1:
         return 0
-    raise ValueError(f"Expected mesh shape with at least one dimension > 1, got {mesh_shape}")
+    raise ValueError(f"Expected 1D mesh shape for T3000 optimized, got {mesh_shape}")
 
 
 def num_mesh_devices(mesh_shape: tuple[int, int]) -> int:
     return mesh_shape[0] * mesh_shape[1]
-
-
-def tp_size_for_mesh(mesh_shape: tuple[int, int]) -> int:
-    if mesh_shape[1] > 1:
-        return mesh_shape[1]
-    return mesh_shape[0]
 
 
 @dataclass
@@ -123,17 +117,24 @@ class ParallelConfig:
     vocab_composer: object
 
 
-def validate_parallel_config(config: ModelConfig, mesh_shape: tuple[int, int], tp_size: int) -> None:
-    if num_mesh_devices(mesh_shape) != 8:
+def validate_parallel_config(config: ModelConfig, mesh_shape: tuple[int, int], num_devices: int) -> None:
+    if mesh_shape != MESH_SHAPE:
+        raise ValueError(f"T3000 optimized expects mesh shape {MESH_SHAPE}, got {mesh_shape}")
+    if num_devices != 8:
         raise ValueError("T3000 model expects an 8-device mesh")
-    if config.num_attention_heads % tp_size != 0:
-        raise ValueError("num_attention_heads must divide evenly across tensor-parallel devices")
-    if config.num_key_value_heads % tp_size != 0:
-        raise ValueError("num_key_value_heads must divide evenly across tensor-parallel devices")
-    if config.hidden_size % tp_size != 0:
+    if config.hidden_size % num_devices != 0:
         raise ValueError("hidden_size must divide evenly across tensor-parallel devices")
-    if config.intermediate_size % tp_size != 0:
+    if config.intermediate_size % num_devices != 0:
         raise ValueError("intermediate_size must divide evenly across tensor-parallel devices")
+
+
+def padded_head_counts(config: ModelConfig, num_devices: int) -> tuple[int, int]:
+    if config.num_attention_heads % config.num_key_value_heads != 0:
+        raise ValueError("num_attention_heads must be a multiple of num_key_value_heads")
+    head_ratio = config.num_attention_heads // config.num_key_value_heads
+    padded_kv = ((config.num_key_value_heads + num_devices - 1) // num_devices) * num_devices
+    padded_heads = head_ratio * padded_kv
+    return padded_heads, padded_kv
 
 
 def all_reduce_tensor(x: ttnn.Tensor, parallel: ParallelConfig) -> ttnn.Tensor:
@@ -222,10 +223,14 @@ class Attention:
         parallel: ParallelConfig,
         paged_attention_config: PagedAttentionConfig,
         page_table: ttnn.Tensor,
+        padded_num_heads: int,
+        padded_num_kv_heads: int,
     ):
         self.parallel = parallel
-        self.n_heads = config.num_attention_heads
-        self.n_kv_heads = config.num_key_value_heads
+        self.n_heads = padded_num_heads
+        self.n_kv_heads = padded_num_kv_heads
+        self.n_heads_real = config.num_attention_heads
+        self.n_kv_heads_real = config.num_key_value_heads
         self.n_local_heads = self.n_heads // parallel.num_devices
         self.n_local_kv_heads = self.n_kv_heads // parallel.num_devices
         self.head_dim = config.head_dim
@@ -238,13 +243,21 @@ class Attention:
         self.sin_cache = sin_cache
 
         p = f"model.layers.{layer_idx}.self_attn."
-        self.q_proj = self._load_weight(state_dict[f"{p}q_proj.weight"], parallel.shard_width_mapper)
-        self.k_proj = self._load_weight(state_dict[f"{p}k_proj.weight"], parallel.shard_width_mapper)
-        self.v_proj = self._load_weight(state_dict[f"{p}v_proj.weight"], parallel.shard_width_mapper)
-        self.o_proj = self._load_weight(state_dict[f"{p}o_proj.weight"], parallel.shard_height_mapper)
-        self.q_bias = self._load_bias(state_dict[f"{p}q_proj.bias"], parallel.shard_width_mapper)
-        self.k_bias = self._load_bias(state_dict[f"{p}k_proj.bias"], parallel.shard_width_mapper)
-        self.v_bias = self._load_bias(state_dict[f"{p}v_proj.bias"], parallel.shard_width_mapper)
+        q_weight = self._pad_out_features(state_dict[f"{p}q_proj.weight"], self.n_heads * self.head_dim)
+        k_weight = self._pad_out_features(state_dict[f"{p}k_proj.weight"], self.n_kv_heads * self.head_dim)
+        v_weight = self._pad_out_features(state_dict[f"{p}v_proj.weight"], self.n_kv_heads * self.head_dim)
+        o_weight = self._pad_in_features(state_dict[f"{p}o_proj.weight"], self.n_heads * self.head_dim)
+        q_bias = self._pad_bias(state_dict[f"{p}q_proj.bias"], self.n_heads * self.head_dim)
+        k_bias = self._pad_bias(state_dict[f"{p}k_proj.bias"], self.n_kv_heads * self.head_dim)
+        v_bias = self._pad_bias(state_dict[f"{p}v_proj.bias"], self.n_kv_heads * self.head_dim)
+
+        self.q_proj = self._load_weight(q_weight, parallel.shard_width_mapper)
+        self.k_proj = self._load_weight(k_weight, parallel.shard_width_mapper)
+        self.v_proj = self._load_weight(v_weight, parallel.shard_width_mapper)
+        self.o_proj = self._load_weight(o_weight, parallel.shard_height_mapper)
+        self.q_bias = self._load_bias(q_bias, parallel.shard_width_mapper)
+        self.k_bias = self._load_bias(k_bias, parallel.shard_width_mapper)
+        self.v_bias = self._load_bias(v_bias, parallel.shard_width_mapper)
 
         cache_shape = (
             self.paged_attention_config.max_num_blocks,
@@ -289,6 +302,29 @@ class Attention:
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             mesh_mapper=mesh_mapper,
         )
+
+    def _pad_out_features(self, w: torch.Tensor, padded_out: int) -> torch.Tensor:
+        if w.shape[0] > padded_out:
+            raise ValueError("padded_out must be >= weight out features")
+        if w.shape[0] == padded_out:
+            return w
+        pad_rows = padded_out - w.shape[0]
+        return torch.nn.functional.pad(w, (0, 0, 0, pad_rows))
+
+    def _pad_in_features(self, w: torch.Tensor, padded_in: int) -> torch.Tensor:
+        if w.shape[1] > padded_in:
+            raise ValueError("padded_in must be >= weight in features")
+        if w.shape[1] == padded_in:
+            return w
+        pad_cols = padded_in - w.shape[1]
+        return torch.nn.functional.pad(w, (0, pad_cols))
+
+    def _pad_bias(self, b: torch.Tensor, padded_out: int) -> torch.Tensor:
+        if b.shape[0] > padded_out:
+            raise ValueError("padded_out must be >= bias size")
+        if b.shape[0] == padded_out:
+            return b
+        return torch.nn.functional.pad(b, (0, padded_out - b.shape[0]))
 
     def __call__(
         self,
@@ -470,6 +506,8 @@ class DecoderLayer:
         parallel: ParallelConfig,
         paged_attention_config: PagedAttentionConfig,
         page_table: ttnn.Tensor,
+        padded_num_heads: int,
+        padded_num_kv_heads: int,
     ):
         p = f"model.layers.{layer_idx}."
         self.attn_norm = RMSNorm(state_dict[f"{p}input_layernorm.weight"], config.rms_norm_eps, parallel)
@@ -483,6 +521,8 @@ class DecoderLayer:
             parallel,
             paged_attention_config,
             page_table,
+            padded_num_heads,
+            padded_num_kv_heads,
         )
         self.mlp = MLP(layer_idx, state_dict, parallel)
 
@@ -541,22 +581,25 @@ class TtnnQwen2ForCausalLM(torch.nn.Module, GenerationMixin):
         self.register_buffer("_torch_dummy", torch.empty(0, dtype=torch.float32), persistent=False)
 
         mesh_shape = tuple(tt_device.shape)
-        tp_size = tp_size_for_mesh(mesh_shape)
-        mesh_axis = mesh_tp_axis(mesh_shape)
-        validate_parallel_config(self.tt_config, mesh_shape, tp_size)
+        num_devices = num_mesh_devices(mesh_shape)
+        mesh_axis = mesh_shape_to_axis(mesh_shape)
+        validate_parallel_config(self.tt_config, mesh_shape, num_devices)
+        padded_num_heads, padded_num_kv_heads = padded_head_counts(self.tt_config, num_devices)
+        self.padded_num_heads = padded_num_heads
+        self.padded_num_kv_heads = padded_num_kv_heads
 
         self.parallel = ParallelConfig(
             mesh_device=tt_device,
             mesh_shape=mesh_shape,
-            num_devices=tp_size,
+            num_devices=num_devices,
             mesh_axis=mesh_axis,
             num_links=MESH_NUM_LINKS,
             topology=MESH_TOPOLOGY,
             replicate_mapper=ttnn.ReplicateTensorToMesh(tt_device),
-            shard_width_mapper=ttnn.ShardTensor2dMesh(tt_device, mesh_shape, dims=(None, 3)),
-            shard_height_mapper=ttnn.ShardTensor2dMesh(tt_device, mesh_shape, dims=(None, 2)),
-            shard_kv_mapper=ttnn.ShardTensor2dMesh(tt_device, mesh_shape, dims=(None, 1)),
-            vocab_composer=ttnn.ConcatMesh2dToTensor(tt_device, mesh_shape, dims=(0, 3)),
+            shard_width_mapper=ttnn.ShardTensorToMesh(tt_device, dim=3),
+            shard_height_mapper=ttnn.ShardTensorToMesh(tt_device, dim=2),
+            shard_kv_mapper=ttnn.ShardTensorToMesh(tt_device, dim=1),
+            vocab_composer=ttnn.ConcatMeshToTensor(tt_device, dim=3),
         )
 
         state_dict = hf_model.state_dict()
@@ -611,7 +654,7 @@ class TtnnQwen2ForCausalLM(torch.nn.Module, GenerationMixin):
             memory_config=ttnn.L1_MEMORY_CONFIG,
             mesh_mapper=self.parallel.replicate_mapper,
         )
-        self.decode_rope_seq = (self.tt_config.num_attention_heads // self.parallel.num_devices) * TILE_SIZE
+        self.decode_rope_seq = (self.padded_num_heads // self.parallel.num_devices) * TILE_SIZE
         self.decode_pos_buffer = ttnn.from_torch(
             torch.zeros((TILE_SIZE,), dtype=torch.int32),
             dtype=ttnn.int32,
@@ -651,6 +694,8 @@ class TtnnQwen2ForCausalLM(torch.nn.Module, GenerationMixin):
                 self.parallel,
                 self.paged_attention_config,
                 self.page_table,
+                self.padded_num_heads,
+                self.padded_num_kv_heads,
             )
             for i in range(self.tt_config.num_hidden_layers)
         ]
@@ -851,8 +896,6 @@ class TtnnQwen2ForCausalLM(torch.nn.Module, GenerationMixin):
         logits, seq_len, padded_seq, past = self._forward_device_logits(input_ids, past_key_values, use_cache)
 
         logits_torch = self._logits_to_torch(logits)
-        if self.parallel.mesh_shape[0] > 1:
-            logits_torch = logits_torch.reshape(self.parallel.mesh_shape[0], batch, padded_seq, -1)[0]
         logits_torch = logits_torch.reshape(batch, padded_seq, -1)[:, :seq_len, :]
 
         if seq_len > 1 or not self.use_decode_trace:
@@ -883,8 +926,6 @@ class TtnnQwen2ForCausalLM(torch.nn.Module, GenerationMixin):
         self._pos = start_pos + seq_len
 
         logits_torch = self._logits_to_torch(logits)
-        if self.parallel.mesh_shape[0] > 1:
-            logits_torch = logits_torch.reshape(self.parallel.mesh_shape[0], batch, 1, -1)[0]
         logits_torch = logits_torch.reshape(batch, 1, -1)[:, 0, :].float()
         ttnn.deallocate(logits)
 


### PR DESCRIPTION
## Summary
- Ported `models/arcee-ai/Arcee-Spark/t3000/optimized/model.py` from a `2x4` mesh layout to `1x8` (`MESH_SHAPE = (1, 8)`) with tensor parallel size 8.
- Updated mesh-axis/sharding/composition paths for 1D mesh usage and kept architecture/dtypes/paged KV cache behavior intact.
- Added padding for Q/KV head projections so TP=8 sharding remains valid for this model config.
- Updated device mesh validation logic in `device_utils.py` to allow a requested mesh shape that differs from auto-discovered shape when total device count matches (needed for requesting `1x8` on systems discovered as `2x4`).
- Updated `MODELS.md` t3000 metrics row and added refreshed `demo.log` / `eval.log` under `models/arcee-ai/Arcee-Spark/t3000/optimized/`.

## Validation
- `python demo.py models/arcee-ai/Arcee-Spark/t3000/optimized/model.py`
  - TTFT: `64 ms`
  - Decode: `21.5 t/s/u`
- `python eval.py models/arcee-ai/Arcee-Spark/t3000/optimized/model.py --model arcee-ai/Arcee-Spark --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 32768`
  - Top-1: `87.00%`
  - Top-5: `100.00%`

Closes #196
