### PR TITLE
models/arcee-ai/Arcee-Spark/t3000/functional (1x8 mesh port)

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -10,7 +10,7 @@ Note: Keep the table columns padded with spaces and right-justify numeric cells 
 | ----------------------------------- | :------: | :--------: | ----: | ----: | -----: | ----: | ------: |
 | arcee-ai/Arcee-Spark                |   n150   | functional |   92% |  100% |   99ms |  13.9 |   29952 |
 | arcee-ai/Arcee-Spark                |   n300   | functional |   91% |  100% |  338ms |   5.0 |   32768 |
-| arcee-ai/Arcee-Spark                |  t3000   | functional |   90% |  100% |  194ms |   7.3 |   32768 |
+| arcee-ai/Arcee-Spark                |  t3000   | functional |   91% |  100% |  192ms |   7.3 |   32768 |
 | arcee-ai/AFM-4.5B                   |   n150   | functional |   98% |  100% |   72ms |  17.2 |   65536 |
 | arcee-ai/AFM-4.5B                   |   n300   | functional |   97% |  100% |  283ms |   5.6 |   65536 |
 | arcee-ai/AFM-4.5B                   |  t3000   | functional |   98% |  100% |  181ms |   7.1 |   65536 |

--- a/models/arcee-ai/Arcee-Spark/t3000/functional/demo.log
+++ b/models/arcee-ai/Arcee-Spark/t3000/functional/demo.log
@@ -1,66 +1,66 @@
-$ python demo.py models/arcee-ai/Arcee-Spark/t3000/functional/model.py
-2026-02-17 10:29:00.000 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+$ TT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python demo.py models/arcee-ai/Arcee-Spark/t3000/functional/model.py
+2026-02-17 12:48:24.421 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
 Loading tokenizer: arcee-ai/Arcee-Spark
 Opening TT device...
-2026-02-17 10:29:00.593 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 10:29:00.624 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-02-17 10:29:00.632 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 10:29:00.706 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 10:29:00.769 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 10:29:00.824 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 10:29:00.834 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 10:29:00.845 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 10:29:00.855 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 10:29:00.869 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 10:29:00.882 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 10:29:00.895 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 10:29:00.909 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 1, 3, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
-2026-02-17 10:29:00.909 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-02-17 10:29:00.909 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
-2026-02-17 10:29:00.917 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-02-17 10:29:00.918 | info     |             UMD | Mapped hugepage 0x280000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 10:29:00.918 | info     |             UMD | Mapped hugepage 0x240000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 10:29:00.919 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 10:29:00.920 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 10:29:00.921 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 10:29:00.921 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 10:29:00.922 | info     |             UMD | Mapped hugepage 0x4240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 10:29:00.923 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 10:29:00.978 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:827)
-2026-02-17 10:29:00.978 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:804)
-2026-02-17 10:29:00.979 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
-2026-02-17 10:29:00.979 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-17 12:48:25.057 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
+2026-02-17 12:48:25.087 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-17 12:48:25.097 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
+2026-02-17 12:48:25.173 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
+2026-02-17 12:48:25.234 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:48:25.292 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:48:25.302 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:48:25.312 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:48:25.322 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:48:25.339 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:48:25.352 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:48:25.365 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:48:25.381 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 1, 3, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
+2026-02-17 12:48:25.381 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-17 12:48:25.381 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-17 12:48:25.389 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-17 12:48:25.390 | info     |             UMD | Mapped hugepage 0x280000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:48:25.391 | info     |             UMD | Mapped hugepage 0x240000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:48:25.392 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:48:25.393 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:48:25.393 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:48:25.394 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:48:25.395 | info     |             UMD | Mapped hugepage 0x4240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:48:25.396 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:48:25.454 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:827)
+2026-02-17 12:48:25.454 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:804)
+2026-02-17 12:48:25.455 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-17 12:48:25.455 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
 Requested mesh (1, 8) exceeds discovered system mesh dimensions (2, 4), but is allowed because device count fits (8 <= 8).
-2026-02-17 10:29:00.986 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
-2026-02-17 10:29:00.986 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-02-17 10:29:00.993 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 10:29:00.995 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 10:29:00.996 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 10:29:00.996 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 10:29:00.997 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 10:29:00.997 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 10:29:00.998 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 10:29:00.998 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 10:29:01.330 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
-2026-02-17 10:29:01.330 | info     |           Metal | Dispatch on FabricConfig::FABRIC_1D with 1 Command Queues
+2026-02-17 12:48:25.460 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-17 12:48:25.460 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-17 12:48:25.467 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:48:25.470 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:48:25.470 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:48:25.471 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:48:25.471 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:48:25.472 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:48:25.472 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:48:25.473 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:48:25.827 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
+2026-02-17 12:48:25.827 | info     |           Metal | Dispatch on FabricConfig::FABRIC_1D with 1 Command Queues
  (device_manager.cpp:328)
-2026-02-17 10:29:01.352 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
-2026-02-17 10:29:01.562 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
-2026-02-17 10:29:01.563 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
-2026-02-17 10:29:01.563 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
-2026-02-17 10:29:01.564 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
-2026-02-17 10:29:01.567 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
-2026-02-17 10:29:01.569 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
-2026-02-17 10:29:01.575 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
-2026-02-17 10:29:01.581 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
-2026-02-17 10:29:01.581 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_1D (device_manager.cpp:409)
-2026-02-17 10:29:01.701 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
-2026-02-17 10:29:01.703 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
-2026-02-17 10:29:01.703 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
-2026-02-17 10:29:01.704 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
+2026-02-17 12:48:25.848 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
+2026-02-17 12:48:26.019 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
+2026-02-17 12:48:26.085 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
+2026-02-17 12:48:26.086 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
+2026-02-17 12:48:26.086 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
+2026-02-17 12:48:26.089 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
+2026-02-17 12:48:26.092 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
+2026-02-17 12:48:26.098 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
+2026-02-17 12:48:26.103 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
+2026-02-17 12:48:26.103 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_1D (device_manager.cpp:409)
+2026-02-17 12:48:26.280 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
+2026-02-17 12:48:26.282 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
+2026-02-17 12:48:26.282 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
+2026-02-17 12:48:26.283 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
 Loading HuggingFace reference model on CPU: arcee-ai/Arcee-Spark
-Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]Loading checkpoint shards:  25%|██▌       | 1/4 [00:00<00:01,  1.68it/s]Loading checkpoint shards:  50%|█████     | 2/4 [00:01<00:01,  1.61it/s]Loading checkpoint shards:  75%|███████▌  | 3/4 [00:01<00:00,  1.66it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:01<00:00,  2.38it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:01<00:00,  2.04it/s]
+Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]Loading checkpoint shards:  25%|██▌       | 1/4 [00:00<00:01,  1.53it/s]Loading checkpoint shards:  50%|█████     | 2/4 [00:01<00:01,  1.53it/s]Loading checkpoint shards:  75%|███████▌  | 3/4 [00:01<00:00,  1.61it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:02<00:00,  2.32it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:02<00:00,  1.97it/s]
 Building TT model...
   Loading embeddings...
   Computing RoPE cache...
@@ -70,16 +70,15 @@ TT demo (t3000)
 Model: arcee-ai/Arcee-Spark
 Mesh shape: 1x8
 Prompt tokens: 56 | Generated tokens: 128
-TTFT: 194 ms | Decode: 7.3 t/s/u (127 tokens)
+TTFT: 192 ms | Decode: 7.3 t/s/u (127 tokens)
 
 Prompt:
 Journal entry, 1957: Tonight a tiny sphere called Sputnik 1 crossed the sky, beeping like a metronome for a new era. The neighbors gathered on the roof, listening and arguing about what comes next. I wrote in my notebook that
 
 Output:
- this event would change the course of history, and that the Russian rocket would soon lead humanity to the moon.
-In his first book since 2004, the Pulitzer Prize-winning playwright explores the human story behind the space race and our deep need to look to the heavens. Fusing the scientific breakthroughs of the 20th century with the triumphs and tragedies of those who risked their lives to build a rocket, The Lifespan of a Fact is a rich and complex narrative that takes us from the Soviet Union to the moon—and reveals the deep and often overlooked emotional underpinnings that drove a civilization to the
-YT_METRICS={"mode": "tt_demo", "model": "arcee-ai/Arcee-Spark", "system": "t3000", "mesh_shape": [1, 8], "prompt_tokens": 56, "generated_tokens": 128, "ttft_ms": 194.07666998449713, "decode_tps_u": 7.329068268419777, "decode_tokens": 127, "max_seq_len": 2048}
-2026-02-17 10:31:53.925 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-02-17 10:31:53.925 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
-
-EXIT_CODE=0
+ this little thing was a sign.
+I wanted to see the Russian rocket but for myself so when I climbed the ladder into the hayloft and turned on the old radio. Then I laid my head against the cold wood and waited. There were it was again. Beeping once every few seconds as a black dot raced across the sky, and suddenly a moment of realization came to me. The universe was not as remote as I thought. It was near, alive, and changing before my eyes. I felt an odd sense of connection to the people across the world.
+In my life I have tried to see this same kind of connection in
+YT_METRICS={"mode": "tt_demo", "model": "arcee-ai/Arcee-Spark", "system": "t3000", "mesh_shape": [1, 8], "prompt_tokens": 56, "generated_tokens": 128, "ttft_ms": 192.2391249681823, "decode_tps_u": 7.299171552436337, "decode_tokens": 127, "max_seq_len": 2048}
+2026-02-17 12:51:10.833 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-17 12:51:10.833 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/arcee-ai/Arcee-Spark/t3000/functional/eval.log
+++ b/models/arcee-ai/Arcee-Spark/t3000/functional/eval.log
@@ -1,78 +1,76 @@
-$ python eval.py models/arcee-ai/Arcee-Spark/t3000/functional/model.py --model arcee-ai/Arcee-Spark --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 32768
-2026-02-17 10:32:17.297 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+$ TT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python eval.py models/arcee-ai/Arcee-Spark/t3000/functional/model.py --model arcee-ai/Arcee-Spark --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 32768
+2026-02-17 12:51:30.104 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
 Loading model module: /localdev/moconnor/ttnn_models/models/arcee-ai/Arcee-Spark/t3000/functional/model.py
 Loading HuggingFace tokenizer...
 Loading HuggingFace reference model on CPU...
-Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]Loading checkpoint shards:  25%|██▌       | 1/4 [00:00<00:01,  1.68it/s]Loading checkpoint shards:  50%|█████     | 2/4 [00:01<00:01,  1.66it/s]Loading checkpoint shards:  75%|███████▌  | 3/4 [00:01<00:00,  1.74it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:01<00:00,  2.50it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:01<00:00,  2.13it/s]
+Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]Loading checkpoint shards:  25%|██▌       | 1/4 [00:00<00:01,  1.54it/s]Loading checkpoint shards:  50%|█████     | 2/4 [00:01<00:01,  1.56it/s]Loading checkpoint shards:  75%|███████▌  | 3/4 [00:01<00:00,  1.65it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:01<00:00,  2.38it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:01<00:00,  2.01it/s]
 Generating reference tokens...
 The following generation flags are not valid and may be ignored: ['temperature', 'top_p', 'top_k']. Set `TRANSFORMERS_VERBOSITY=info` for more details.
 Opening device (1x8)...
-2026-02-17 10:33:14.650 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 10:33:14.682 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-02-17 10:33:14.693 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 10:33:14.766 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 10:33:14.829 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 10:33:14.884 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 10:33:14.893 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 10:33:14.903 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 10:33:14.913 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 10:33:14.927 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 10:33:14.940 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 10:33:14.953 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 10:33:14.966 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 1, 3, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
-2026-02-17 10:33:14.966 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-02-17 10:33:14.966 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
-2026-02-17 10:33:14.976 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-02-17 10:33:14.977 | info     |             UMD | Mapped hugepage 0x280000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 10:33:14.978 | info     |             UMD | Mapped hugepage 0x240000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 10:33:14.979 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 10:33:14.979 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 10:33:14.980 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 10:33:14.981 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 10:33:14.982 | info     |             UMD | Mapped hugepage 0x4240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 10:33:14.982 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 10:33:15.034 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:827)
-2026-02-17 10:33:15.034 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:804)
-2026-02-17 10:33:15.035 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
-2026-02-17 10:33:15.035 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-17 12:52:31.767 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
+2026-02-17 12:52:31.797 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-17 12:52:31.807 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
+2026-02-17 12:52:31.882 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
+2026-02-17 12:52:31.942 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:52:32.000 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:52:32.010 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:52:32.021 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:52:32.031 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:52:32.045 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:52:32.058 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:52:32.072 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 12:52:32.086 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 1, 3, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
+2026-02-17 12:52:32.086 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-17 12:52:32.086 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-17 12:52:32.095 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-17 12:52:32.096 | info     |             UMD | Mapped hugepage 0x280000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:52:32.097 | info     |             UMD | Mapped hugepage 0x240000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:52:32.098 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:52:32.099 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:52:32.100 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:52:32.100 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:52:32.101 | info     |             UMD | Mapped hugepage 0x4240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:52:32.102 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 12:52:32.155 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:827)
+2026-02-17 12:52:32.155 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:804)
+2026-02-17 12:52:32.155 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-17 12:52:32.155 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
 Requested mesh (1, 8) exceeds discovered system mesh dimensions (2, 4), but is allowed because device count fits (8 <= 8).
-2026-02-17 10:33:15.040 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
-2026-02-17 10:33:15.041 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-02-17 10:33:15.047 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 10:33:15.050 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 10:33:15.050 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 10:33:15.051 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 10:33:15.051 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 10:33:15.052 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 10:33:15.052 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 10:33:15.053 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 10:33:15.385 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
-2026-02-17 10:33:15.385 | info     |           Metal | Dispatch on FabricConfig::FABRIC_1D with 1 Command Queues
+2026-02-17 12:52:32.162 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-17 12:52:32.162 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-17 12:52:32.169 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:52:32.171 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:52:32.172 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:52:32.172 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:52:32.173 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:52:32.174 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:52:32.174 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:52:32.175 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 12:52:32.521 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
+2026-02-17 12:52:32.521 | info     |           Metal | Dispatch on FabricConfig::FABRIC_1D with 1 Command Queues
  (device_manager.cpp:328)
-2026-02-17 10:33:15.397 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
-2026-02-17 10:33:15.559 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
-2026-02-17 10:33:15.610 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
-2026-02-17 10:33:15.611 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
-2026-02-17 10:33:15.611 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
-2026-02-17 10:33:15.614 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
-2026-02-17 10:33:15.617 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
-2026-02-17 10:33:15.622 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
-2026-02-17 10:33:15.628 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
-2026-02-17 10:33:15.628 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_1D (device_manager.cpp:409)
-2026-02-17 10:33:15.747 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
-2026-02-17 10:33:15.748 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
-2026-02-17 10:33:15.751 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
-2026-02-17 10:33:15.751 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
+2026-02-17 12:52:32.534 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
+2026-02-17 12:52:32.747 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
+2026-02-17 12:52:32.748 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
+2026-02-17 12:52:32.748 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
+2026-02-17 12:52:32.749 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
+2026-02-17 12:52:32.752 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
+2026-02-17 12:52:32.755 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
+2026-02-17 12:52:32.760 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
+2026-02-17 12:52:32.766 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
+2026-02-17 12:52:32.766 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_1D (device_manager.cpp:409)
+2026-02-17 12:52:32.890 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
+2026-02-17 12:52:32.891 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
+2026-02-17 12:52:32.892 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
+2026-02-17 12:52:32.892 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
 Loading ttnn model...
   Loading embeddings...
   Computing RoPE cache...
   Loading 28 layers...
 Running teacher-forcing eval (100 tokens)...
-Top-1 accuracy: 90.00% (0.9000)
+Top-1 accuracy: 91.00% (0.9100)
 Top-5 accuracy: 100.00% (1.0000)
-YT_METRICS={"mode": "tt_eval", "model": "arcee-ai/Arcee-Spark", "top1": 0.9, "top5": 1.0, "top1_pct": 90.0, "top5_pct": 100.0, "total_tokens": 100, "max_new_tokens": 100, "max_seq_len": 32768}
-2026-02-17 10:35:58.519 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-02-17 10:35:58.519 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
-
-EXIT_CODE=0
+YT_METRICS={"mode": "tt_eval", "model": "arcee-ai/Arcee-Spark", "top1": 0.91, "top5": 1.0, "top1_pct": 91.0, "top5_pct": 100.0, "total_tokens": 100, "max_new_tokens": 100, "max_seq_len": 32768}
+2026-02-17 12:55:14.865 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-17 12:55:14.865 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)


### PR DESCRIPTION
## Summary
- update `MODELS.md` for Arcee-Spark t3000 functional bringup status
- refresh functional `demo.log` and `eval.log` outputs
- clear generated artifacts under `generated/`

Fixes #195
