### PR TITLE
models/arcee-ai/AFM-4.5B t3000 functional: update MODELS and logs

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -13,7 +13,7 @@ Note: Keep the table columns padded with spaces and right-justify numeric cells 
 | arcee-ai/Arcee-Spark                |  t3000   | functional |   90% |  100% |  343ms |   4.9 |   32768 |
 | arcee-ai/AFM-4.5B                   |   n150   | functional |   98% |  100% |   72ms |  17.2 |   65536 |
 | arcee-ai/AFM-4.5B                   |   n300   | functional |   97% |  100% |  283ms |   5.6 |   65536 |
-| arcee-ai/AFM-4.5B                   |  t3000   | functional |   98% |  100% |  183ms |   7.5 |   65536 |
+| arcee-ai/AFM-4.5B                   |  t3000   | functional |   98% |  100% |  182ms |   7.6 |   65536 |
 | humain-ai/ALLaM-7B-Instruct-preview |   n150   | functional |   97% |  100% |   76ms |  14.9 |    4096 |
 | humain-ai/ALLaM-7B-Instruct-preview |   n300   | functional |   97% |  100% |  184ms |   7.9 |    4096 |
 | humain-ai/ALLaM-7B-Instruct-preview |  t3000   | functional |   95% |  100% |  127ms |   9.1 |    4096 |

--- a/models/arcee-ai/AFM-4.5B/t3000/functional/demo.log
+++ b/models/arcee-ai/AFM-4.5B/t3000/functional/demo.log
@@ -1,64 +1,66 @@
-env TT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto PYTHONUNBUFFERED=1 python -u demo.py models/arcee-ai/AFM-4.5B/t3000/functional/model.py
-2026-02-17 11:01:38.568 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+python demo.py models/arcee-ai/AFM-4.5B/t3000/functional/model.py
+2026-02-17 12:03:24.814 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
+2026-02-17 12:03:25.686 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-17 12:03:25.718 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-17 12:03:25.727 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-17 12:03:25.804 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-17 12:03:25.867 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x202 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:03:25.927 | info     |             UMD | Harvesting masks for chip 2 tensix: 0xc dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:03:25.938 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:03:25.948 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:03:25.959 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:03:25.973 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x30 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:03:25.987 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:03:26.000 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x300 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:03:26.014 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 3, 1, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
+2026-02-17 12:03:26.014 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-17 12:03:26.014 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-17 12:03:26.022 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-17 12:03:26.023 | info     |             UMD | Mapped hugepage 0x200000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:03:26.023 | info     |             UMD | Mapped hugepage 0x140000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:03:26.024 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:03:26.025 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:03:26.026 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:03:26.027 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:03:26.028 | info     |             UMD | Mapped hugepage 0x42c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:03:26.028 | info     |             UMD | Mapped hugepage 0x4280000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:03:26.081 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:827)
+2026-02-17 12:03:26.081 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:804)
+2026-02-17 12:03:26.082 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-17 12:03:26.082 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-17 12:03:26.088 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-17 12:03:26.089 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-17 12:03:26.096 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:03:26.099 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:03:26.100 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:03:26.100 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:03:26.101 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:03:26.101 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:03:26.102 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:03:26.102 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:03:26.460 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
+2026-02-17 12:03:26.460 | info     |           Metal | Dispatch on FabricConfig::FABRIC_1D with 1 Command Queues
+ (device_manager.cpp:328)
+2026-02-17 12:03:26.475 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
+2026-02-17 12:03:26.730 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
+2026-02-17 12:03:26.731 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
+2026-02-17 12:03:26.732 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
+2026-02-17 12:03:26.732 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
+2026-02-17 12:03:26.735 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
+2026-02-17 12:03:26.740 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
+2026-02-17 12:03:26.743 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
+2026-02-17 12:03:26.749 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
+2026-02-17 12:03:26.749 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_1D (device_manager.cpp:409)
+2026-02-17 12:03:26.874 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
+2026-02-17 12:03:26.875 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
+2026-02-17 12:03:26.876 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
+2026-02-17 12:03:26.877 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
 Loading tokenizer: arcee-ai/AFM-4.5B
 Opening TT device...
-2026-02-17 11:01:39.326 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 11:01:39.357 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-02-17 11:01:39.366 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 11:01:39.441 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 11:01:39.503 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 11:01:39.560 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 11:01:39.571 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 11:01:39.582 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 11:01:39.593 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 11:01:39.606 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 11:01:39.620 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 11:01:39.634 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 11:01:39.648 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 1, 3, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
-2026-02-17 11:01:39.648 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-02-17 11:01:39.648 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
-2026-02-17 11:01:39.657 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-02-17 11:01:39.658 | info     |             UMD | Mapped hugepage 0x280000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 11:01:39.658 | info     |             UMD | Mapped hugepage 0x240000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 11:01:39.659 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 11:01:39.660 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 11:01:39.661 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 11:01:39.662 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 11:01:39.662 | info     |             UMD | Mapped hugepage 0x4240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 11:01:39.663 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 11:01:39.716 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto (metal_context.cpp:822)
-2026-02-17 11:01:39.717 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
-Requested mesh (1, 8) reshapes discovered system mesh (2, 4); continuing because device count matches.
-2026-02-17 11:01:39.724 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
-2026-02-17 11:01:39.724 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-02-17 11:01:39.731 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 11:01:39.734 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 11:01:39.735 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 11:01:39.735 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 11:01:39.736 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 11:01:39.736 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 11:01:39.737 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 11:01:39.737 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 11:01:40.077 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
-2026-02-17 11:01:40.077 | info     |           Metal | Dispatch on FabricConfig::FABRIC_1D with 1 Command Queues
- (device_manager.cpp:328)
-2026-02-17 11:01:40.091 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
-2026-02-17 11:01:40.267 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
-2026-02-17 11:01:40.320 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
-2026-02-17 11:01:40.320 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
-2026-02-17 11:01:40.321 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
-2026-02-17 11:01:40.324 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
-2026-02-17 11:01:40.326 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
-2026-02-17 11:01:40.332 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
-2026-02-17 11:01:40.339 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
-2026-02-17 11:01:40.339 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_1D (device_manager.cpp:409)
-2026-02-17 11:01:40.467 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
-2026-02-17 11:01:40.467 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
-2026-02-17 11:01:40.467 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
-2026-02-17 11:01:40.469 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
+Requested 1D mesh (1, 8) exceeds discovered mesh dimensions (2, 4); continuing because both shapes use the same number of devices.
 Loading HuggingFace reference model on CPU: arcee-ai/AFM-4.5B
-Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:00<00:00,  1.60it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.73it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.71it/s]
+Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:00<00:00,  1.50it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.55it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.54it/s]
 Building TT model...
   Loading embeddings...
   Computing RoPE cache...
@@ -68,7 +70,7 @@ TT demo (t3000)
 Model: arcee-ai/AFM-4.5B
 Mesh shape: 1x8
 Prompt tokens: 55 | Generated tokens: 128
-TTFT: 183 ms | Decode: 7.5 t/s/u (127 tokens)
+TTFT: 182 ms | Decode: 7.6 t/s/u (127 tokens)
 
 Prompt:
 Journal entry, 1957: Tonight a tiny sphere called Sputnik 1 crossed the sky, beeping like a metronome for a new era. The neighbors gathered on the roof, listening and arguing about what comes next. I wrote in my notebook that
@@ -77,6 +79,6 @@ Output:
  we might be entering the Age of the Great Inversion. Here's what I mean by that: for the first time in human history, the rich, the educated, the technologically connected have the most to lose from change, and the poor, the rural, the technologically isolated are most likely to benefit. It's a reversal from the patterns of the past two centuries, during which progress was an engine of equality. To understand the future of the Great Inversion, it's necessary to understand the history of the Great Compression.
 
 Journal entry, 1947: A year when many things were just beginning, and when the world was
-YT_METRICS={"mode": "tt_demo", "model": "arcee-ai/AFM-4.5B", "system": "t3000", "mesh_shape": [1, 8], "prompt_tokens": 55, "generated_tokens": 128, "ttft_ms": 182.53185198409483, "decode_tps_u": 7.523515377344315, "decode_tokens": 127, "max_seq_len": 2048}
-2026-02-17 11:03:56.800 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-02-17 11:03:56.800 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
+YT_METRICS={"mode": "tt_demo", "model": "arcee-ai/AFM-4.5B", "system": "t3000", "mesh_shape": [1, 8], "prompt_tokens": 55, "generated_tokens": 128, "ttft_ms": 182.16144479811192, "decode_tps_u": 7.5558490604694555, "decode_tokens": 127, "max_seq_len": 2048}
+2026-02-17 12:05:46.892 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-17 12:05:46.892 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/arcee-ai/AFM-4.5B/t3000/functional/eval.log
+++ b/models/arcee-ai/AFM-4.5B/t3000/functional/eval.log
@@ -1,66 +1,68 @@
-env TT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto PYTHONUNBUFFERED=1 python -u eval.py models/arcee-ai/AFM-4.5B/t3000/functional/model.py --model arcee-ai/AFM-4.5B --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 65536
-2026-02-17 11:04:27.867 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+python eval.py models/arcee-ai/AFM-4.5B/t3000/functional/model.py --model arcee-ai/AFM-4.5B --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 65536
+2026-02-17 12:06:06.883 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
 Loading model module: /localdev/moconnor/ttnn_models/models/arcee-ai/AFM-4.5B/t3000/functional/model.py
 Loading HuggingFace tokenizer...
 Loading HuggingFace reference model on CPU...
-Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:00<00:00,  1.57it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.73it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.70it/s]
+Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:00<00:00,  1.47it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.58it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.56it/s]
+2026-02-17 12:07:02.077 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-17 12:07:02.108 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-17 12:07:02.118 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-17 12:07:02.195 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-17 12:07:02.255 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x202 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:07:02.315 | info     |             UMD | Harvesting masks for chip 2 tensix: 0xc dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:07:02.326 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:07:02.336 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:07:02.347 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:07:02.360 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x30 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:07:02.374 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:07:02.387 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x300 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:07:02.401 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 3, 1, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
+2026-02-17 12:07:02.401 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-17 12:07:02.401 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-17 12:07:02.410 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-17 12:07:02.410 | info     |             UMD | Mapped hugepage 0x200000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:07:02.411 | info     |             UMD | Mapped hugepage 0x140000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:07:02.412 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:07:02.413 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:07:02.414 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:07:02.415 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:07:02.416 | info     |             UMD | Mapped hugepage 0x42c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:07:02.417 | info     |             UMD | Mapped hugepage 0x4280000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:07:02.470 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:827)
+2026-02-17 12:07:02.470 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:804)
+2026-02-17 12:07:02.471 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-17 12:07:02.471 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-17 12:07:02.478 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-17 12:07:02.478 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-17 12:07:02.486 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:07:02.490 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:07:02.491 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:07:02.491 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:07:02.492 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:07:02.492 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:07:02.493 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:07:02.493 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:07:02.845 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
+2026-02-17 12:07:02.845 | info     |           Metal | Dispatch on FabricConfig::FABRIC_1D with 1 Command Queues
+ (device_manager.cpp:328)
+2026-02-17 12:07:02.859 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
+2026-02-17 12:07:03.054 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
+2026-02-17 12:07:03.054 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
+2026-02-17 12:07:03.110 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
+2026-02-17 12:07:03.111 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
+2026-02-17 12:07:03.114 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
+2026-02-17 12:07:03.119 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
+2026-02-17 12:07:03.122 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
+2026-02-17 12:07:03.128 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
+2026-02-17 12:07:03.128 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_1D (device_manager.cpp:409)
+2026-02-17 12:07:03.255 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
+2026-02-17 12:07:03.255 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
+2026-02-17 12:07:03.256 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
+2026-02-17 12:07:03.258 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
 Generating reference tokens...
 Opening device (1x8)...
-2026-02-17 11:05:12.540 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 11:05:12.571 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-02-17 11:05:12.580 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 11:05:12.654 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 11:05:12.714 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 11:05:12.772 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 11:05:12.783 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 11:05:12.793 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 11:05:12.803 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 11:05:12.816 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 11:05:12.830 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 11:05:12.844 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 11:05:12.858 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 1, 3, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
-2026-02-17 11:05:12.858 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-02-17 11:05:12.858 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
-2026-02-17 11:05:12.866 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-02-17 11:05:12.867 | info     |             UMD | Mapped hugepage 0x280000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 11:05:12.867 | info     |             UMD | Mapped hugepage 0x240000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 11:05:12.868 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 11:05:12.869 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 11:05:12.870 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 11:05:12.871 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 11:05:12.872 | info     |             UMD | Mapped hugepage 0x4240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 11:05:12.872 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 11:05:12.950 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto (metal_context.cpp:822)
-2026-02-17 11:05:12.951 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
-Requested mesh (1, 8) reshapes discovered system mesh (2, 4); continuing because device count matches.
-2026-02-17 11:05:12.956 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
-2026-02-17 11:05:12.956 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-02-17 11:05:12.965 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 11:05:12.968 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 11:05:12.968 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 11:05:12.969 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 11:05:12.969 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 11:05:12.970 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 11:05:12.970 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 11:05:12.971 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 11:05:13.310 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
-2026-02-17 11:05:13.310 | info     |           Metal | Dispatch on FabricConfig::FABRIC_1D with 1 Command Queues
- (device_manager.cpp:328)
-2026-02-17 11:05:13.325 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
-2026-02-17 11:05:13.523 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
-2026-02-17 11:05:13.576 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
-2026-02-17 11:05:13.577 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
-2026-02-17 11:05:13.578 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
-2026-02-17 11:05:13.580 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
-2026-02-17 11:05:13.583 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
-2026-02-17 11:05:13.589 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
-2026-02-17 11:05:13.595 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
-2026-02-17 11:05:13.595 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_1D (device_manager.cpp:409)
-2026-02-17 11:05:13.712 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
-2026-02-17 11:05:13.713 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
-2026-02-17 11:05:13.713 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
-2026-02-17 11:05:13.713 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
+Requested 1D mesh (1, 8) exceeds discovered mesh dimensions (2, 4); continuing because both shapes use the same number of devices.
 Loading ttnn model...
   Loading embeddings...
   Computing RoPE cache...
@@ -69,5 +71,5 @@ Running teacher-forcing eval (100 tokens)...
 Top-1 accuracy: 98.00% (0.9800)
 Top-5 accuracy: 100.00% (1.0000)
 YT_METRICS={"mode": "tt_eval", "model": "arcee-ai/AFM-4.5B", "top1": 0.98, "top5": 1.0, "top1_pct": 98.0, "top5_pct": 100.0, "total_tokens": 100, "max_new_tokens": 100, "max_seq_len": 65536}
-2026-02-17 11:07:33.769 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-02-17 11:07:33.769 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
+2026-02-17 12:09:28.937 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-17 12:09:28.937 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)


### PR DESCRIPTION
## Summary
- Update `MODELS.md` metrics for `arcee-ai/AFM-4.5B` on `t3000` functional (1x8).
- Refresh functional `demo.log` and `eval.log` for `models/arcee-ai/AFM-4.5B/t3000/functional`.

## Notes
- Cleared local artifacts under `generated/`.

Fixes #193
