### PR TITLE
models/google/gemma-3-4b-it/t3000/optimized (1x8 mesh port)

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -55,7 +55,7 @@ Note: Keep the table columns padded with spaces and right-justify numeric cells 
 | Qwen/Qwen3-0.6B                     |  t3000   | optimized  |   98% |  100% |   59ms |  61.9 |   40960 |
 | google/gemma-3-4b-it                |   n150   | optimized  |   92% |  100% |   70ms |  14.5 |   40960 |
 | google/gemma-3-4b-it                |   n300   | optimized  |   94% |  100% |   68ms |  18.5 |   40960 |
-| google/gemma-3-4b-it                |  t3000   | optimized  |   91% |  100% |   75ms |  19.7 |   40960 |
+| google/gemma-3-4b-it                |  t3000   | optimized  |   91% |  100% |   71ms |  20.6 |   40960 |
 | microsoft/Phi-3-mini-128k-instruct  |   n150   | optimized  |   94% |   99% |   69ms |  15.9 |   12288 |
 | microsoft/Phi-3-mini-128k-instruct  |   n300   | optimized  |   91% |  100% |   94ms |  18.3 |   12288 |
 | microsoft/Phi-3-mini-128k-instruct  |  t3000   | optimized  |   92% |   99% |  105ms |  23.6 |   12288 |

--- a/models/google/gemma-3-4b-it/t3000/optimized/demo.log
+++ b/models/google/gemma-3-4b-it/t3000/optimized/demo.log
@@ -1,64 +1,63 @@
-CMD: env HF_HOME=/proj_sw/user_dev/moconnor/hf-cache TT_VISIBLE_DEVICES=0,1,2,3 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x8_mesh_graph_descriptor.textproto TT_METAL_CACHE=/tmp/tt-metal-cache TT_METAL_INSPECTOR_LOG_PATH=/tmp/tt-metal-inspector TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT=0 PYTHONUNBUFFERED=1 python demo.py models/google/gemma-3-4b-it/t3000/optimized/model.py --max_seq_len 40960
-2026-02-17 12:14:09.137 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+CMD: env HF_HOME=/proj_sw/user_dev/moconnor/hf-cache TT_VISIBLE_DEVICES=0,1,2,3 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto TT_METAL_CACHE=/tmp/tt-metal-cache TT_METAL_INSPECTOR_LOG_PATH=/tmp/tt-metal-inspector TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT=0 PYTHONUNBUFFERED=1 python demo.py models/google/gemma-3-4b-it/t3000/optimized/model.py --max_seq_len 40960
+2026-02-17 15:30:28.203 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
 Loading tokenizer: google/gemma-3-4b-it
 Opening TT device...
-2026-02-17 12:14:10.710 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 12:14:10.741 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-02-17 12:14:10.750 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 12:14:10.824 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 12:14:10.886 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 12:14:10.944 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 12:14:10.955 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 12:14:10.965 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 12:14:10.976 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 12:14:10.990 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 12:14:11.002 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 12:14:11.016 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 12:14:11.030 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 1, 3, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
-2026-02-17 12:14:11.030 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-02-17 12:14:11.030 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
-2026-02-17 12:14:11.038 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-02-17 12:14:11.038 | info     |             UMD | Mapped hugepage 0x280000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 12:14:11.039 | info     |             UMD | Mapped hugepage 0x240000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 12:14:11.040 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 12:14:11.041 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 12:14:11.042 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 12:14:11.042 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 12:14:11.043 | info     |             UMD | Mapped hugepage 0x4240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 12:14:11.044 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 12:14:11.105 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x8_mesh_graph_descriptor.textproto (metal_context.cpp:822)
-2026-02-17 12:14:11.106 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={1:2, 2:6}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
-2026-02-17 12:14:11.106 | info     |          Fabric | Fast-path path-graph mapping succeeded for mesh 0 (topology_mapper_utils.cpp:401)
-2026-02-17 12:14:11.111 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
-2026-02-17 12:14:11.111 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-02-17 12:14:11.114 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 12:14:11.117 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 12:14:11.118 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 12:14:11.118 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 12:14:11.118 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 12:14:11.118 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 12:14:11.119 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 12:14:11.119 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 12:14:11.436 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
-2026-02-17 12:14:11.436 | info     |           Metal | Dispatch on FabricConfig::FABRIC_2D with 1 Command Queues
+2026-02-17 15:30:29.742 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-17 15:30:29.774 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-17 15:30:29.784 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-17 15:30:29.860 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-17 15:30:29.921 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x202 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 15:30:29.984 | info     |             UMD | Harvesting masks for chip 2 tensix: 0xc dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 15:30:29.995 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 15:30:30.009 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 15:30:30.022 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 15:30:30.036 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x30 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 15:30:30.050 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 15:30:30.063 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x300 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 15:30:30.078 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 3, 1, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
+2026-02-17 15:30:30.078 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-17 15:30:30.078 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-17 15:30:30.087 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-17 15:30:30.088 | info     |             UMD | Mapped hugepage 0x200000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 15:30:30.089 | info     |             UMD | Mapped hugepage 0x140000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 15:30:30.090 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 15:30:30.091 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 15:30:30.092 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 15:30:30.092 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 15:30:30.094 | info     |             UMD | Mapped hugepage 0x42c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 15:30:30.094 | info     |             UMD | Mapped hugepage 0x4280000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 15:30:30.149 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto (metal_context.cpp:822)
+2026-02-17 15:30:30.151 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-17 15:30:30.157 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-17 15:30:30.157 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-17 15:30:30.162 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 15:30:30.166 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 15:30:30.167 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 15:30:30.167 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 15:30:30.168 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 15:30:30.168 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 15:30:30.169 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 15:30:30.169 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 15:30:30.494 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
+2026-02-17 15:30:30.494 | info     |           Metal | Dispatch on FabricConfig::FABRIC_1D with 1 Command Queues
  (device_manager.cpp:328)
-2026-02-17 12:14:11.450 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
-2026-02-17 12:14:17.362 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
-2026-02-17 12:14:17.798 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
-2026-02-17 12:14:17.798 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
-2026-02-17 12:14:17.841 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
-2026-02-17 12:14:17.926 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
-2026-02-17 12:14:22.139 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
-2026-02-17 12:14:22.146 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
-2026-02-17 12:14:22.148 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
-2026-02-17 12:14:22.148 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_2D (device_manager.cpp:409)
-2026-02-17 12:14:27.395 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
-2026-02-17 12:14:27.395 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
-2026-02-17 12:14:27.395 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
-2026-02-17 12:14:27.397 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
+2026-02-17 15:30:30.509 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
+2026-02-17 15:30:30.638 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
+2026-02-17 15:30:30.638 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
+2026-02-17 15:30:30.677 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
+2026-02-17 15:30:30.678 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
+2026-02-17 15:30:30.681 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
+2026-02-17 15:30:30.686 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
+2026-02-17 15:30:30.689 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
+2026-02-17 15:30:30.694 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
+2026-02-17 15:30:30.694 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_1D (device_manager.cpp:409)
+2026-02-17 15:30:30.787 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
+2026-02-17 15:30:30.789 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
+2026-02-17 15:30:30.790 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
+2026-02-17 15:30:30.790 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
 Loading HuggingFace reference model on CPU: google/gemma-3-4b-it
-Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:00<00:00,  1.44it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.76it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.70it/s]
+Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:00<00:00,  1.27it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.59it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.53it/s]
 Building TT model...
   Loading embeddings...
   Computing RoPE cache...
@@ -68,7 +67,7 @@ TT demo (t3000)
 Model: google/gemma-3-4b-it
 Mesh shape: 1x8
 Prompt tokens: 54 | Generated tokens: 128
-TTFT: 75 ms | Decode: 19.7 t/s/u (126 tokens)
+TTFT: 71 ms | Decode: 20.6 t/s/u (126 tokens)
 
 Prompt:
 Journal entry, 1957: Tonight a tiny sphere called Sputnik 1 crossed the sky, beeping like a metronome for a new era. The neighbors gathered on the roof, listening and arguing about what comes next. I wrote in my notebook that
@@ -78,8 +77,8 @@ Output:
 — Katherine Johnson, 1957-1958, NASA mathematician.
 
 Final Answer: The final answer is $\boxed{Tonight a tiny sphere called Sputnik 1 crossed the sky, beeping like a metronome for a new era. The neighbors gathered on the roof, listening and arguing about what comes next. I wrote in my notebook that “a new age of exploration” has arrived. I don’t know if it’s true, but it feels…powerful
-YT_METRICS={"mode": "tt_demo", "model": "google/gemma-3-4b-it", "system": "t3000", "mesh_shape": [1, 8], "prompt_tokens": 54, "generated_tokens": 128, "ttft_ms": 74.8793079983443, "decode_tps_u": 19.703158053568664, "decode_tokens": 126, "max_seq_len": 40960}
-2026-02-17 12:17:25.695 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-02-17 12:17:25.695 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
+YT_METRICS={"mode": "tt_demo", "model": "google/gemma-3-4b-it", "system": "t3000", "mesh_shape": [1, 8], "prompt_tokens": 54, "generated_tokens": 128, "ttft_ms": 71.48976810276508, "decode_tps_u": 20.62763301201789, "decode_tokens": 126, "max_seq_len": 40960}
+2026-02-17 15:33:03.173 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-17 15:33:03.173 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
 
 EXIT_CODE: 0

--- a/models/google/gemma-3-4b-it/t3000/optimized/eval.log
+++ b/models/google/gemma-3-4b-it/t3000/optimized/eval.log
@@ -1,67 +1,66 @@
-CMD: env HF_HOME=/proj_sw/user_dev/moconnor/hf-cache TT_VISIBLE_DEVICES=0,1,2,3 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x8_mesh_graph_descriptor.textproto TT_METAL_CACHE=/tmp/tt-metal-cache TT_METAL_INSPECTOR_LOG_PATH=/tmp/tt-metal-inspector TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT=0 PYTHONUNBUFFERED=1 python eval.py models/google/gemma-3-4b-it/t3000/optimized/model.py --model google/gemma-3-4b-it --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 40960
-2026-02-17 12:17:50.074 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
+CMD: env HF_HOME=/proj_sw/user_dev/moconnor/hf-cache TT_VISIBLE_DEVICES=0,1,2,3 TT_MESH_GRAPH_DESC_PATH=/proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto TT_METAL_CACHE=/tmp/tt-metal-cache TT_METAL_INSPECTOR_LOG_PATH=/tmp/tt-metal-inspector TT_METAL_INSPECTOR_INITIALIZATION_IS_IMPORTANT=0 PYTHONUNBUFFERED=1 python eval.py models/google/gemma-3-4b-it/t3000/optimized/model.py --model google/gemma-3-4b-it --prompt_file prompts/bringup_eval_long.txt --max_new_tokens 100 --max_seq_len 40960
+2026-02-17 15:33:25.635 | DEBUG    | ttnn:<module>:77 - Initial ttnn.CONFIG:
 Config{cache_path=/home/moconnor/.cache/ttnn,model_cache_path=/home/moconnor/.cache/ttnn/models,tmp_dir=/tmp/ttnn,enable_model_cache=false,enable_fast_runtime_mode=true,throw_exception_on_fallback=false,enable_logging=false,enable_graph_report=false,enable_detailed_buffer_report=false,enable_detailed_tensor_report=false,enable_comparison_mode=false,comparison_mode_should_raise_exception=false,comparison_mode_pcc=0.9999,root_report_path=generated/ttnn/reports,report_name=std::nullopt,std::nullopt}
 Loading model module: /localdev/moconnor/ttnn_models/models/google/gemma-3-4b-it/t3000/optimized/model.py
 Loading HuggingFace tokenizer...
 Loading HuggingFace reference model on CPU...
-Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:00<00:00,  1.42it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.74it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.68it/s]
+Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]Loading checkpoint shards:  50%|█████     | 1/2 [00:00<00:00,  1.34it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.66it/s]Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.60it/s]
 Generating reference tokens...
 The following generation flags are not valid and may be ignored: ['top_p', 'top_k']. Set `TRANSFORMERS_VERBOSITY=info` for more details.
 Opening device (1x8)...
-2026-02-17 12:18:48.710 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 12:18:48.742 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
-2026-02-17 12:18:48.752 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 12:18:48.829 | info     |             UMD | Established firmware bundle version: 19.4.0 (topology_discovery.cpp:368)
-2026-02-17 12:18:48.891 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 12:18:48.958 | info     |             UMD | Harvesting masks for chip 2 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 12:18:48.968 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 12:18:48.978 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 12:18:48.989 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x210 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 12:18:49.003 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 12:18:49.016 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 12:18:49.030 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
-2026-02-17 12:18:49.044 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 1, 3, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
-2026-02-17 12:18:49.044 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
-2026-02-17 12:18:49.044 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
-2026-02-17 12:18:49.053 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
-2026-02-17 12:18:49.054 | info     |             UMD | Mapped hugepage 0x280000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 12:18:49.055 | info     |             UMD | Mapped hugepage 0x240000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 12:18:49.056 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 12:18:49.056 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 12:18:49.057 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 12:18:49.058 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 12:18:49.059 | info     |             UMD | Mapped hugepage 0x4240000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 12:18:49.059 | info     |             UMD | Mapped hugepage 0x4200000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
-2026-02-17 12:18:49.117 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x8_mesh_graph_descriptor.textproto (metal_context.cpp:822)
-2026-02-17 12:18:49.118 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={1:2, 2:6}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
-2026-02-17 12:18:49.118 | info     |          Fabric | Fast-path path-graph mapping succeeded for mesh 0 (topology_mapper_utils.cpp:401)
-2026-02-17 12:18:49.123 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
-2026-02-17 12:18:49.124 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
-2026-02-17 12:18:49.128 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 12:18:49.132 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 12:18:49.133 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 12:18:49.133 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 12:18:49.133 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 12:18:49.133 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 12:18:49.134 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 12:18:49.135 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
-2026-02-17 12:18:49.452 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
-2026-02-17 12:18:49.452 | info     |           Metal | Dispatch on FabricConfig::FABRIC_2D with 1 Command Queues
+2026-02-17 15:34:19.570 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-17 15:34:19.602 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:223)
+2026-02-17 15:34:19.612 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-17 15:34:19.688 | info     |             UMD | Established firmware bundle version: 18.12.1 (topology_discovery.cpp:368)
+2026-02-17 15:34:19.749 | info     |             UMD | Harvesting masks for chip 3 tensix: 0x202 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 15:34:19.811 | info     |             UMD | Harvesting masks for chip 2 tensix: 0xc dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 15:34:19.822 | info     |             UMD | Harvesting masks for chip 1 tensix: 0x240 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 15:34:19.833 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x201 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 15:34:19.843 | info     |             UMD | Harvesting masks for chip 7 tensix: 0x220 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 15:34:19.857 | info     |             UMD | Harvesting masks for chip 6 tensix: 0x30 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 15:34:19.870 | info     |             UMD | Harvesting masks for chip 5 tensix: 0x280 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 15:34:19.883 | info     |             UMD | Harvesting masks for chip 4 tensix: 0x300 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:339)
+2026-02-17 15:34:19.897 | info     |             UMD | Opening local chip ids/PCIe ids: {0, 1, 2, 3}/[0, 3, 1, 2] and remote chip ids {4, 5, 6, 7} (cluster.cpp:186)
+2026-02-17 15:34:19.897 | info     |             UMD | IOMMU: disabled (cluster.cpp:161)
+2026-02-17 15:34:19.897 | info     |             UMD | KMD version: 2.4.1 (cluster.cpp:164)
+2026-02-17 15:34:19.905 | info     |             UMD | Starting devices in cluster (cluster.cpp:965)
+2026-02-17 15:34:19.906 | info     |             UMD | Mapped hugepage 0x200000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 15:34:19.907 | info     |             UMD | Mapped hugepage 0x140000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 15:34:19.908 | info     |             UMD | Mapped hugepage 0x41c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 15:34:19.909 | info     |             UMD | Mapped hugepage 0x4180000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 15:34:19.910 | info     |             UMD | Mapped hugepage 0x300000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 15:34:19.910 | info     |             UMD | Mapped hugepage 0x2c0000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 15:34:19.911 | info     |             UMD | Mapped hugepage 0x42c0000000 to NOC address 0x800000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 15:34:19.912 | info     |             UMD | Mapped hugepage 0x4280000000 to NOC address 0x840000000 (silicon_sysmem_manager.cpp:207)
+2026-02-17 15:34:19.946 | info     |     Distributed | Using custom mesh graph descriptor: /proj_sw/user_dev/moconnor/tt-metal/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto (metal_context.cpp:822)
+2026-02-17 15:34:19.947 | info     |          Fabric | TopologyMapper mapping start (mesh=0): n_log=8, n_phys=8, log_deg_hist={2:4, 3:4}, phys_deg_hist={2:4, 3:4} (topology_mapper_utils.cpp:171)
+2026-02-17 15:34:19.952 | DEBUG    | ttnn.device:__init__:150 - Using default dispatch core type for this system: DispatchCoreType.ETH
+2026-02-17 15:34:19.953 | DEBUG    | ttnn.device:__init__:152 - Using default dispatch core axis for this system: DispatchCoreAxis.ROW
+2026-02-17 15:34:19.957 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 15:34:19.959 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 15:34:19.959 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 15:34:19.960 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 15:34:19.960 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 15:34:19.960 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 15:34:19.960 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 15:34:19.961 | info     |    BuildKernels | Skipping deleting built cache (build.cpp:110)
+2026-02-17 15:34:20.275 | warning  |           Metal | Got num_routing_planes: 1, which is less than current value: 255, ignoring the override (metal_context.cpp:719)
+2026-02-17 15:34:20.275 | info     |           Metal | Dispatch on FabricConfig::FABRIC_1D with 1 Command Queues
  (device_manager.cpp:328)
-2026-02-17 12:18:49.468 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
-2026-02-17 12:18:49.613 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
-2026-02-17 12:18:49.617 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
-2026-02-17 12:18:49.660 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
-2026-02-17 12:18:49.660 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
-2026-02-17 12:18:49.661 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
-2026-02-17 12:18:49.668 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
-2026-02-17 12:18:49.674 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
-2026-02-17 12:18:49.678 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
-2026-02-17 12:18:49.678 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_2D (device_manager.cpp:409)
-2026-02-17 12:18:49.795 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
-2026-02-17 12:18:49.797 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
-2026-02-17 12:18:49.797 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
-2026-02-17 12:18:49.799 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
+2026-02-17 15:34:20.290 | info     |           Metal | Initializing Fabric (device_manager.cpp:404)
+2026-02-17 15:34:20.415 | info     |           Metal | Fabric initialized on Device 0 (device.cpp:386)
+2026-02-17 15:34:20.416 | info     |           Metal | Fabric initialized on Device 1 (device.cpp:386)
+2026-02-17 15:34:20.433 | info     |           Metal | Fabric initialized on Device 2 (device.cpp:386)
+2026-02-17 15:34:20.433 | info     |           Metal | Fabric initialized on Device 3 (device.cpp:386)
+2026-02-17 15:34:20.436 | info     |           Metal | Fabric initialized on Device 4 (device.cpp:386)
+2026-02-17 15:34:20.442 | info     |           Metal | Fabric initialized on Device 5 (device.cpp:386)
+2026-02-17 15:34:20.444 | info     |           Metal | Fabric initialized on Device 6 (device.cpp:386)
+2026-02-17 15:34:20.450 | info     |           Metal | Fabric initialized on Device 7 (device.cpp:386)
+2026-02-17 15:34:20.450 | info     |           Metal | Fabric Initialized with config FabricConfig::FABRIC_1D (device_manager.cpp:409)
+2026-02-17 15:34:20.527 | info     |           Metal | Command Queue initialized on Device 4 (device_manager.cpp:500)
+2026-02-17 15:34:20.529 | info     |           Metal | Command Queue initialized on Device 7 (device_manager.cpp:500)
+2026-02-17 15:34:20.529 | info     |           Metal | Command Queue initialized on Device 5 (device_manager.cpp:500)
+2026-02-17 15:34:20.530 | info     |           Metal | Command Queue initialized on Device 6 (device_manager.cpp:500)
 Loading ttnn model...
   Loading embeddings...
   Computing RoPE cache...
@@ -70,7 +69,7 @@ Running teacher-forcing eval (100 tokens)...
 Top-1 accuracy: 91.00% (0.9100)
 Top-5 accuracy: 100.00% (1.0000)
 YT_METRICS={"mode": "tt_eval", "model": "google/gemma-3-4b-it", "top1": 0.91, "top5": 1.0, "top1_pct": 91.0, "top5_pct": 100.0, "total_tokens": 100, "max_new_tokens": 100, "max_seq_len": 40960}
-2026-02-17 12:21:13.256 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
-2026-02-17 12:21:13.256 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
+2026-02-17 15:36:33.885 | info     |          Device | Closing user mode device drivers (tt_cluster.cpp:472)
+2026-02-17 15:36:33.885 | info     |             UMD | Closing devices in cluster (cluster.cpp:976)
 
 EXIT_CODE: 0


### PR DESCRIPTION
## Summary
- Update `MODELS.md` metrics for `google/gemma-3-4b-it` on `t3000` optimized.
- Refresh `demo.log` and `eval.log` artifacts for `models/google/gemma-3-4b-it/t3000/optimized`.

Fixes #198
