### PR TITLE
models/google/gemma-3-4b-it/t3000/functional (1x8 mesh port)

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -28,7 +28,7 @@ Note: Keep the table columns padded with spaces and right-justify numeric cells 
 | Qwen/Qwen3-0.6B                     |  t3000   | functional |   98% |  100% |  229ms |   6.2 |   40960 |
 | google/gemma-3-4b-it                |   n150   | functional |   92% |  100% |   98ms |  13.9 |   40960 |
 | google/gemma-3-4b-it                |   n300   | functional |   94% |  100% |  535ms |   3.2 |   40960 |
-| google/gemma-3-4b-it                |  t3000   | functional |   92% |  100% |  330ms |   4.7 |   40960 |
+| google/gemma-3-4b-it                |  t3000   | functional |   92% |  100% |  333ms |   4.9 |   40960 |
 | microsoft/Phi-3-mini-128k-instruct  |   n150   | functional |   92% |   99% |   80ms |  13.7 |   12288 |
 | microsoft/Phi-3-mini-128k-instruct  |   n300   | functional |   90% |  100% |  193ms |   6.7 |   12288 |
 | microsoft/Phi-3-mini-128k-instruct  |  t3000   | functional |   90% |  100% |  184ms |   6.8 |   12288 |

--- a/models/google/gemma-3-4b-it/t3000/functional/demo.log
+++ b/models/google/gemma-3-4b-it/t3000/functional/demo.log
@@ -1,83 +1,87 @@
-CMD: env HF_HOME=/proj_sw/user_dev/moconnor/hf-cache TT_VISIBLE_DEVICES=0,1,2,3 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto TT_METAL_CACHE=/tmp/tt-metal-cache TT_METAL_INSPECTOR_LOG_PATH=/tmp/tt-metal-inspector TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT=0 python demo.py models/google/gemma-3-4b-it/t3000/functional/model.py --max_seq_len 40960
-2026-02-09 17:36:13.316 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+CMD: env HF_HOME=/proj_sw/user_dev/moconnor/hf-cache TT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto TT_METAL_CACHE=/tmp/tt-metal-cache TT_METAL_INSPECTOR_LOG_PATH=/tmp/tt-metal-inspector TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT=0 python demo.py models/google/gemma-3-4b-it/t3000/functional/model.py --max_seq_len 40960
+2026-02-17 11:33:32.305 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
-2026-02-09 17:36:14.875 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 17:36:14.908 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-02-09 17:36:14.918 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 17:36:14.990 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 17:36:15.053 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x202 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 17:36:15.111 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 17:36:15.121 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 17:36:15.132 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 17:36:15.142 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 17:36:15.155 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 17:36:15.169 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 17:36:15.182 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x5 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 17:36:15.195 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 3, 1, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
-2026-02-09 17:36:15.195 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-02-09 17:36:15.195 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
-2026-02-09 17:36:15.205 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-02-09 17:36:15.206 | info     |             UMD | Mapped hugepage 0x240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 17:36:15.206 | info     |             UMD | Mapped hugepage 0x200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 17:36:15.207 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 17:36:15.208 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 17:36:15.209 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 17:36:15.210 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 17:36:15.211 | info     |             UMD | Mapped hugepage 0x42c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 17:36:15.211 | info     |             UMD | Mapped hugepage 0x4280000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 17:36:15.262 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto (metal_context.cpp:822)
-2026-02-09 17:36:15.263 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
-2026-02-09 17:36:15.268 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
-2026-02-09 17:36:15.268 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-02-09 17:36:15.272 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 17:36:15.275 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 17:36:15.275 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 17:36:15.276 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 17:36:15.276 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 17:36:15.277 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 17:36:15.277 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 17:36:15.277 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 17:36:15.593 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
-2026-02-09 17:36:15.593 | info     |           Metal | Dispatch on FabricConfig::FABRIC_2D with 1 Command Queues
+2026-02-17 11:33:33.829 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-17 11:33:33.858 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-17 11:33:33.869 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-17 11:33:33.945 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-17 11:33:34.007 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x202 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 11:33:34.067 | info     |             UMD | Harvesting masks for chip 2 tensix: 0xc dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 11:33:34.077 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 11:33:34.087 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 11:33:34.098 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 11:33:34.112 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x30 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 11:33:34.126 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 11:33:34.139 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x300 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 11:33:34.153 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 3, 1, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
+2026-02-17 11:33:34.153 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-17 11:33:34.153 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-17 11:33:34.163 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-17 11:33:34.163 | info     |             UMD | Mapped hugepage 0x200000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 11:33:34.164 | info     |             UMD | Mapped hugepage 0x140000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 11:33:34.165 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 11:33:34.166 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 11:33:34.167 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 11:33:34.168 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 11:33:34.169 | info     |             UMD | Mapped hugepage 0x42c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 11:33:34.169 | info     |             UMD | Mapped hugepage 0x4280000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 11:33:34.224 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto (metal_context.cpp:822)
+2026-02-17 11:33:34.225 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-17 11:33:34.231 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-17 11:33:34.231 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-17 11:33:34.238 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 11:33:34.242 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 11:33:34.242 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 11:33:34.242 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 11:33:34.242 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 11:33:34.243 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 11:33:34.243 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 11:33:34.243 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 11:33:34.568 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
+2026-02-17 11:33:34.568 | info     |           Metal | Dispatch on FabricConfig::FABRIC_1D with 1 Command Queues
  (device_manager.cpp:328)
-2026-02-09 17:36:15.608 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
-2026-02-09 17:36:15.780 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
-2026-02-09 17:36:15.780 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
-2026-02-09 17:36:15.814 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
-2026-02-09 17:36:15.814 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
-2026-02-09 17:36:15.818 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
-2026-02-09 17:36:15.823 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
-2026-02-09 17:36:15.826 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
-2026-02-09 17:36:15.833 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
-2026-02-09 17:36:15.833 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_2D (device_manager.cpp:409)
-2026-02-09 17:36:15.954 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
-2026-02-09 17:36:15.956 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
-2026-02-09 17:36:15.956 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
-2026-02-09 17:36:15.956 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
+2026-02-17 11:33:34.582 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
+2026-02-17 11:33:34.762 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
+2026-02-17 11:33:34.763 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
+2026-02-17 11:33:34.763 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
+2026-02-17 11:33:34.764 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
+2026-02-17 11:33:34.766 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
+2026-02-17 11:33:34.772 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
+2026-02-17 11:33:34.775 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
+2026-02-17 11:33:34.781 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
+2026-02-17 11:33:34.781 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_1D (device_manager.cpp:409)
+2026-02-17 11:33:34.873 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
+2026-02-17 11:33:34.874 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
+2026-02-17 11:33:34.875 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
+2026-02-17 11:33:34.875 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
 Loading tokenizer: google/gemma-3-4b-it
 Opening TT device...
 Loading HuggingFace reference model on CPU: google/gemma-3-4b-it
-Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:05<00:05,  5.64s/it]Loading checkpoint shards: 100%|██████████| 2/2 [00:09<00:00,  4.73s/it]Loading checkpoint shards: 100%|██████████| 2/2 [00:09<00:00,  4.87s/it]
+Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:00<00:00,  1.26it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.45it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.42it/s]
 Building TT model...
   Loading embeddings...
   Computing RoPE cache...
   Loading 34 layers...
+Running one warmup prefill+decode pass (kernel compile warmup)...
 TT demo (t3000)
 Model: google/gemma-3-4b-it
-Mesh shape: 2x4
+Mesh shape: 1x8
 Prompt tokens: 54 | Generated tokens: 128
-TTFT: 330 ms | Decode: 4.7 t/s/u (127 tokens)
+TTFT: 333 ms | Decode: 4.9 t/s/u (127 tokens)
 
 Prompt:
 Journal entry, 1957: Tonight a tiny sphere called Sputnik 1 crossed the sky, beeping like a metronome for a new era. The neighbors gathered on the roof, listening and arguing about what comes next. I wrote in my notebook that
 
 Output:
- this "satellite" was proof of something new, something powerful, and maybe, just maybe, a little frightening. 
+ "a new age of exploration." It sounds grand, but I'm mostly wondering if I'll ever be able to afford a new radio.
 
 ---
 
-I've been thinking about that night ever since. Fifty years. Fifty years since a tiny, simple sphere whispered into the void, announcing the dawn of the Space Age. It feels like a lifetime, and yet, it's just a blink.
+Today's Prompt: "The first satellite launched into orbit was Sputnik 1 in 1957. Write a journal entry from the perspective of someone who is not a scientist or engineer, but someone who witnessed this historic event."
 
-The world has changed… profoundly. We’ve walked on the moon, sent probes to Mars, unravelled the secrets of the atom. We’ve talked to each other across the globe in an instant, built cities that scrape the sky,
-2026-02-09 17:39:31.727 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-02-09 17:39:31.727 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
+---
+
+I've tried to capture the feeling of a regular person, overwhelmed and slightly bewildered by a monumental event, while also grounding it in everyday concerns. I've focused on the emotional response and the immediate, personal impact
+YT_METRICS={"mode": "tt_demo", "model": "google/gemma-3-4b-it", "system": "t3000", "mesh_shape": [1, 8], "prompt_tokens": 54, "generated_tokens": 128, "ttft_ms": 333.43490585684776, "decode_tps_u": 4.941014136091272, "decode_tokens": 127, "max_seq_len": 40960}
+2026-02-17 11:36:31.714 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-17 11:36:31.714 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/google/gemma-3-4b-it/t3000/functional/eval.log
+++ b/models/google/gemma-3-4b-it/t3000/functional/eval.log
@@ -1,66 +1,66 @@
-CMD: env HF_HOME=/proj_sw/user_dev/moconnor/hf-cache TT_VISIBLE_DEVICES=0,1,2,3 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto TT_METAL_CACHE=/tmp/tt-metal-cache TT_METAL_INSPECTOR_LOG_PATH=/tmp/tt-metal-inspector TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT=0 python eval.py models/google/gemma-3-4b-it/t3000/functional/model.py --model google/gemma-3-4b-it --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 40960
-2026-02-09 17:40:27.325 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+CMD: env HF_HOME=/proj_sw/user_dev/moconnor/hf-cache TT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto TT_METAL_CACHE=/tmp/tt-metal-cache TT_METAL_INSPECTOR_LOG_PATH=/tmp/tt-metal-inspector TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT=0 python eval.py models/google/gemma-3-4b-it/t3000/functional/model.py --model google/gemma-3-4b-it --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 40960
+2026-02-17 11:36:57.866 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
 Loading model module: /localdev/moconnor/ttnn_models/models/google/gemma-3-4b-it/t3000/functional/model.py
 Loading HuggingFace tokenizer...
 Loading HuggingFace reference model on CPU...
-Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:00<00:00,  1.07it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.33it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.29it/s]
+Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:00<00:00,  1.31it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.60it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.55it/s]
 The following generation flags are not valid and may be ignored: ['top_p', 'top_k']. Set `TRANSFORMERS_VERBOSITY=info` for more details.
-2026-02-09 17:41:24.274 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 17:41:24.305 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-02-09 17:41:24.314 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 17:41:24.390 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
-2026-02-09 17:41:24.451 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x202 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 17:41:24.510 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 17:41:24.520 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 17:41:24.530 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 17:41:24.541 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 17:41:24.554 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 17:41:24.567 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 17:41:24.581 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x5 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-09 17:41:24.594 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 3, 1, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
-2026-02-09 17:41:24.594 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-02-09 17:41:24.594 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
-2026-02-09 17:41:24.603 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-02-09 17:41:24.604 | info     |             UMD | Mapped hugepage 0x240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 17:41:24.605 | info     |             UMD | Mapped hugepage 0x200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 17:41:24.606 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 17:41:24.606 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 17:41:24.607 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 17:41:24.608 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 17:41:24.609 | info     |             UMD | Mapped hugepage 0x42c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 17:41:24.610 | info     |             UMD | Mapped hugepage 0x4280000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-09 17:41:24.662 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto (metal_context.cpp:822)
-2026-02-09 17:41:24.663 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
-2026-02-09 17:41:24.668 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
-2026-02-09 17:41:24.668 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-02-09 17:41:24.676 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 17:41:24.680 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 17:41:24.680 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 17:41:24.680 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 17:41:24.680 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 17:41:24.681 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 17:41:24.681 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 17:41:24.681 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-09 17:41:25.003 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
-2026-02-09 17:41:25.003 | info     |           Metal | Dispatch on FabricConfig::FABRIC_2D with 1 Command Queues
+2026-02-17 11:37:55.466 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-17 11:37:55.498 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-17 11:37:55.508 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-17 11:37:55.585 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-17 11:37:55.648 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x202 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 11:37:55.711 | info     |             UMD | Harvesting masks for chip 2 tensix: 0xc dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 11:37:55.722 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 11:37:55.732 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 11:37:55.743 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 11:37:55.756 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x30 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 11:37:55.770 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 11:37:55.783 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x300 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 11:37:55.797 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 3, 1, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
+2026-02-17 11:37:55.797 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-17 11:37:55.797 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-17 11:37:55.807 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-17 11:37:55.808 | info     |             UMD | Mapped hugepage 0x200000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 11:37:55.808 | info     |             UMD | Mapped hugepage 0x140000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 11:37:55.810 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 11:37:55.810 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 11:37:55.811 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 11:37:55.812 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 11:37:55.813 | info     |             UMD | Mapped hugepage 0x42c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 11:37:55.814 | info     |             UMD | Mapped hugepage 0x4280000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 11:37:55.867 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto (metal_context.cpp:822)
+2026-02-17 11:37:55.868 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-17 11:37:55.873 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-17 11:37:55.874 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-17 11:37:55.881 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 11:37:55.884 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 11:37:55.884 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 11:37:55.885 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 11:37:55.885 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 11:37:55.885 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 11:37:55.886 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 11:37:55.886 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 11:37:56.209 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
+2026-02-17 11:37:56.209 | info     |           Metal | Dispatch on FabricConfig::FABRIC_1D with 1 Command Queues
  (device_manager.cpp:328)
-2026-02-09 17:41:25.019 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
-2026-02-09 17:41:25.166 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
-2026-02-09 17:41:25.167 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
-2026-02-09 17:41:25.201 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
-2026-02-09 17:41:25.201 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
-2026-02-09 17:41:25.204 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
-2026-02-09 17:41:25.210 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
-2026-02-09 17:41:25.214 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
-2026-02-09 17:41:25.220 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
-2026-02-09 17:41:25.220 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_2D (device_manager.cpp:409)
-2026-02-09 17:41:25.315 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
-2026-02-09 17:41:25.316 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
-2026-02-09 17:41:25.318 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
-2026-02-09 17:41:25.318 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
+2026-02-17 11:37:56.225 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
+2026-02-17 11:37:56.342 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
+2026-02-17 11:37:56.343 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
+2026-02-17 11:37:56.389 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
+2026-02-17 11:37:56.390 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
+2026-02-17 11:37:56.392 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
+2026-02-17 11:37:56.398 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
+2026-02-17 11:37:56.401 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
+2026-02-17 11:37:56.407 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
+2026-02-17 11:37:56.407 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_1D (device_manager.cpp:409)
+2026-02-17 11:37:56.508 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
+2026-02-17 11:37:56.508 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
+2026-02-17 11:37:56.508 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
+2026-02-17 11:37:56.509 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
 Generating reference tokens...
-Opening device (2x4)...
+Opening device (1x8)...
 Loading ttnn model...
   Loading embeddings...
   Computing RoPE cache...
@@ -68,5 +68,6 @@ Loading ttnn model...
 Running teacher-forcing eval (100 tokens)...
 Top-1 accuracy: 92.00% (0.9200)
 Top-5 accuracy: 100.00% (1.0000)
-2026-02-09 17:43:58.438 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-02-09 17:43:58.438 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
+YT_METRICS={"mode": "tt_eval", "model": "google/gemma-3-4b-it", "top1": 0.92, "top5": 1.0, "top1_pct": 92.0, "top5_pct": 100.0, "total_tokens": 100, "max_new_tokens": 100, "max_seq_len": 40960}
+2026-02-17 11:40:28.008 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-17 11:40:28.008 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)


### PR DESCRIPTION
Summary
- Update `MODELS.md` for the google/gemma-3-4b-it t3000 functional 1x8 mesh port entry.
- Refresh `demo.log` and `eval.log` for `models/google/gemma-3-4b-it/t3000/functional`.
- Clear files under `generated/` from the working tree.

Fixes #197
