### PR TITLE
models/arcee-ai/Arcee-Spark/t3000/optimized (1x8 mesh port)

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -37,7 +37,7 @@ Note: Keep the table columns padded with spaces and right-justify numeric cells 
 | tiiuae/Falcon3-7B-Instruct          |  t3000   | functional |   97% |  100% |  199ms |   7.3 |   32768 |
 | arcee-ai/Arcee-Spark                |   n150   | optimized  |   91% |  100% |   77ms |  14.5 |   29952 |
 | arcee-ai/Arcee-Spark                |   n300   | optimized  |   85% |  100% |  101ms |  16.0 |   32768 |
-| arcee-ai/Arcee-Spark                |  t3000   | optimized  |   84% |  100% |   73ms |  19.6 |   32768 |
+| arcee-ai/Arcee-Spark                |  t3000   | optimized  |   87% |  100% |   62ms |  21.2 |   32768 |
 | arcee-ai/AFM-4.5B                   |   n150   | optimized  |   98% |  100% |   57ms |  19.6 |   65536 |
 | arcee-ai/AFM-4.5B                   |   n300   | optimized  |   99% |  100% |   56ms |  23.6 |   65536 |
 | arcee-ai/AFM-4.5B                   |  t3000   | optimized  |   98% |  100% |   69ms |  29.0 |   65536 |

--- a/models/arcee-ai/Arcee-Spark/t3000/optimized/demo.log
+++ b/models/arcee-ai/Arcee-Spark/t3000/optimized/demo.log
@@ -1,112 +1,65 @@
-python demo.py models/arcee-ai/Arcee-Spark/t3000/optimized/model.py 
-2026-02-17 13:20:55.298 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+$ python demo.py models/arcee-ai/Arcee-Spark/t3000/optimized/model.py
+2026-02-17 14:56:03.522 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
 Loading tokenizer: arcee-ai/Arcee-Spark
 Opening TT device...
-2026-02-17 13:20:55.949 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 13:20:55.980 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-02-17 13:20:55.991 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 13:20:56.067 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 13:20:56.130 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:20:56.188 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:20:56.199 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:20:56.209 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:20:56.220 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:20:56.233 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:20:56.247 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:20:56.260 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:20:56.274 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 1, 3, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
-2026-02-17 13:20:56.274 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-02-17 13:20:56.274 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
-2026-02-17 13:20:56.282 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-02-17 13:20:56.283 | info     |             UMD | Mapped hugepage 0x280000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:20:56.283 | info     |             UMD | Mapped hugepage 0x240000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:20:56.284 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:20:56.285 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:20:56.286 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:20:56.287 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:20:56.287 | info     |             UMD | Mapped hugepage 0x4240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:20:56.288 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:20:56.320 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:827)
-2026-02-17 13:20:56.320 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:804)
-2026-02-17 13:20:56.321 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
-2026-02-17 13:20:56.321 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
-Traceback (most recent call last):
-  File "/localdev/moconnor/ttnn_models/demo.py", line 506, in <module>
-    main()
-  File "/localdev/moconnor/ttnn_models/demo.py", line 482, in main
-    run_tt_demo(
-  File "/localdev/moconnor/ttnn_models/demo.py", line 393, in run_tt_demo
-    tt_device, is_mesh, fabric_config = open_tt_device(mesh_shape, device_id)
-  File "/localdev/moconnor/ttnn_models/device_utils.py", line 99, in open_tt_device
-    raise RuntimeError(f"Requested mesh {requested_mesh_shape} exceeds system mesh {system_shape}")
-RuntimeError: Requested mesh (1, 8) exceeds system mesh (2, 4)
-2026-02-17 13:20:57.031 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-02-17 13:20:57.031 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
-
-env TTNN_ALLOW_SYSTEM_MESH_FALLBACK=1 python demo.py models/arcee-ai/Arcee-Spark/t3000/optimized/model.py 
-2026-02-17 13:21:42.388 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
-Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
-Loading tokenizer: arcee-ai/Arcee-Spark
-Opening TT device...
-2026-02-17 13:21:43.022 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 13:21:43.054 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-02-17 13:21:43.064 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 13:21:43.140 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 13:21:43.204 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:21:43.256 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:21:43.267 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:21:43.277 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:21:43.288 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:21:43.302 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:21:43.315 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:21:43.329 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:21:43.343 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 1, 3, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
-2026-02-17 13:21:43.343 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-02-17 13:21:43.343 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
-2026-02-17 13:21:43.353 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-02-17 13:21:43.354 | info     |             UMD | Mapped hugepage 0x280000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:21:43.355 | info     |             UMD | Mapped hugepage 0x240000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:21:43.356 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:21:43.356 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:21:43.357 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:21:43.358 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:21:43.359 | info     |             UMD | Mapped hugepage 0x4240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:21:43.360 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:21:43.414 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:827)
-2026-02-17 13:21:43.414 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:804)
-2026-02-17 13:21:43.415 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
-2026-02-17 13:21:43.415 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
-Requested mesh (1, 8) exceeds discovered system mesh (2, 4); falling back to discovered mesh because TTNN_ALLOW_SYSTEM_MESH_FALLBACK is enabled.
-2026-02-17 13:21:43.421 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
-2026-02-17 13:21:43.422 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-02-17 13:21:43.427 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 13:21:43.430 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 13:21:43.431 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 13:21:43.431 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 13:21:43.432 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 13:21:43.432 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 13:21:43.433 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 13:21:43.433 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 13:21:43.776 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
-2026-02-17 13:21:43.776 | info     |           Metal | Dispatch on FabricConfig::FABRIC_2D with 1 Command Queues
+2026-02-17 14:56:04.110 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
+2026-02-17 14:56:04.140 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-17 14:56:04.149 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
+2026-02-17 14:56:04.220 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
+2026-02-17 14:56:04.281 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 14:56:04.340 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 14:56:04.352 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 14:56:04.362 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 14:56:04.372 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 14:56:04.386 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 14:56:04.400 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 14:56:04.414 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 14:56:04.428 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 1, 3, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
+2026-02-17 14:56:04.428 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-17 14:56:04.428 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-17 14:56:04.437 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-17 14:56:04.437 | info     |             UMD | Mapped hugepage 0x280000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 14:56:04.438 | info     |             UMD | Mapped hugepage 0x240000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 14:56:04.439 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 14:56:04.440 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 14:56:04.441 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 14:56:04.441 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 14:56:04.442 | info     |             UMD | Mapped hugepage 0x4240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 14:56:04.443 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 14:56:04.498 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:827)
+2026-02-17 14:56:04.498 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:804)
+2026-02-17 14:56:04.499 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-17 14:56:04.499 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-17 14:56:04.503 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-17 14:56:04.503 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-17 14:56:04.508 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 14:56:04.511 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 14:56:04.511 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 14:56:04.512 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 14:56:04.512 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 14:56:04.513 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 14:56:04.513 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 14:56:04.514 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 14:56:04.850 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
+2026-02-17 14:56:04.850 | info     |           Metal | Dispatch on FabricConfig::FABRIC_1D with 1 Command Queues
  (device_manager.cpp:328)
-2026-02-17 13:21:43.797 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
-2026-02-17 13:21:44.000 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
-2026-02-17 13:21:44.030 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
-2026-02-17 13:21:44.030 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
-2026-02-17 13:21:44.031 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
-2026-02-17 13:21:44.034 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
-2026-02-17 13:21:44.037 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
-2026-02-17 13:21:44.043 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
-2026-02-17 13:21:44.050 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
-2026-02-17 13:21:44.050 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_2D (device_manager.cpp:409)
-2026-02-17 13:21:44.178 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
-2026-02-17 13:21:44.178 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
-2026-02-17 13:21:44.182 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
-2026-02-17 13:21:44.182 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
+2026-02-17 14:56:04.872 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
+2026-02-17 14:56:05.041 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
+2026-02-17 14:56:05.089 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
+2026-02-17 14:56:05.090 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
+2026-02-17 14:56:05.091 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
+2026-02-17 14:56:05.093 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
+2026-02-17 14:56:05.096 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
+2026-02-17 14:56:05.102 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
+2026-02-17 14:56:05.107 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
+2026-02-17 14:56:05.107 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_1D (device_manager.cpp:409)
+2026-02-17 14:56:05.250 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
+2026-02-17 14:56:05.251 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
+2026-02-17 14:56:05.253 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
+2026-02-17 14:56:05.254 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
 Loading HuggingFace reference model on CPU: arcee-ai/Arcee-Spark
-Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]Loading checkpoint shards:  25%|██▌       | 1/4 [00:00<00:01,  1.61it/s]Loading checkpoint shards:  50%|█████     | 2/4 [00:01<00:01,  1.61it/s]Loading checkpoint shards:  75%|███████▌  | 3/4 [00:01<00:00,  1.68it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:01<00:00,  2.40it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:01<00:00,  2.05it/s]
+Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]Loading checkpoint shards:  25%|██▌       | 1/4 [00:00<00:01,  1.60it/s]Loading checkpoint shards:  50%|█████     | 2/4 [00:01<00:01,  1.60it/s]Loading checkpoint shards:  75%|███████▌  | 3/4 [00:01<00:00,  1.65it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:01<00:00,  2.38it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:01<00:00,  2.03it/s]
 Building TT model...
   Loading embeddings...
   Computing RoPE cache...
@@ -114,16 +67,16 @@ Building TT model...
 Running one warmup prefill+decode pass (kernel compile warmup)...
 TT demo (t3000)
 Model: arcee-ai/Arcee-Spark
-Mesh shape: 2x4
+Mesh shape: 1x8
 Prompt tokens: 56 | Generated tokens: 128
-TTFT: 73 ms | Decode: 19.6 t/s/u (126 tokens)
+TTFT: 62 ms | Decode: 21.2 t/s/u (126 tokens)
 
 Prompt:
 Journal entry, 1957: Tonight a tiny sphere called Sputnik 1 crossed the sky, beeping like a metronome for a new era. The neighbors gathered on the roof, listening and arguing about what comes next. I wrote in my notebook that
 
 Output:
- this event would change everything. We would never be the same. We would look up in awe at the stars, wondering whether we alone inhabit the cosmos. We would never again think of time in the way we had before. The universe, always there, has suddenly stepped into the present, now. And we are in it.
-The Sputnik that rocketed through Earth’s upper atmosphere in 1957 was long gone, but its orbit has decayed. But the stars of the universe have not. They continue to shine, to emit the light it takes to get to us, to make the universe accessible. And for
-YT_METRICS={"mode": "tt_demo", "model": "arcee-ai/Arcee-Spark", "system": "t3000", "mesh_shape": [2, 4], "prompt_tokens": 56, "generated_tokens": 128, "ttft_ms": 73.46224796492606, "decode_tps_u": 19.615817916540877, "decode_tokens": 126, "max_seq_len": 2048}
-2026-02-17 13:24:35.068 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-02-17 13:24:35.068 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
+ this event would change everything. That it had already. That the future was here, but it’s not what we were told it would look like. That the future is now and it won’t be a mirror of the past.
+Journal entry, 2057: “Future’s now’, said my great-grandmother. I looked at the screen. It read 24:51. I’d already been up for 15 hours. I kept my eyes on the screen as the time, date, and temperature scrolled by. “Tomorrow’s Wednesday’. The time moved on. I didn’t see anything. I stared
+YT_METRICS={"mode": "tt_demo", "model": "arcee-ai/Arcee-Spark", "system": "t3000", "mesh_shape": [1, 8], "prompt_tokens": 56, "generated_tokens": 128, "ttft_ms": 62.14860803447664, "decode_tps_u": 21.246540249590367, "decode_tokens": 126, "max_seq_len": 2048}
+2026-02-17 14:58:46.132 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-17 14:58:46.132 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)

--- a/models/arcee-ai/Arcee-Spark/t3000/optimized/eval.log
+++ b/models/arcee-ai/Arcee-Spark/t3000/optimized/eval.log
@@ -1,125 +1,75 @@
-python eval.py models/arcee-ai/Arcee-Spark/t3000/optimized/model.py --model arcee-ai/Arcee-Spark --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 32768 
-2026-02-17 13:25:00.323 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+$ python eval.py models/arcee-ai/Arcee-Spark/t3000/optimized/model.py --model arcee-ai/Arcee-Spark --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 32768
+2026-02-17 14:59:04.418 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
 Loading model module: /localdev/moconnor/ttnn_models/models/arcee-ai/Arcee-Spark/t3000/optimized/model.py
 Loading HuggingFace tokenizer...
 Loading HuggingFace reference model on CPU...
-Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]Loading checkpoint shards:  25%|██▌       | 1/4 [00:00<00:01,  1.62it/s]Loading checkpoint shards:  50%|█████     | 2/4 [00:01<00:01,  1.63it/s]Loading checkpoint shards:  75%|███████▌  | 3/4 [00:01<00:00,  1.71it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:01<00:00,  2.45it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:01<00:00,  2.09it/s]
+Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]Loading checkpoint shards:  25%|██▌       | 1/4 [00:00<00:01,  1.62it/s]Loading checkpoint shards:  50%|█████     | 2/4 [00:01<00:01,  1.63it/s]Loading checkpoint shards:  75%|███████▌  | 3/4 [00:01<00:00,  1.71it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:01<00:00,  2.46it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:01<00:00,  2.09it/s]
 Generating reference tokens...
 The following generation flags are not valid and may be ignored: ['temperature', 'top_p', 'top_k']. Set `TRANSFORMERS_VERBOSITY=info` for more details.
 Opening device (1x8)...
-2026-02-17 13:26:06.131 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 13:26:06.162 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-02-17 13:26:06.172 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 13:26:06.248 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 13:26:06.310 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:26:06.372 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:26:06.383 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:26:06.393 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:26:06.404 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:26:06.418 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:26:06.430 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:26:06.444 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:26:06.457 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 1, 3, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
-2026-02-17 13:26:06.457 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-02-17 13:26:06.457 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
-2026-02-17 13:26:06.466 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-02-17 13:26:06.466 | info     |             UMD | Mapped hugepage 0x280000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:26:06.467 | info     |             UMD | Mapped hugepage 0x240000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:26:06.468 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:26:06.469 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:26:06.469 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:26:06.470 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:26:06.471 | info     |             UMD | Mapped hugepage 0x4240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:26:06.472 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:26:06.526 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:827)
-2026-02-17 13:26:06.526 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:804)
-2026-02-17 13:26:06.527 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
-2026-02-17 13:26:06.527 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
-Traceback (most recent call last):
-  File "/localdev/moconnor/ttnn_models/eval.py", line 227, in <module>
-    main()
-  File "/localdev/moconnor/ttnn_models/eval.py", line 179, in main
-    tt_device, is_mesh, fabric_config = open_tt_device(mesh_shape, args.device_id)
-  File "/localdev/moconnor/ttnn_models/device_utils.py", line 99, in open_tt_device
-    raise RuntimeError(f"Requested mesh {requested_mesh_shape} exceeds system mesh {system_shape}")
-RuntimeError: Requested mesh (1, 8) exceeds system mesh (2, 4)
-2026-02-17 13:26:08.655 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-02-17 13:26:08.655 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
-
-env TTNN_ALLOW_SYSTEM_MESH_FALLBACK=1 python eval.py models/arcee-ai/Arcee-Spark/t3000/optimized/model.py --model arcee-ai/Arcee-Spark --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 32768 
-2026-02-17 13:26:32.098 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
-Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
-Loading model module: /localdev/moconnor/ttnn_models/models/arcee-ai/Arcee-Spark/t3000/optimized/model.py
-Loading HuggingFace tokenizer...
-Loading HuggingFace reference model on CPU...
-Loading checkpoint shards:   0%|          | 0/4 [00:00<?, ?it/s]Loading checkpoint shards:  25%|██▌       | 1/4 [00:00<00:01,  1.62it/s]Loading checkpoint shards:  50%|█████     | 2/4 [00:01<00:01,  1.64it/s]Loading checkpoint shards:  75%|███████▌  | 3/4 [00:01<00:00,  1.72it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:01<00:00,  2.46it/s]Loading checkpoint shards: 100%|██████████| 4/4 [00:01<00:00,  2.09it/s]
-Generating reference tokens...
-The following generation flags are not valid and may be ignored: ['temperature', 'top_p', 'top_k']. Set `TRANSFORMERS_VERBOSITY=info` for more details.
-Opening device (1x8)...
-2026-02-17 13:27:37.972 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 13:27:38.003 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-02-17 13:27:38.013 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 13:27:38.089 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 13:27:38.151 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:27:38.204 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:27:38.214 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:27:38.224 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:27:38.234 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:27:38.248 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:27:38.261 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:27:38.275 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 13:27:38.288 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 1, 3, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
-2026-02-17 13:27:38.288 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-02-17 13:27:38.288 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
-2026-02-17 13:27:38.298 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-02-17 13:27:38.299 | info     |             UMD | Mapped hugepage 0x280000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:27:38.300 | info     |             UMD | Mapped hugepage 0x240000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:27:38.301 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:27:38.301 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:27:38.302 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:27:38.303 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:27:38.304 | info     |             UMD | Mapped hugepage 0x4240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:27:38.305 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 13:27:38.362 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:827)
-2026-02-17 13:27:38.362 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:804)
-2026-02-17 13:27:38.363 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
-2026-02-17 13:27:38.363 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
-Requested mesh (1, 8) exceeds discovered system mesh (2, 4); falling back to discovered mesh because TTNN_ALLOW_SYSTEM_MESH_FALLBACK is enabled.
-2026-02-17 13:27:38.369 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
-2026-02-17 13:27:38.370 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-02-17 13:27:38.375 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 13:27:38.379 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 13:27:38.380 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 13:27:38.381 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 13:27:38.382 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 13:27:38.382 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 13:27:38.383 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 13:27:38.383 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 13:27:38.725 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
-2026-02-17 13:27:38.725 | info     |           Metal | Dispatch on FabricConfig::FABRIC_2D with 1 Command Queues
+2026-02-17 15:00:09.731 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
+2026-02-17 15:00:09.763 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-17 15:00:09.775 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
+2026-02-17 15:00:09.851 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
+2026-02-17 15:00:09.912 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 15:00:09.978 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 15:00:09.988 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 15:00:09.998 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 15:00:10.008 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 15:00:10.021 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 15:00:10.035 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 15:00:10.049 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 15:00:10.063 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 1, 3, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
+2026-02-17 15:00:10.063 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-17 15:00:10.063 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-17 15:00:10.071 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-17 15:00:10.072 | info     |             UMD | Mapped hugepage 0x280000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 15:00:10.072 | info     |             UMD | Mapped hugepage 0x240000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 15:00:10.073 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 15:00:10.074 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 15:00:10.075 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 15:00:10.076 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 15:00:10.077 | info     |             UMD | Mapped hugepage 0x4240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 15:00:10.077 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 15:00:10.155 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_context.cpp:827)
+2026-02-17 15:00:10.155 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_context.cpp:804)
+2026-02-17 15:00:10.155 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-17 15:00:10.155 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-17 15:00:10.167 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-17 15:00:10.167 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-17 15:00:10.173 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 15:00:10.176 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 15:00:10.177 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 15:00:10.177 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 15:00:10.178 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 15:00:10.179 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 15:00:10.179 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 15:00:10.180 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 15:00:10.525 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
+2026-02-17 15:00:10.525 | info     |           Metal | Dispatch on FabricConfig::FABRIC_1D with 1 Command Queues
  (device_manager.cpp:328)
-2026-02-17 13:27:38.737 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
-2026-02-17 13:27:38.929 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
-2026-02-17 13:27:38.989 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
-2026-02-17 13:27:38.990 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
-2026-02-17 13:27:38.990 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
-2026-02-17 13:27:38.993 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
-2026-02-17 13:27:38.996 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
-2026-02-17 13:27:39.002 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
-2026-02-17 13:27:39.009 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
-2026-02-17 13:27:39.009 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_2D (device_manager.cpp:409)
-2026-02-17 13:27:39.141 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
-2026-02-17 13:27:39.141 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
-2026-02-17 13:27:39.143 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
-2026-02-17 13:27:39.143 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
+2026-02-17 15:00:10.537 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
+2026-02-17 15:00:10.707 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
+2026-02-17 15:00:10.826 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
+2026-02-17 15:00:10.826 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
+2026-02-17 15:00:10.827 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
+2026-02-17 15:00:10.830 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
+2026-02-17 15:00:10.832 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
+2026-02-17 15:00:10.838 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
+2026-02-17 15:00:10.845 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
+2026-02-17 15:00:10.845 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_1D (device_manager.cpp:409)
+2026-02-17 15:00:10.966 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
+2026-02-17 15:00:10.967 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
+2026-02-17 15:00:10.971 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
+2026-02-17 15:00:10.971 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
 Loading ttnn model...
   Loading embeddings...
   Computing RoPE cache...
   Loading 28 layers...
 Running teacher-forcing eval (100 tokens)...
-Top-1 accuracy: 84.00% (0.8400)
+Top-1 accuracy: 87.00% (0.8700)
 Top-5 accuracy: 100.00% (1.0000)
-YT_METRICS={"mode": "tt_eval", "model": "arcee-ai/Arcee-Spark", "top1": 0.84, "top5": 1.0, "top1_pct": 84.0, "top5_pct": 100.0, "total_tokens": 100, "max_new_tokens": 100, "max_seq_len": 32768}
-2026-02-17 13:30:18.038 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-02-17 13:30:18.038 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
+YT_METRICS={"mode": "tt_eval", "model": "arcee-ai/Arcee-Spark", "top1": 0.87, "top5": 1.0, "top1_pct": 87.0, "top5_pct": 100.0, "total_tokens": 100, "max_new_tokens": 100, "max_seq_len": 32768}
+2026-02-17 15:02:48.981 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-17 15:02:48.981 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)


### PR DESCRIPTION
Summary
- Update `MODELS.md` for `models/arcee-ai/Arcee-Spark/t3000/optimized`.
- Refresh `demo.log` and `eval.log` artifacts for the optimized 1x8 mesh run.

Fixes #196
